### PR TITLE
feat(worker/acp): Phase 1 — 核心功能补齐（P0）

### DIFF
--- a/internal/gateway/errors.go
+++ b/internal/gateway/errors.go
@@ -23,7 +23,11 @@ func (h *Handler) sendErrorf(ctx context.Context, env *events.Envelope, code eve
 // Worker process death (ErrKindUnavailable) maps to ErrCodeSessionTerminated
 // so clients can reconnect rather than treating them as transient internal errors.
 // Timeout errors (ErrKindTimeout) are not treated as fatal — the worker is still alive.
+// ErrNotImplemented maps to ErrCodeNotSupported for unimplemented worker capabilities.
 func classifyWorkerError(err error) events.ErrorCode {
+	if errors.Is(err, worker.ErrNotImplemented) {
+		return events.ErrCodeNotSupported
+	}
 	we, ok := errors.AsType[*worker.WorkerError](err)
 	if ok {
 		switch we.Kind {

--- a/internal/gateway/worker_cmds.go
+++ b/internal/gateway/worker_cmds.go
@@ -133,19 +133,19 @@ func (h *Handler) handlePassthroughCommand(ctx context.Context, env *events.Enve
 		switch cmd {
 		case events.StdioCompact:
 			if err := commander.Compact(ctx, nil); err != nil {
-				return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "compact: %v", err)
+				return h.sendErrorf(ctx, env, classifyWorkerError(err), "compact: %v", err)
 			}
 			h.sendCommandFeedback(ctx, env.SessionID, "✅ 对话历史已压缩")
 			return nil
 		case events.StdioClear:
 			if err := commander.Clear(ctx); err != nil {
-				return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "clear: %v", err)
+				return h.sendErrorf(ctx, env, classifyWorkerError(err), "clear: %v", err)
 			}
 			h.sendCommandFeedback(ctx, env.SessionID, "✅ 会话已清空，新会话已创建")
 			return nil
 		case events.StdioRewind:
 			if err := commander.Rewind(ctx, ""); err != nil {
-				return h.sendErrorf(ctx, env, events.ErrCodeInternalError, "rewind: %v", err)
+				return h.sendErrorf(ctx, env, classifyWorkerError(err), "rewind: %v", err)
 			}
 			h.sendCommandFeedback(ctx, env.SessionID, "✅ 已回退到上一轮对话")
 			return nil

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -267,4 +267,35 @@ var (
 		Help:      "Duration of worker creation and launch in seconds",
 		Buckets:   []float64{0.5, 1, 2, 5, 10, 30, 60},
 	}, []string{"worker_type"})
+
+	// ─── ACP Worker Metrics ────────────────────────────────────────────────────
+
+	// ACPPromptTokensTotal tracks token usage from ACP usage_update events.
+	ACPPromptTokensTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "hotplex",
+		Name:      "acp_prompt_tokens_total",
+		Help:      "Total token usage from ACP agents by type (input/output/cached_read/cached_write/thought)",
+	}, []string{"type"})
+
+	// ACPToolCallsTotal tracks tool call counts by kind.
+	ACPToolCallsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "hotplex",
+		Name:      "acp_tool_calls_total",
+		Help:      "Total ACP tool calls by kind (read/edit/delete/execute/search/other)",
+	}, []string{"kind"})
+
+	// ACPPermissionRequestsTotal tracks permission request outcomes.
+	ACPPermissionRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "hotplex",
+		Name:      "acp_permission_requests_total",
+		Help:      "Total ACP permission requests by outcome (approved/denied/timeout)",
+	}, []string{"outcome"})
+
+	// ACPHandshakeDuration records ACP initialize handshake duration.
+	ACPHandshakeDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "hotplex",
+		Name:      "acp_handshake_duration_seconds",
+		Help:      "Duration of ACP agent initialize handshake in seconds",
+		Buckets:   []float64{0.1, 0.25, 0.5, 1, 2, 5, 10},
+	})
 )

--- a/internal/worker/acp/conn.go
+++ b/internal/worker/acp/conn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hrygo/hotplex/internal/worker"
@@ -21,10 +22,14 @@ type acpConn struct {
 	recvCh    chan *events.Envelope
 	mu        sync.Mutex
 	closed    bool
+	lastInput atomic.Pointer[string] // cached for InputRecoverer crash recovery
 }
 
-// Compile-time check.
-var _ worker.SessionConn = (*acpConn)(nil)
+// Compile-time checks.
+var (
+	_ worker.SessionConn    = (*acpConn)(nil)
+	_ worker.InputRecoverer = (*acpConn)(nil)
+)
 
 func newACPConn(userID, sessionID string, log *slog.Logger) *acpConn {
 	return &acpConn{
@@ -115,6 +120,16 @@ func (c *acpConn) Close() error {
 	c.closed = true
 	close(c.recvCh)
 	return nil
+}
+
+// LastInput returns the most recent user input for crash recovery re-delivery.
+// Satisfies worker.InputRecoverer — Bridge's handleWorkerExit reads this to
+// re-inject the last message after a worker restart.
+func (c *acpConn) LastInput() string {
+	if p := c.lastInput.Load(); p != nil {
+		return *p
+	}
+	return ""
 }
 
 func (c *acpConn) UserID() string    { return c.userID }

--- a/internal/worker/acp/mapper.go
+++ b/internal/worker/acp/mapper.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/hrygo/hotplex/internal/metrics"
+
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
 )
@@ -286,6 +288,14 @@ func (m *ACPMapper) mapToolCall(raw json.RawMessage) []*events.Envelope {
 		Kind:      u.Kind,
 		Locations: locations,
 	}
+
+	// Record Prometheus tool call metric.
+	toolKind := u.Kind
+	if toolKind == "" {
+		toolKind = "other"
+	}
+	metrics.ACPToolCallsTotal.WithLabelValues(toolKind).Inc()
+
 	return []*events.Envelope{m.newEnvelope(events.ToolCall, data)}
 }
 
@@ -527,6 +537,23 @@ func (m *ACPMapper) updateUsage(raw json.RawMessage) {
 		}
 		s.Cost.Amount += u.Cost.Amount
 		s.Cost.Currency = u.Cost.Currency
+	}
+
+	// Record Prometheus token metrics.
+	if u.InputTokens > 0 {
+		metrics.ACPPromptTokensTotal.WithLabelValues("input").Add(float64(u.InputTokens))
+	}
+	if u.OutputTokens > 0 {
+		metrics.ACPPromptTokensTotal.WithLabelValues("output").Add(float64(u.OutputTokens))
+	}
+	if u.ThoughtTokens > 0 {
+		metrics.ACPPromptTokensTotal.WithLabelValues("thought").Add(float64(u.ThoughtTokens))
+	}
+	if u.CachedReadTokens > 0 {
+		metrics.ACPPromptTokensTotal.WithLabelValues("cached_read").Add(float64(u.CachedReadTokens))
+	}
+	if u.CachedWriteTokens > 0 {
+		metrics.ACPPromptTokensTotal.WithLabelValues("cached_write").Add(float64(u.CachedWriteTokens))
 	}
 }
 

--- a/internal/worker/acp/mapper.go
+++ b/internal/worker/acp/mapper.go
@@ -531,20 +531,16 @@ func (m *ACPMapper) updateUsage(raw json.RawMessage) {
 	m.usageMu.Unlock()
 
 	// Prometheus metrics outside the lock — counters have internal synchronization.
-	if u.InputTokens > 0 {
-		metrics.ACPPromptTokensTotal.WithLabelValues("input").Add(float64(u.InputTokens))
-	}
-	if u.OutputTokens > 0 {
-		metrics.ACPPromptTokensTotal.WithLabelValues("output").Add(float64(u.OutputTokens))
-	}
-	if u.ThoughtTokens > 0 {
-		metrics.ACPPromptTokensTotal.WithLabelValues("thought").Add(float64(u.ThoughtTokens))
-	}
-	if u.CachedReadTokens > 0 {
-		metrics.ACPPromptTokensTotal.WithLabelValues("cached_read").Add(float64(u.CachedReadTokens))
-	}
-	if u.CachedWriteTokens > 0 {
-		metrics.ACPPromptTokensTotal.WithLabelValues("cached_write").Add(float64(u.CachedWriteTokens))
+	for label, val := range map[string]int{
+		"input":        u.InputTokens,
+		"output":       u.OutputTokens,
+		"thought":      u.ThoughtTokens,
+		"cached_read":  u.CachedReadTokens,
+		"cached_write": u.CachedWriteTokens,
+	} {
+		if val > 0 {
+			metrics.ACPPromptTokensTotal.WithLabelValues(label).Add(float64(val))
+		}
 	}
 }
 

--- a/internal/worker/acp/mapper.go
+++ b/internal/worker/acp/mapper.go
@@ -476,7 +476,8 @@ func (m *ACPMapper) buildStats(result *PromptResult) map[string]any {
 		stats["context_used"] = m.usage.ContextUsed
 	}
 	if m.usage.Cost != nil && m.usage.Cost.Amount > 0 {
-		stats["cost"] = m.usage.Cost
+		costCopy := *m.usage.Cost
+		stats["cost"] = &costCopy
 	}
 	m.usageMu.Unlock()
 
@@ -547,8 +548,13 @@ func (m *ACPMapper) updateUsage(raw json.RawMessage) {
 // LastUsage returns a copy of the current usage snapshot for ControlRequester queries.
 func (m *ACPMapper) LastUsage() usageSnapshot {
 	m.usageMu.Lock()
-	defer m.usageMu.Unlock()
-	return m.usage
+	snap := m.usage
+	m.usageMu.Unlock()
+	if snap.Cost != nil {
+		cp := *snap.Cost
+		snap.Cost = &cp
+	}
+	return snap
 }
 
 func extractToolName(raw json.RawMessage) string {

--- a/internal/worker/acp/mapper.go
+++ b/internal/worker/acp/mapper.go
@@ -32,16 +32,12 @@ type ACPMapper struct {
 }
 
 // usageSnapshot caches token usage, context size, and cost from usage_update events.
+// Embeds PromptUsage for token fields; adds context/cost fields from usage_update.
 type usageSnapshot struct {
-	InputTokens       int
-	OutputTokens      int
-	ThoughtTokens     int
-	CachedReadTokens  int
-	CachedWriteTokens int
-	TotalTokens       int
-	ContextSize       int
-	ContextUsed       int
-	Cost              *CostInfo
+	PromptUsage
+	ContextSize int
+	ContextUsed int
+	Cost        *CostInfo
 }
 
 // CostInfo holds cost information from usage_update events.
@@ -510,10 +506,8 @@ func (m *ACPMapper) updateUsage(raw json.RawMessage) {
 		return
 	}
 
+	// Accumulate into snapshot under lock (field names match PromptUsage via embedding).
 	m.usageMu.Lock()
-	defer m.usageMu.Unlock()
-
-	// Accumulate tokens (usage_update may fire multiple times per turn).
 	s := &m.usage
 	s.InputTokens += u.InputTokens
 	s.OutputTokens += u.OutputTokens
@@ -521,16 +515,12 @@ func (m *ACPMapper) updateUsage(raw json.RawMessage) {
 	s.CachedReadTokens += u.CachedReadTokens
 	s.CachedWriteTokens += u.CachedWriteTokens
 	s.TotalTokens += u.TotalTokens
-
-	// Context size/used are absolute snapshots, not cumulative.
 	if u.ContextSize > 0 {
 		s.ContextSize = u.ContextSize
 	}
 	if u.ContextUsed > 0 {
 		s.ContextUsed = u.ContextUsed
 	}
-
-	// Cost accumulates across updates.
 	if u.Cost != nil {
 		if s.Cost == nil {
 			s.Cost = &CostInfo{}
@@ -538,8 +528,9 @@ func (m *ACPMapper) updateUsage(raw json.RawMessage) {
 		s.Cost.Amount += u.Cost.Amount
 		s.Cost.Currency = u.Cost.Currency
 	}
+	m.usageMu.Unlock()
 
-	// Record Prometheus token metrics.
+	// Prometheus metrics outside the lock — counters have internal synchronization.
 	if u.InputTokens > 0 {
 		metrics.ACPPromptTokensTotal.WithLabelValues("input").Add(float64(u.InputTokens))
 	}

--- a/internal/worker/acp/mapper.go
+++ b/internal/worker/acp/mapper.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"encoding/json"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 
 	"github.com/hrygo/hotplex/pkg/aep"
@@ -21,6 +22,30 @@ type ACPMapper struct {
 	turnActive atomic.Bool // true while a prompt turn is in progress
 	seq        atomic.Int64
 	msgID      string // pre-computed "msg_" + sessionID, avoids allocation on hot path
+
+	// usageSnapshot caches the latest usage_update for ControlRequester queries.
+	// Accumulated across multiple usage_update notifications within a turn.
+	usageMu sync.Mutex
+	usage   usageSnapshot
+}
+
+// usageSnapshot caches token usage, context size, and cost from usage_update events.
+type usageSnapshot struct {
+	InputTokens       int
+	OutputTokens      int
+	ThoughtTokens     int
+	CachedReadTokens  int
+	CachedWriteTokens int
+	TotalTokens       int
+	ContextSize       int
+	ContextUsed       int
+	Cost              *CostInfo
+}
+
+// CostInfo holds cost information from usage_update events.
+type CostInfo struct {
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currency"`
 }
 
 // NewACPMapper creates a mapper bound to the given session.
@@ -40,6 +65,9 @@ func NewACPMapper(sessionID, userID string, log *slog.Logger) *ACPMapper {
 func (m *ACPMapper) Reset() {
 	m.msgActive.Store(false)
 	m.turnActive.Store(false)
+	m.usageMu.Lock()
+	m.usage = usageSnapshot{}
+	m.usageMu.Unlock()
 }
 
 // SetTurnActive marks the start of a prompt turn.
@@ -81,6 +109,7 @@ func (m *ACPMapper) MapNotification(notif *JSONRPCNotification) []*events.Envelo
 	case "tool_call_update":
 		return m.mapToolCallUpdate(params.Update)
 	case "usage_update":
+		m.updateUsage(params.Update)
 		return nil // internal tracking, stats included in Done
 	case "plan":
 		return m.mapPlan(params.Update)
@@ -431,7 +460,81 @@ func (m *ACPMapper) buildStats(result *PromptResult) map[string]any {
 	if result.Usage.TotalTokens > 0 {
 		stats["total_tokens"] = result.Usage.TotalTokens
 	}
+
+	// Include accumulated usage_update data (context size, cost).
+	m.usageMu.Lock()
+	if m.usage.ContextSize > 0 {
+		stats["context_size"] = m.usage.ContextSize
+	}
+	if m.usage.ContextUsed > 0 {
+		stats["context_used"] = m.usage.ContextUsed
+	}
+	if m.usage.Cost != nil && m.usage.Cost.Amount > 0 {
+		stats["cost"] = m.usage.Cost
+	}
+	m.usageMu.Unlock()
+
 	return stats
+}
+
+// ─── Usage Tracking ──────────────────────────────────────────────────────────
+
+// updateUsage parses a usage_update notification and accumulates into the snapshot.
+func (m *ACPMapper) updateUsage(raw json.RawMessage) {
+	var u struct {
+		InputTokens       int `json:"inputTokens"`
+		OutputTokens      int `json:"outputTokens"`
+		ThoughtTokens     int `json:"thoughtTokens"`
+		CachedReadTokens  int `json:"cachedReadTokens"`
+		CachedWriteTokens int `json:"cachedWriteTokens"`
+		TotalTokens       int `json:"totalTokens"`
+		ContextSize       int `json:"contextSize"`
+		ContextUsed       int `json:"contextUsed"`
+		Cost              *struct {
+			Amount   float64 `json:"amount"`
+			Currency string  `json:"currency"`
+		} `json:"cost"`
+	}
+	if err := json.Unmarshal(raw, &u); err != nil {
+		m.log.Debug("acp mapper: failed to parse usage_update", "error", err)
+		return
+	}
+
+	m.usageMu.Lock()
+	defer m.usageMu.Unlock()
+
+	// Accumulate tokens (usage_update may fire multiple times per turn).
+	s := &m.usage
+	s.InputTokens += u.InputTokens
+	s.OutputTokens += u.OutputTokens
+	s.ThoughtTokens += u.ThoughtTokens
+	s.CachedReadTokens += u.CachedReadTokens
+	s.CachedWriteTokens += u.CachedWriteTokens
+	s.TotalTokens += u.TotalTokens
+
+	// Context size/used are absolute snapshots, not cumulative.
+	if u.ContextSize > 0 {
+		s.ContextSize = u.ContextSize
+	}
+	if u.ContextUsed > 0 {
+		s.ContextUsed = u.ContextUsed
+	}
+
+	// Cost accumulates across updates.
+	if u.Cost != nil {
+		if s.Cost == nil {
+			s.Cost = &CostInfo{}
+		}
+		s.Cost.Amount += u.Cost.Amount
+		s.Cost.Currency = u.Cost.Currency
+	}
+}
+
+// LastUsage returns a copy of the current usage snapshot for ControlRequester queries.
+func (m *ACPMapper) LastUsage() usageSnapshot {
+	m.usageMu.Lock()
+	defer m.usageMu.Unlock()
+	return m.usage
 }
 
 func extractToolName(raw json.RawMessage) string {

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -262,6 +262,9 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	w.mapper.Reset()
 	w.mapper.SetTurnActive()
 
+	// Cache input for crash recovery (InputRecoverer).
+	conn.lastInput.Store(&content)
+
 	// Emit state(running).
 	conn.TrySend(w.mapper.MapStateRunning())
 	w.SetLastIO(time.Now())

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -35,7 +35,7 @@ var commandParts atomic.Value // []string
 
 // autoApproveDefault is the global default for auto-approve set from config.
 // Per-session overrides live on Worker.autoApprove.
-var autoApproveDefault atomic.Value // bool
+var autoApproveDefault atomic.Bool
 
 func init() {
 	commandParts.Store([]string{"hermes", "acp"})
@@ -43,9 +43,7 @@ func init() {
 
 	worker.Register(worker.TypeACP, func() (worker.Worker, error) {
 		w := &Worker{BaseWorker: base.NewBaseWorker(slog.Default(), nil)}
-		if v, ok := autoApproveDefault.Load().(bool); ok {
-			w.autoApprove.Store(v)
-		}
+		w.autoApprove.Store(autoApproveDefault.Load())
 		return w, nil
 	})
 }
@@ -346,8 +344,7 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	w.mapper.SetTurnActive()
 
 	// Inject system prompt on first user input (ACP v1 has no native system prompt).
-	if w.systemPrompt != "" && !w.systemPromptInjected.Load() {
-		w.systemPromptInjected.Store(true)
+	if w.systemPrompt != "" && w.systemPromptInjected.CompareAndSwap(false, true) {
 		content = fmt.Sprintf("[SYSTEM INSTRUCTIONS]\n%s\n[/SYSTEM INSTRUCTIONS]\n\n%s", w.systemPrompt, content)
 	}
 
@@ -474,8 +471,13 @@ func (w *Worker) Compact(_ context.Context, _ map[string]any) error {
 // The PID stays the same; only the acpSessionID changes.
 // I/O runs outside Mu to avoid blocking Terminate/Health during Cancel+NewSession.
 func (w *Worker) Clear(ctx context.Context) error {
+	// Snapshot all fields needed for I/O under one lock hold to avoid data races
+	// on projectDir (string), mcpServers (slice), and acpSessionID (string).
 	w.Mu.Lock()
 	client := w.client
+	projectDir := w.projectDir
+	mcpServers := w.mcpServers
+	sessionID := w.acpSessionID
 	w.Mu.Unlock()
 
 	if client == nil {
@@ -486,9 +488,9 @@ func (w *Worker) Clear(ctx context.Context) error {
 	defer hcancel()
 
 	// Cancel any in-flight turn before creating new session.
-	_ = client.Cancel(hctx, w.GetWorkerSessionID())
+	_ = client.Cancel(hctx, sessionID)
 
-	result, err := client.NewSession(hctx, w.projectDir, w.mcpServers)
+	result, err := client.NewSession(hctx, projectDir, mcpServers)
 	if err != nil {
 		return fmt.Errorf("acp: clear: new session: %w", err)
 	}
@@ -529,18 +531,10 @@ func (w *Worker) SendControlRequest(ctx context.Context, subtype string, body ma
 
 func (w *Worker) handleContextUsage() (map[string]any, error) {
 	snapshot := w.mapper.LastUsage()
-	result := map[string]any{
+	// Return context usage snapshot; zero values mean no data yet (consistent with OCS).
+	return map[string]any{
 		"maxTokens":   snapshot.ContextSize,
 		"totalTokens": snapshot.ContextUsed,
-	}
-	// Include model if known from last prompt result.
-	if snapshot.ContextSize > 0 || snapshot.ContextUsed > 0 {
-		return result, nil
-	}
-	// No usage data yet — return zero-value map (consistent with OCS behavior).
-	return map[string]any{
-		"maxTokens":   0,
-		"totalTokens": 0,
 	}, nil
 }
 
@@ -560,8 +554,10 @@ func (w *Worker) handleSetPermissionMode(body map[string]any) (map[string]any, e
 	switch mode {
 	case "auto-accept":
 		w.autoApprove.Store(true)
-	default:
+	case "default", "":
 		w.autoApprove.Store(false)
+	default:
+		return nil, fmt.Errorf("acp: set_permission_mode: unsupported mode: %s", mode)
 	}
 	return map[string]any{"mode": mode}, nil
 }

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/metrics"
 	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/internal/worker/base"
@@ -275,6 +276,9 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 		acpSessID = sessResult.SessionID
 	}
 	w.SetWorkerSessionID(acpSessID)
+
+	// Record handshake latency.
+	metrics.ACPHandshakeDuration.Observe(time.Since(now).Seconds())
 
 	// Create mapper.
 	mapper := w.testMapper
@@ -566,8 +570,10 @@ func (w *Worker) HandlePermissionResponse(ctx context.Context, reqID string, all
 	var outcome any
 	if allowed {
 		outcome = pm.FormatAllowedOutcome()
+		metrics.ACPPermissionRequestsTotal.WithLabelValues("approved").Inc()
 	} else {
 		outcome = pm.FormatDeniedOutcome()
+		metrics.ACPPermissionRequestsTotal.WithLabelValues("denied").Inc()
 	}
 
 	return w.client.RespondPermission(ctx, pm.RequestID, outcome)
@@ -637,6 +643,7 @@ func (w *Worker) handleServerRequest(ctx context.Context, req *JSONRPCRequest, c
 		// Check auto-approve.
 		if val, _ := autoApprove.Load().(bool); val {
 			_ = w.client.RespondPermission(ctx, req.ID, pm.FormatAllowedOutcome())
+			metrics.ACPPermissionRequestsTotal.WithLabelValues("approved").Inc()
 			return
 		}
 

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -126,6 +126,11 @@ type Worker struct {
 	// pendingPerm stores the permission mapping for in-flight permission requests.
 	pendingPerm sync.Map // requestID (string) → *PermissionMapResult
 
+	// systemPrompt holds the B/C channel agent config from SessionInfo.SystemPrompt.
+	// Injected as a prefix on the first user prompt (ACP v1 has no native system prompt).
+	systemPrompt         string
+	systemPromptInjected bool
+
 	// testHooks for injection-based testing.
 	testClient *ACPClient
 	testMapper *ACPMapper
@@ -164,6 +169,16 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	w.sessionID = session.SessionID
 	w.projectDir = session.ProjectDir
 	w.Mu.Unlock()
+
+	// Cache system prompt for first-input injection (ACP v1 has no native mechanism).
+	sp := session.SystemPrompt
+	if len(sp) > 32*1024 {
+		w.Log.Warn("acp: system prompt exceeds 32KB, truncating",
+			"session_id", session.SessionID, "size", len(sp))
+		sp = sp[:32*1024]
+	}
+	w.systemPrompt = sp
+	w.systemPromptInjected = false
 
 	// Phase 2: I/O-heavy operations outside the lock.
 
@@ -307,6 +322,12 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	// Regular user input → send prompt.
 	w.mapper.Reset()
 	w.mapper.SetTurnActive()
+
+	// Inject system prompt on first user input (ACP v1 has no native system prompt).
+	if w.systemPrompt != "" && !w.systemPromptInjected {
+		w.systemPromptInjected = true
+		content = fmt.Sprintf("[SYSTEM INSTRUCTIONS]\n%s\n[/SYSTEM INSTRUCTIONS]\n\n%s", w.systemPrompt, content)
+	}
 
 	// Cache input for crash recovery (InputRecoverer).
 	conn.lastInput.Store(&content)

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -25,6 +25,7 @@ var (
 	_ worker.Worker                 = (*Worker)(nil)
 	_ worker.WorkerSessionIDHandler = (*Worker)(nil)
 	_ worker.WorkerCommander        = (*Worker)(nil)
+	_ worker.ControlRequester       = (*Worker)(nil)
 	_ base.MetadataHandler          = (*Worker)(nil)
 )
 
@@ -489,6 +490,65 @@ func (w *Worker) lastMCPConfig() string {
 	// Currently no cached MCP config on Worker; return empty to use defaults.
 	// When FR-02 ControlRequester is implemented, this can cache from Start().
 	return ""
+}
+
+// ─── ControlRequester ────────────────────────────────────────────────────────
+
+// SendControlRequest handles structured control queries from Bridge/worker_cmds.
+// Supported subtypes: get_context_usage, set_model, set_permission_mode, mcp_status.
+func (w *Worker) SendControlRequest(ctx context.Context, subtype string, body map[string]any) (map[string]any, error) {
+	switch subtype {
+	case "get_context_usage":
+		return w.handleContextUsage()
+	case "set_model":
+		return w.handleSetModel(ctx, body)
+	case "set_permission_mode":
+		return w.handleSetPermissionMode(body)
+	case "mcp_status":
+		// ACP has no MCP status query method — return empty map.
+		return map[string]any{}, nil
+	default:
+		return nil, fmt.Errorf("acp: unsupported control request: %s", subtype)
+	}
+}
+
+func (w *Worker) handleContextUsage() (map[string]any, error) {
+	snapshot := w.mapper.LastUsage()
+	result := map[string]any{
+		"maxTokens":   snapshot.ContextSize,
+		"totalTokens": snapshot.ContextUsed,
+	}
+	// Include model if known from last prompt result.
+	if snapshot.ContextSize > 0 || snapshot.ContextUsed > 0 {
+		return result, nil
+	}
+	// No usage data yet — return zero-value map (consistent with OCS behavior).
+	return map[string]any{
+		"maxTokens":   0,
+		"totalTokens": 0,
+	}, nil
+}
+
+func (w *Worker) handleSetModel(ctx context.Context, body map[string]any) (map[string]any, error) {
+	modelID, _ := body["modelId"].(string)
+	if modelID == "" {
+		return nil, fmt.Errorf("acp: set_model: missing modelId")
+	}
+	if err := w.client.SetSessionModel(ctx, w.GetWorkerSessionID(), modelID); err != nil {
+		return nil, fmt.Errorf("acp: set_model: %w", err)
+	}
+	return map[string]any{"model": modelID}, nil
+}
+
+func (w *Worker) handleSetPermissionMode(body map[string]any) (map[string]any, error) {
+	mode, _ := body["mode"].(string)
+	switch mode {
+	case "auto-accept":
+		autoApprove.Store(true)
+	default:
+		autoApprove.Store(false)
+	}
+	return map[string]any{"mode": mode}, nil
 }
 
 // ─── MetadataHandler ─────────────────────────────────────────────────────────

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -24,6 +24,7 @@ import (
 var (
 	_ worker.Worker                 = (*Worker)(nil)
 	_ worker.WorkerSessionIDHandler = (*Worker)(nil)
+	_ worker.WorkerCommander        = (*Worker)(nil)
 	_ base.MetadataHandler          = (*Worker)(nil)
 )
 
@@ -438,6 +439,56 @@ func (w *Worker) Health() worker.WorkerHealth {
 func (w *Worker) ResetContext(_ context.Context) error {
 	// ACP doesn't support in-place reset → terminate + restart handled by Bridge.
 	return worker.ErrNotImplemented
+}
+
+// ─── WorkerCommander ─────────────────────────────────────────────────────────
+
+// Compact returns ErrNotImplemented — ACP has no compact method.
+// Terminate+Start is too expensive; let Bridge fallback to Input passthrough.
+func (w *Worker) Compact(_ context.Context, _ map[string]any) error {
+	return worker.ErrNotImplemented
+}
+
+// Clear creates a new ACP session within the same process (equivalent to /clear).
+// The PID stays the same; only the acpSessionID changes.
+func (w *Worker) Clear(ctx context.Context) error {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+
+	if w.client == nil {
+		return fmt.Errorf("acp: clear: worker not started")
+	}
+
+	hctx, hcancel := context.WithTimeout(ctx, 10*time.Second)
+	defer hcancel()
+
+	// Cancel any in-flight turn before creating new session.
+	_ = w.client.Cancel(hctx, w.acpSessionID)
+
+	mcpServers := parseMCPServers(w.lastMCPConfig())
+	result, err := w.client.NewSession(hctx, w.projectDir, mcpServers)
+	if err != nil {
+		return fmt.Errorf("acp: clear: new session: %w", err)
+	}
+
+	w.acpSessionID = result.SessionID
+	w.mapper.Reset()
+	w.systemPromptInjected = false
+	w.IncResetGeneration()
+	return nil
+}
+
+// Rewind returns ErrNotImplemented — ACP has no rewind method.
+func (w *Worker) Rewind(_ context.Context, _ string) error {
+	return worker.ErrNotImplemented
+}
+
+// lastMCPConfig returns the MCP config to use for new sessions.
+// Stored as an indirect method to allow future per-session caching.
+func (w *Worker) lastMCPConfig() string {
+	// Currently no cached MCP config on Worker; return empty to use defaults.
+	// When FR-02 ControlRequester is implemented, this can cache from Start().
+	return ""
 }
 
 // ─── MetadataHandler ─────────────────────────────────────────────────────────

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -33,15 +33,20 @@ var (
 // commandParts stores the space-split command (binary + optional prefix args).
 var commandParts atomic.Value // []string
 
-// autoApprove controls whether permission requests are auto-approved.
-var autoApprove atomic.Value // bool
+// autoApproveDefault is the global default for auto-approve set from config.
+// Per-session overrides live on Worker.autoApprove.
+var autoApproveDefault atomic.Value // bool
 
 func init() {
 	commandParts.Store([]string{"hermes", "acp"})
-	autoApprove.Store(false)
+	autoApproveDefault.Store(false)
 
 	worker.Register(worker.TypeACP, func() (worker.Worker, error) {
-		return &Worker{BaseWorker: base.NewBaseWorker(slog.Default(), nil)}, nil
+		w := &Worker{BaseWorker: base.NewBaseWorker(slog.Default(), nil)}
+		if v, ok := autoApproveDefault.Load().(bool); ok {
+			w.autoApprove.Store(v)
+		}
+		return w, nil
 	})
 }
 
@@ -57,7 +62,7 @@ func InitConfig(cfg config.ACPConfig) {
 		return
 	}
 	commandParts.Store(parts)
-	autoApprove.Store(cfg.AutoApprove)
+	autoApproveDefault.Store(cfg.AutoApprove)
 	if err := security.RegisterCommand(parts[0]); err != nil {
 		slog.Default().Error("acp: failed to register command", "command", parts[0], "err", err)
 	}
@@ -91,6 +96,9 @@ func parseMCPServers(mcpConfig string) []any {
 
 // normalizeMCPServersToArray converts the mcpServers value to []any.
 // ACP session/new expects an array; config provides either a map or array.
+// NOTE: For map input, this mutates the inner maps in-place (sets m["name"]=name).
+// Currently safe because input always comes from json.Unmarshal (fresh allocation),
+// but callers must not pass shared/persistent maps.
 func normalizeMCPServersToArray(servers any) []any {
 	if servers == nil {
 		return nil
@@ -132,7 +140,14 @@ type Worker struct {
 	// systemPrompt holds the B/C channel agent config from SessionInfo.SystemPrompt.
 	// Injected as a prefix on the first user prompt (ACP v1 has no native system prompt).
 	systemPrompt         string
-	systemPromptInjected bool
+	systemPromptInjected atomic.Bool
+
+	// mcpServers caches the parsed MCP servers from Start() so Clear() can reuse them.
+	mcpServers []any
+
+	// autoApprove controls per-session permission auto-approval.
+	// Initialized from global default, overridable via set_permission_mode.
+	autoApprove atomic.Bool
 
 	// testHooks for injection-based testing.
 	testClient *ACPClient
@@ -181,7 +196,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 		sp = sp[:32*1024]
 	}
 	w.systemPrompt = sp
-	w.systemPromptInjected = false
+	w.systemPromptInjected.Store(false)
 
 	// Phase 2: I/O-heavy operations outside the lock.
 
@@ -249,6 +264,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 
 	// Create or load session.
 	mcpServers := parseMCPServers(session.MCPConfig)
+	w.mcpServers = mcpServers // cache for Clear()
 	var acpSessID string
 	var historyLost bool
 	if session.WorkerSessionID != "" {
@@ -330,8 +346,8 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	w.mapper.SetTurnActive()
 
 	// Inject system prompt on first user input (ACP v1 has no native system prompt).
-	if w.systemPrompt != "" && !w.systemPromptInjected {
-		w.systemPromptInjected = true
+	if w.systemPrompt != "" && !w.systemPromptInjected.Load() {
+		w.systemPromptInjected.Store(true)
 		content = fmt.Sprintf("[SYSTEM INSTRUCTIONS]\n%s\n[/SYSTEM INSTRUCTIONS]\n\n%s", w.systemPrompt, content)
 	}
 
@@ -456,11 +472,13 @@ func (w *Worker) Compact(_ context.Context, _ map[string]any) error {
 
 // Clear creates a new ACP session within the same process (equivalent to /clear).
 // The PID stays the same; only the acpSessionID changes.
+// I/O runs outside Mu to avoid blocking Terminate/Health during Cancel+NewSession.
 func (w *Worker) Clear(ctx context.Context) error {
 	w.Mu.Lock()
-	defer w.Mu.Unlock()
+	client := w.client
+	w.Mu.Unlock()
 
-	if w.client == nil {
+	if client == nil {
 		return fmt.Errorf("acp: clear: worker not started")
 	}
 
@@ -468,32 +486,25 @@ func (w *Worker) Clear(ctx context.Context) error {
 	defer hcancel()
 
 	// Cancel any in-flight turn before creating new session.
-	_ = w.client.Cancel(hctx, w.acpSessionID)
+	_ = client.Cancel(hctx, w.GetWorkerSessionID())
 
-	mcpServers := parseMCPServers(w.lastMCPConfig())
-	result, err := w.client.NewSession(hctx, w.projectDir, mcpServers)
+	result, err := client.NewSession(hctx, w.projectDir, w.mcpServers)
 	if err != nil {
 		return fmt.Errorf("acp: clear: new session: %w", err)
 	}
 
+	w.Mu.Lock()
 	w.acpSessionID = result.SessionID
 	w.mapper.Reset()
-	w.systemPromptInjected = false
+	w.systemPromptInjected.Store(false)
 	w.IncResetGeneration()
+	w.Mu.Unlock()
 	return nil
 }
 
 // Rewind returns ErrNotImplemented — ACP has no rewind method.
 func (w *Worker) Rewind(_ context.Context, _ string) error {
 	return worker.ErrNotImplemented
-}
-
-// lastMCPConfig returns the MCP config to use for new sessions.
-// Stored as an indirect method to allow future per-session caching.
-func (w *Worker) lastMCPConfig() string {
-	// Currently no cached MCP config on Worker; return empty to use defaults.
-	// When FR-02 ControlRequester is implemented, this can cache from Start().
-	return ""
 }
 
 // ─── ControlRequester ────────────────────────────────────────────────────────
@@ -548,9 +559,9 @@ func (w *Worker) handleSetPermissionMode(body map[string]any) (map[string]any, e
 	mode, _ := body["mode"].(string)
 	switch mode {
 	case "auto-accept":
-		autoApprove.Store(true)
+		w.autoApprove.Store(true)
 	default:
-		autoApprove.Store(false)
+		w.autoApprove.Store(false)
 	}
 	return map[string]any{"mode": mode}, nil
 }
@@ -641,7 +652,7 @@ func (w *Worker) handleServerRequest(ctx context.Context, req *JSONRPCRequest, c
 		}
 
 		// Check auto-approve.
-		if val, _ := autoApprove.Load().(bool); val {
+		if w.autoApprove.Load() {
 			_ = w.client.RespondPermission(ctx, req.ID, pm.FormatAllowedOutcome())
 			metrics.ACPPermissionRequestsTotal.WithLabelValues("approved").Inc()
 			return

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -2,6 +2,7 @@ package acp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -63,6 +64,50 @@ func InitConfig(cfg config.ACPConfig) {
 var acpEnvBlocklist = []string{
 	"CLAUDECODE",
 	"HOTPLEX_",
+}
+
+// parseMCPServers extracts the mcpServers array from the JSON config string
+// produced by Bridge's buildWorkerInfo. The input format is {"mcpServers":{...}}.
+// Returns an empty slice if the config is empty or unparseable.
+func parseMCPServers(mcpConfig string) []any {
+	if mcpConfig == "" {
+		return nil
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(mcpConfig), &raw); err != nil {
+		return nil
+	}
+	servers, ok := raw["mcpServers"]
+	if !ok {
+		return nil
+	}
+	// mcpServers is typically a map → normalize to []any for ACP protocol.
+	// normalizeMCPServers in client.go handles nil → []any{}.
+	return normalizeMCPServersToArray(servers)
+}
+
+// normalizeMCPServersToArray converts the mcpServers value to []any.
+// ACP session/new expects an array; config provides either a map or array.
+func normalizeMCPServersToArray(servers any) []any {
+	if servers == nil {
+		return nil
+	}
+	switch v := servers.(type) {
+	case []any:
+		return v
+	case map[string]any:
+		// Convert map to array of named server configs.
+		result := make([]any, 0, len(v))
+		for name, cfg := range v {
+			if m, ok := cfg.(map[string]any); ok {
+				m["name"] = name
+				result = append(result, m)
+			}
+		}
+		return result
+	default:
+		return nil
+	}
 }
 
 // Worker implements the ACP (Agent Client Protocol) worker adapter.
@@ -185,15 +230,16 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	}
 
 	// Create or load session.
+	mcpServers := parseMCPServers(session.MCPConfig)
 	var acpSessID string
 	var historyLost bool
 	if session.WorkerSessionID != "" {
 		// Resume existing session.
-		sessResult, loadErr := client.LoadSession(hctx, session.WorkerSessionID, session.ProjectDir, nil)
+		sessResult, loadErr := client.LoadSession(hctx, session.WorkerSessionID, session.ProjectDir, mcpServers)
 		if loadErr != nil {
 			w.Log.Error("acp: load session failed, conversation history will be lost",
 				"session_id", session.SessionID, "acp_session_id", session.WorkerSessionID, "error", loadErr)
-			newSess, newErr := client.NewSession(hctx, session.ProjectDir, nil)
+			newSess, newErr := client.NewSession(hctx, session.ProjectDir, mcpServers)
 			if newErr != nil {
 				_ = w.Proc.Kill()
 				return fmt.Errorf("acp: new session: %w", newErr)
@@ -204,7 +250,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 			acpSessID = sessResult.SessionID
 		}
 	} else {
-		sessResult, sessErr := client.NewSession(hctx, session.ProjectDir, nil)
+		sessResult, sessErr := client.NewSession(hctx, session.ProjectDir, mcpServers)
 		if sessErr != nil {
 			_ = w.Proc.Kill()
 			return fmt.Errorf("acp: new session: %w", sessErr)

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -539,11 +539,17 @@ func (w *Worker) handleContextUsage() (map[string]any, error) {
 }
 
 func (w *Worker) handleSetModel(ctx context.Context, body map[string]any) (map[string]any, error) {
-	modelID, _ := body["modelId"].(string)
+	modelID, _ := body["model"].(string)
 	if modelID == "" {
-		return nil, fmt.Errorf("acp: set_model: missing modelId")
+		return nil, fmt.Errorf("acp: set_model: missing model")
 	}
-	if err := w.client.SetSessionModel(ctx, w.GetWorkerSessionID(), modelID); err != nil {
+	w.Mu.Lock()
+	client := w.client
+	w.Mu.Unlock()
+	if client == nil {
+		return nil, fmt.Errorf("acp: set_model: worker not started")
+	}
+	if err := client.SetSessionModel(ctx, w.GetWorkerSessionID(), modelID); err != nil {
 		return nil, fmt.Errorf("acp: set_model: %w", err)
 	}
 	return map[string]any{"model": modelID}, nil
@@ -583,7 +589,13 @@ func (w *Worker) HandlePermissionResponse(ctx context.Context, reqID string, all
 		metrics.ACPPermissionRequestsTotal.WithLabelValues("denied").Inc()
 	}
 
-	return w.client.RespondPermission(ctx, pm.RequestID, outcome)
+	w.Mu.Lock()
+	client := w.client
+	w.Mu.Unlock()
+	if client == nil {
+		return fmt.Errorf("acp: permission response: worker not started")
+	}
+	return client.RespondPermission(ctx, pm.RequestID, outcome)
 }
 
 func (w *Worker) HandleQuestionResponse(_ context.Context, _ string, _ map[string]string) error {

--- a/internal/worker/acp/worker_enhance_test.go
+++ b/internal/worker/acp/worker_enhance_test.go
@@ -1,0 +1,307 @@
+package acp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ─── parseMCPServers ──────────────────────────────────────────────────────────
+
+func TestParseMCPServers_Empty(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, parseMCPServers(""))
+}
+
+func TestParseMCPServers_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, parseMCPServers("{invalid"))
+}
+
+func TestParseMCPServers_NoMCPKey(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, parseMCPServers(`{"other":{}}`))
+}
+
+func TestParseMCPServers_MapInput(t *testing.T) {
+	t.Parallel()
+	result := parseMCPServers(`{"mcpServers":{"fs":{"type":"filesystem","path":"/tmp"}}}`)
+	require.Len(t, result, 1)
+
+	// Verify name was injected.
+	m, ok := result[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "fs", m["name"])
+	require.Equal(t, "filesystem", m["type"])
+}
+
+func TestParseMCPServers_ArrayInput(t *testing.T) {
+	t.Parallel()
+	result := parseMCPServers(`{"mcpServers":[{"type":"filesystem"}]}`)
+	require.Len(t, result, 1)
+}
+
+// ─── normalizeMCPServersToArray ───────────────────────────────────────────────
+
+func TestNormalizeMCPServersToArray_Nil(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, normalizeMCPServersToArray(nil))
+}
+
+func TestNormalizeMCPServersToArray_ArrayPassthrough(t *testing.T) {
+	t.Parallel()
+	arr := []any{"a", "b"}
+	require.Equal(t, arr, normalizeMCPServersToArray(arr))
+}
+
+func TestNormalizeMCPServersToArray_InvalidType(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, normalizeMCPServersToArray(42))
+}
+
+func TestNormalizeMCPServersToArray_MapConversion(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{
+		"server1": map[string]any{"url": "http://a"},
+		"server2": "not-a-map", // should be skipped
+	}
+	result := normalizeMCPServersToArray(input)
+	require.Len(t, result, 1)
+
+	m, ok := result[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "server1", m["name"])
+	require.Equal(t, "http://a", m["url"])
+}
+
+// ─── LastInput ────────────────────────────────────────────────────────────────
+
+func TestACPConn_LastInput_Empty(t *testing.T) {
+	t.Parallel()
+	c := newACPConn("u", "s", nil)
+	require.Equal(t, "", c.LastInput())
+}
+
+func TestACPConn_LastInput_StoreAndLoad(t *testing.T) {
+	t.Parallel()
+	c := newACPConn("u", "s", nil)
+
+	content := "hello world"
+	c.lastInput.Store(&content)
+	require.Equal(t, "hello world", c.LastInput())
+}
+
+func TestACPConn_LastInput_Overwrite(t *testing.T) {
+	t.Parallel()
+	c := newACPConn("u", "s", nil)
+
+	first := "first message"
+	c.lastInput.Store(&first)
+	second := "second message"
+	c.lastInput.Store(&second)
+	require.Equal(t, "second message", c.LastInput())
+}
+
+// ─── usageSnapshot / updateUsage / LastUsage / Reset ──────────────────────────
+
+func TestUpdateUsage_AccumulatesTokens(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	// First usage_update.
+	raw := mustMarshal(map[string]any{
+		"sessionUpdate": "usage_update",
+		"inputTokens":   100,
+		"outputTokens":  50,
+		"totalTokens":   150,
+		"contextSize":   200000,
+		"contextUsed":   5000,
+	})
+	m.updateUsage(raw)
+
+	snap := m.LastUsage()
+	require.Equal(t, 100, snap.InputTokens)
+	require.Equal(t, 50, snap.OutputTokens)
+	require.Equal(t, 150, snap.TotalTokens)
+	require.Equal(t, 200000, snap.ContextSize)
+	require.Equal(t, 5000, snap.ContextUsed)
+}
+
+func TestUpdateUsage_AccumulatesAcrossMultiple(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	for _, tc := range []struct {
+		input  int
+		output int
+		total  int
+	}{
+		{100, 50, 150},
+		{200, 100, 300},
+	} {
+		raw := mustMarshal(map[string]any{
+			"sessionUpdate": "usage_update",
+			"inputTokens":   tc.input,
+			"outputTokens":  tc.output,
+			"totalTokens":   tc.total,
+		})
+		m.updateUsage(raw)
+	}
+
+	snap := m.LastUsage()
+	require.Equal(t, 300, snap.InputTokens)  // 100 + 200
+	require.Equal(t, 150, snap.OutputTokens) // 50 + 100
+	require.Equal(t, 450, snap.TotalTokens)  // 150 + 300
+}
+
+func TestUpdateUsage_CostAccumulation(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	raw := mustMarshal(map[string]any{
+		"sessionUpdate": "usage_update",
+		"cost": map[string]any{
+			"amount":   0.05,
+			"currency": "USD",
+		},
+	})
+	m.updateUsage(raw)
+
+	snap := m.LastUsage()
+	require.NotNil(t, snap.Cost)
+	require.InDelta(t, 0.05, snap.Cost.Amount, 0.001)
+	require.Equal(t, "USD", snap.Cost.Currency)
+}
+
+func TestUpdateUsage_CostMultipleAccumulates(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	for _, amt := range []float64{0.03, 0.07} {
+		raw := mustMarshal(map[string]any{
+			"sessionUpdate": "usage_update",
+			"cost":          map[string]any{"amount": amt, "currency": "USD"},
+		})
+		m.updateUsage(raw)
+	}
+
+	snap := m.LastUsage()
+	require.InDelta(t, 0.10, snap.Cost.Amount, 0.001)
+}
+
+func TestUpdateUsage_InvalidJSON_Skipped(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+	// Should not panic on malformed update.
+	m.updateUsage(json.RawMessage(`{bad json`))
+	snap := m.LastUsage()
+	require.Equal(t, 0, snap.InputTokens)
+}
+
+func TestUpdateUsage_ContextSizeOverwrites(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	// Context size is absolute snapshot, not cumulative.
+	raw1 := mustMarshal(map[string]any{"sessionUpdate": "usage_update", "contextSize": 100})
+	m.updateUsage(raw1)
+	require.Equal(t, 100, m.LastUsage().ContextSize)
+
+	raw2 := mustMarshal(map[string]any{"sessionUpdate": "usage_update", "contextSize": 200})
+	m.updateUsage(raw2)
+	require.Equal(t, 200, m.LastUsage().ContextSize)
+}
+
+func TestReset_ClearsUsage(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	raw := mustMarshal(map[string]any{
+		"sessionUpdate": "usage_update",
+		"inputTokens":   500,
+	})
+	m.updateUsage(raw)
+	require.Equal(t, 500, m.LastUsage().InputTokens)
+
+	m.Reset()
+	require.Equal(t, 0, m.LastUsage().InputTokens)
+}
+
+func TestReset_ClearsTurnState(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+	m.msgActive.Store(true)
+	m.turnActive.Store(true)
+
+	m.Reset()
+	require.False(t, m.msgActive.Load())
+	require.False(t, m.turnActive.Load())
+}
+
+// ─── buildStats includes usage_update data ───────────────────────────────────
+
+func TestBuildStats_IncludesUsageSnapshot(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	// Feed usage_update data.
+	raw := mustMarshal(map[string]any{
+		"sessionUpdate": "usage_update",
+		"contextSize":   128000,
+		"contextUsed":   25000,
+		"cost":          map[string]any{"amount": 0.42, "currency": "USD"},
+	})
+	m.updateUsage(raw)
+
+	// Build stats from a prompt result.
+	stats := m.buildStats(&PromptResult{
+		StopReason: "end_turn",
+		Usage:      PromptUsage{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+	})
+
+	require.Equal(t, 128000, stats["context_size"])
+	require.Equal(t, 25000, stats["context_used"])
+	cost, ok := stats["cost"].(*CostInfo)
+	require.True(t, ok)
+	require.InDelta(t, 0.42, cost.Amount, 0.001)
+}
+
+func TestBuildStats_NoUsageSnapshot(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	stats := m.buildStats(&PromptResult{
+		StopReason: "end_turn",
+		Usage:      PromptUsage{InputTokens: 100},
+	})
+
+	require.Nil(t, stats["context_size"])
+	require.Nil(t, stats["context_used"])
+	require.Nil(t, stats["cost"])
+}
+
+// ─── MapNotification routes usage_update ──────────────────────────────────────
+
+func TestMapNotification_UsageUpdate_NoEnvelopes(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	notif := &JSONRPCNotification{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params: mustMarshal(map[string]any{
+			"sessionId": "s1",
+			"update": map[string]any{
+				"sessionUpdate": "usage_update",
+				"inputTokens":   100,
+			},
+		}),
+	}
+
+	envs := m.MapNotification(notif)
+	require.Nil(t, envs) // usage_update returns nil envelopes, data is internal.
+
+	// But usage was accumulated.
+	require.Equal(t, 100, m.LastUsage().InputTokens)
+}


### PR DESCRIPTION
## Summary

ACP Worker 从"可用"到"生产首选"的第一阶段：实现 7 个关键接口和指标，对齐 ClaudeCode/OCS Worker。

**规格文档**: `docs/specs/ACP-Worker-Enhancement-Spec.md` §9 Phase 1

## Changes (7 commits, atomic per FR)

| FR | 变更 | 文件 |
|----|------|------|
| FR-05 | InputRecoverer — acpConn.lastInput 缓存 | conn.go, worker.go |
| FR-03 | MCP 配置注入 — parseMCPServers + NewSession/LoadSession | worker.go |
| FR-04 | 系统提示词注入 — 首次 prompt 前置 [SYSTEM INSTRUCTIONS] | worker.go |
| FR-01 | WorkerCommander — Compact/Rewind=ErrNotImplemented, Clear=session/new | worker.go |
| FR-10 | cost tracking — usageSnapshot + updateUsage + buildStats 扩展 | mapper.go |
| FR-02 | ControlRequester — get_context_usage/set_model/set_permission_mode/mcp_status | worker.go |
| NFR-04 | Prometheus 指标 — 4 个新 ACP 指标 + mapper/worker 接入 | metrics.go, mapper.go, worker.go |

## Key Design Decisions

- **Compact/Rewind = ErrNotImplemented**: ACP 无等效方法，Terminate+Start 成本过高
- **Clear = session/new**: 复用同一进程（PID 不变），仅创建新 acpSessionID
- **System prompt = 首次注入**: ACP v1 无原生系统提示词，采用 Prompt 前置注入
- **MCP map→array**: config 格式是 `{"mcpServers":{...}}`，ACP 期望 `[]any`
- **Context usage camelCase**: `maxTokens`/`totalTokens` 匹配 `MapContextUsageResponse`
- **集中式指标**: 遵循项目模式，在 metrics.go 注册，worker_type label 自动覆盖

## Testing

- [x] `make check` 全量通过（lint + test + build）
- [x] ACP 单元测试 `-race -count=1` 通过
- [x] 编译验证所有新增接口满足编译时断言

## Closes

Closes #587
Closes #583 (P2-2 MCP config — implemented in FR-03)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Commit 3: test(worker/acp): add coverage for new Phase 1 functions (c4f6f2d)

Coverage: 35.3% → 44.1% (threshold: 40%)

### Commit 4: fix(gateway): correct error codes for unimplemented worker commands (5474c1f)

- `classifyWorkerError` now handles `ErrNotImplemented` → `ErrCodeNotSupported`
- Compact/Clear/Rewind errors use `classifyWorkerError` instead of hardcoded `ErrCodeInternalError`