### PR TITLE
docs(patrol): webhook config, ACP events, per-bot sandbox/acp_command

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -25,6 +25,7 @@ description: "HotPlex Worker Gateway 所有配置项的权威参考，覆盖配�
    - [agent_config — Agent 人格与上下文](#38-agent_config--agent-人格与上下文)
    - [skills — Skills 发现](#39-skills--skills-发现)
    - [cron — 定时任务调度器](#310-cron--定时任务调度器)
+   - [webhook — GitHub Webhook 接收器](#3101-webhook--github-webhook-接收器)
    - [messaging — 消息平台](#311-messaging--消息平台)
    - [log — 日志](#312-log--日志)
    - [webchat — Web Chat UI](#313-webchat--web-chat-ui)
@@ -349,6 +350,35 @@ AI-native 定时任务引擎：自然语言 prompt 作为 payload，结果投递
 
 ---
 
+### 3.10.1 webhook — GitHub Webhook 接收器
+
+GitHub Webhook 接收器，用于事件驱动的 Cron 任务触发。当收到匹配的 GitHub 事件（如 PR opened/synchronize）时，自动触发指定的 Cron Job。
+
+| 字段 | 类型 | 默认值 | 环境变量 | 说明 |
+|------|------|--------|----------|------|
+| `enabled` | bool | `false` | `HOTPLEX_WEBHOOK_ENABLED` | 是否启用 Webhook 接收器 |
+| `secret` | string | `""` | `HOTPLEX_WEBHOOK_SECRET` | GitHub Webhook Secret（用于 HMAC-SHA256 签名验证）。**必须设置，为空时拒绝启动** |
+| `path` | string | `/api/webhook/github` | `HOTPLEX_WEBHOOK_PATH` | HTTP 端点路径 |
+| `max_body_size` | int64 | `1048576` (1MB) | `HOTPLEX_WEBHOOK_MAX_BODY_SIZE` | 请求体最大大小（字节） |
+| `allowed_repos` | []string | `[]` | — | 允许的仓库列表（空 = 接受所有） |
+| `target_job_name` | string | `pr-review-hotplex` | `HOTPLEX_WEBHOOK_TARGET_JOB_NAME` | 匹配事件时触发的 Cron Job 名称 |
+
+**配置示例**：
+
+```yaml
+webhook:
+  enabled: true
+  secret: "${GITHUB_WEBHOOK_SECRET}"   # 通过环境变量注入
+  path: /api/webhook/github
+  allowed_repos:
+    - "owner/repo"
+  target_job_name: "pr-review"
+```
+
+**安全要求**：`secret` 必须与 GitHub Webhook 设置中的 Secret 一致。未设置 secret 时 Webhook 不会注册（安全基线）。
+
+---
+
 ### 3.11 messaging — 消息平台
 
 消息平台适配器配置。采用**共享默认值 + 平台覆盖**模式。
@@ -452,6 +482,8 @@ Yuanxin 是基于 Apache Pulsar 的企业消息平台适配器。
 | `display_name` | string | 覆盖顶层 Assistant 显示名称（bot 级品牌化） |
 | `icon_emoji` | string | 覆盖顶层 Assistant emoji 图标（bot 级品牌化） |
 | `worker_type` | string | 覆盖 Worker 类型 |
+| `sandbox` | string | 覆盖 CodexCLI sandbox 模式（bot 级） |
+| `acp_command` | string | 覆盖 ACP Agent 启动命令（bot 级，仅 `worker_type: acp` 时生效） |
 | `stt_*` | — | 覆盖 STT 配置（继承平台级 → messaging 级） |
 | `tts_*` | — | 覆盖 TTS 配置（继承平台级 → messaging 级） |
 
@@ -463,6 +495,8 @@ Yuanxin 是基于 Apache Pulsar 的企业消息平台适配器。
 | `app_id` | string | 飞书 App ID |
 | `app_secret` | string | 飞书 App Secret |
 | `worker_type` | string | 覆盖 Worker 类型 |
+| `sandbox` | string | 覆盖 CodexCLI sandbox 模式（bot 级） |
+| `acp_command` | string | 覆盖 ACP Agent 启动命令（bot 级，仅 `worker_type: acp` 时生效） |
 | `stt_*` | — | 覆盖 STT 配置 |
 | `tts_*` | — | 覆盖 TTS 配置 |
 
@@ -658,8 +692,24 @@ HOTPLEX_SECURITY_API_KEY_1, HOTPLEX_SECURITY_API_KEY_2, ...
 | `HOTPLEX_WORKER_OPENCODE_SERVER_HTTP_TIMEOUT` | `worker.opencode_server.http_timeout` | `30s` |
 | `HOTPLEX_WORKER_AUTO_RETRY_ENABLED` | `worker.auto_retry.enabled` | `true` |
 | `HOTPLEX_WORKER_AUTO_RETRY_MAX_RETRIES` | `worker.auto_retry.max_retries` | `9` |
+| `HOTPLEX_WORKER_CODEX_CLI_COMMAND` | `worker.codex_cli.command` | `codex` |
+| `HOTPLEX_WORKER_CODEX_CLI_MODEL` | `worker.codex_cli.model` | `""` |
+| `HOTPLEX_WORKER_CODEX_CLI_SANDBOX` | `worker.codex_cli.sandbox` | `danger-full-access` |
+| `HOTPLEX_WORKER_CODEX_CLI_APPROVAL_MODE` | `worker.codex_cli.approval_mode` | `never` |
+| `HOTPLEX_WORKER_ACP_COMMAND` | `worker.acp.command` | `hermes acp` |
+| `HOTPLEX_WORKER_ACP_AUTO_APPROVE` | `worker.acp.auto_approve` | `false` |
 | `HOTPLEX_WORKER_GH_TOKEN` | 通过 `worker.environment` 注入 | — |
 | `HOTPLEX_WORKER_GITHUB_TOKEN` | 通过 `worker.environment` 注入 | — |
+
+#### Webhook
+
+| 变量 | 对应配置 | 默认值 |
+|------|----------|--------|
+| `HOTPLEX_WEBHOOK_ENABLED` | `webhook.enabled` | `false` |
+| `HOTPLEX_WEBHOOK_SECRET` | `webhook.secret` | `""` |
+| `HOTPLEX_WEBHOOK_PATH` | `webhook.path` | `/api/webhook/github` |
+| `HOTPLEX_WEBHOOK_MAX_BODY_SIZE` | `webhook.max_body_size` | `1048576` |
+| `HOTPLEX_WEBHOOK_TARGET_JOB_NAME` | `webhook.target_job_name` | `pr-review-hotplex` |
 
 #### Security
 

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -178,8 +178,14 @@ type ToolCallData struct {
     ID    string         `json:"id"`
     Name  string         `json:"name"`
     Input map[string]any `json:"input"`
+    // ACP extension fields — zero breaking change, omitted by existing workers.
+    Title     string         `json:"title,omitempty"`      // "read: main.go"
+    Kind      string         `json:"kind,omitempty"`       // read/edit/delete/move/search/execute/think/fetch/switch_mode/other
+    Locations []FileLocation `json:"locations,omitempty"`  // 文件位置引用
 }
 ```
+
+> ACP 扩展字段由 ACP 兼容 Worker 填充，现有 Worker（ClaudeCode/Codex/OCS）不发送这些字段。
 
 #### `tool_result` — 工具执行结果
 
@@ -188,6 +194,9 @@ type ToolResultData struct {
     ID     string `json:"id"`     // 对应 tool_call.id
     Output any    `json:"output"`
     Error  string `json:"error,omitempty"`
+    // ACP extension fields — zero breaking change, omitted by existing workers.
+    Status string    `json:"status,omitempty"` // completed / failed
+    Diff   *FileDiff `json:"diff,omitempty"`   // 结构化文件编辑
 }
 ```
 
@@ -278,6 +287,61 @@ type RawData struct {
 ```
 
 **可被 backpressure 丢弃**，丢弃时不消耗 seq。用于将 Worker（如 Claude Code）的 Agent 特定事件原样透传给客户端。
+
+#### `tool_update` — 工具调用中间状态（ACP 扩展）
+
+ACP Agent 工具执行过程中的中间状态更新。现有 Worker（ClaudeCode/Codex/OCS）不发送此事件。
+
+```go
+type ToolUpdateData struct {
+    ID        string    `json:"id"`
+    Status    string    `json:"status"`              // pending / in_progress
+    Content   any       `json:"content,omitempty"`
+    Diff      *FileDiff `json:"diff,omitempty"`
+    RawOutput string    `json:"raw_output,omitempty"`
+}
+```
+
+#### `plan` — 计划/任务列表更新（ACP 扩展）
+
+ACP Agent 的任务计划更新。映射自 ACP `AgentPlanUpdate`。
+
+```go
+type PlanData struct {
+    Items []PlanItem `json:"items"`
+}
+
+type PlanItem struct {
+    Content  string `json:"content"`  // 任务描述（ACP PlanEntry.content）
+    Priority string `json:"priority"` // high / medium / low
+    Status   string `json:"status"`   // pending / in_progress / completed
+}
+```
+
+#### `mode_update` — Agent 模式切换（ACP 扩展）
+
+ACP Agent 执行模式变更通知。映射自 ACP `CurrentModeUpdate`。
+
+```go
+type ModeUpdateData struct {
+    Mode string `json:"mode"` // Agent 当前模式标识
+}
+```
+
+#### ACP 公共结构体
+
+```go
+type FileLocation struct {
+    Path string `json:"path"`
+    Line int    `json:"line,omitempty"`
+}
+
+type FileDiff struct {
+    Path    string `json:"path"`
+    OldText string `json:"old_text"`
+    NewText string `json:"new_text"`
+}
+```
 
 #### `context_usage` — Context Window 使用报告
 


### PR DESCRIPTION
## 文档巡逻 2026-05-31

自 `a7ad410` 以来 22 个提交，影响 webhook/ACP/cron/slack-branding 等代码区域。

### 修复内容

| 文件 | 修复内容 |
|------|---------|
| `docs/reference/configuration.md` | 新增 §3.10.1 webhook 配置段（6 字段 + 5 环境变量） |
| `docs/reference/configuration.md` | 多 Bot 配置表补充 `sandbox`、`acp_command` 字段（Slack + Feishu） |
| `docs/reference/configuration.md` | 环境变量速查补充 codex_cli(4)、acp(2)、webhook(5) 共 11 条 |
| `docs/reference/events.md` | 新增 ACP 扩展事件：`tool_update`、`plan`、`mode_update` + 公共结构体 |
| `docs/reference/events.md` | `tool_call`/`tool_result` 补充 ACP 扩展字段说明 |

### 验证

- `go run cmd/build-docs/main.go` ✓ 55 篇文档，无断链

🤖 Generated with [Claude Code](https://claude.com/claude-code)