### PR TITLE
chore(webchat): add pnpm-workspace.yaml for sharp build approval

### DIFF
--- a/webchat/pnpm-workspace.yaml
+++ b/webchat/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  sharp: true


### PR DESCRIPTION
## Summary

添加 `webchat/pnpm-workspace.yaml`，声明 sharp 原生构建白名单。

### Changes

- `webchat/pnpm-workspace.yaml` — `allowBuilds: sharp: true`

**背景**：PR review 过程中误删此文件，导致 webchat build 失败（pnpm 拒绝执行 sharp 的 postinstall 构建脚本）。

## Test Plan

- [x] make check 全通过
- [x] pre-push hook 验证通过

