### PR TITLE
feat(worker/acp): Phase 2 — interaction completeness, reset optimization, discovery, error UX

### DIFF
--- a/internal/worker/acp/client.go
+++ b/internal/worker/acp/client.go
@@ -125,9 +125,11 @@ func (c *ACPClient) Cancel(ctx context.Context, sessionID string) error {
 	return nil
 }
 
-// RespondPermission sends a response to a server-initiated request_permission.
+// RespondRequest sends a JSON-RPC response to a server-initiated request
+// (permission, question, or elicitation). It is the canonical name;
+// RespondPermission is kept as a compatibility alias.
 // No pendingMu needed (does not access the pending map); writeMu serializes stdin writes.
-func (c *ACPClient) RespondPermission(ctx context.Context, id json.RawMessage, outcome any) error {
+func (c *ACPClient) RespondRequest(ctx context.Context, id json.RawMessage, outcome any) error {
 	req := &JSONRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,
@@ -137,9 +139,14 @@ func (c *ACPClient) RespondPermission(ctx context.Context, id json.RawMessage, o
 	err := WriteMessage(c.stdin, req)
 	c.writeMu.Unlock()
 	if err != nil {
-		return fmt.Errorf("acp respond permission: %w", err)
+		return fmt.Errorf("acp respond request: %w", err)
 	}
 	return nil
+}
+
+// RespondPermission is a compatibility alias for RespondRequest.
+func (c *ACPClient) RespondPermission(ctx context.Context, id json.RawMessage, outcome any) error {
+	return c.RespondRequest(ctx, id, outcome)
 }
 
 // SetSessionModel switches the model for an active session .

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -27,6 +27,7 @@ var (
 	_ worker.WorkerSessionIDHandler = (*Worker)(nil)
 	_ worker.WorkerCommander        = (*Worker)(nil)
 	_ worker.ControlRequester       = (*Worker)(nil)
+	_ worker.InPlaceReseter         = (*Worker)(nil)
 	_ base.MetadataHandler          = (*Worker)(nil)
 )
 
@@ -135,6 +136,13 @@ type Worker struct {
 	// pendingPerm stores the permission mapping for in-flight permission requests.
 	pendingPerm sync.Map // requestID (string) → *PermissionMapResult
 
+	// pendingRequests stores non-permission server-initiated requests (questions, elicitations)
+	// for forwarding client responses back to the agent as JSON-RPC responses.
+	pendingRequests sync.Map // requestID (string) → *JSONRPCRequest
+
+	// initResult caches the ACP initialize handshake result for agent discovery and capability checks.
+	initResult *InitializeResult
+
 	// systemPrompt holds the B/C channel agent config from SessionInfo.SystemPrompt.
 	// Injected as a prefix on the first user prompt (ACP v1 has no native system prompt).
 	systemPrompt         string
@@ -220,7 +228,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 
 	stdin, stdout, _, err := w.Proc.Start(context.Background(), binary, args, env, session.ProjectDir)
 	if err != nil {
-		return fmt.Errorf("acp: failed to start process: %w", err)
+		return w.fmtStartError(binary, err)
 	}
 	if stdin == nil || stdout == nil {
 		return fmt.Errorf("acp: failed to start process: %s", binary)
@@ -255,22 +263,30 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	defer hcancel()
 
 	clientInfo := map[string]string{"name": "hotplex", "version": "1.0"}
-	if _, err := client.Initialize(hctx, clientInfo); err != nil {
+	initResult, err := client.Initialize(hctx, clientInfo)
+	if err != nil {
 		_ = w.Proc.Kill()
-		return fmt.Errorf("acp: initialize handshake: %w", err)
+		return w.fmtHandshakeError(err)
 	}
+	w.initResult = initResult
+	w.Log.Info("acp: agent discovered",
+		"agent", initResult.AgentInfo.Name,
+		"version", initResult.AgentInfo.Version,
+		"protocol", initResult.ProtocolVersion)
 
 	// Create or load session.
 	mcpServers := parseMCPServers(session.MCPConfig)
 	w.mcpServers = mcpServers // cache for Clear()
 	var acpSessID string
 	var historyLost bool
-	if session.WorkerSessionID != "" {
-		// Resume existing session.
+	if session.WorkerSessionID != "" && w.supportsCapability("loadSession") {
+		// Resume existing session (only if agent supports load).
 		sessResult, loadErr := client.LoadSession(hctx, session.WorkerSessionID, session.ProjectDir, mcpServers)
 		if loadErr != nil {
-			w.Log.Error("acp: load session failed, conversation history will be lost",
-				"session_id", session.SessionID, "acp_session_id", session.WorkerSessionID, "error", loadErr)
+			w.Log.Error("acp: session load failed, falling back to new session (history lost)",
+				"session_id", session.SessionID, "acp_session_id", session.WorkerSessionID,
+				"error", loadErr,
+				"hint", "check agent session storage and persistence")
 			newSess, newErr := client.NewSession(hctx, session.ProjectDir, mcpServers)
 			if newErr != nil {
 				_ = w.Proc.Kill()
@@ -403,9 +419,13 @@ func (w *Worker) Terminate(ctx context.Context) error {
 		_ = conn.Close()
 	}
 
-	// Clear stale pending permission entries (session teardown cleanup).
+	// Clear stale pending permission/request entries (session teardown cleanup).
 	w.pendingPerm.Range(func(key, _ any) bool {
 		w.pendingPerm.Delete(key)
+		return true
+	})
+	w.pendingRequests.Range(func(key, _ any) bool {
+		w.pendingRequests.Delete(key)
 		return true
 	})
 
@@ -442,21 +462,85 @@ func (w *Worker) Conn() worker.SessionConn {
 
 func (w *Worker) Health() worker.WorkerHealth {
 	h := w.BaseWorker.Health(worker.TypeACP)
-	// BaseWorker.Health reads base.Conn which is nil for ACP (we use acpConn instead).
-	// Populate SessionID from acpConn if available.
 	w.Mu.Lock()
 	if w.conn != nil {
 		h.SessionID = w.conn.SessionID()
 	}
+	ir := w.initResult
 	w.Mu.Unlock()
+	if ir != nil {
+		h.AgentName = ir.AgentInfo.Name
+		h.AgentVersion = ir.AgentInfo.Version
+		h.ProtocolVersion = ir.ProtocolVersion
+	}
 	return h
+}
+
+// supportsCapability checks whether the agent declared a capability in the
+// initialize handshake. Returns true if the capability is absent (assume supported)
+// or explicitly true. Returns false only if explicitly set to false.
+func (w *Worker) supportsCapability(name string) bool {
+	if w.initResult == nil {
+		return true // no handshake result, assume supported
+	}
+	caps := w.initResult.AgentCapabilities
+	if caps == nil {
+		return true // no capabilities declared, assume all supported
+	}
+	v, ok := caps[name]
+	if !ok {
+		return true // not listed, assume supported
+	}
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return true
 }
 
 // ─── ResetContext ────────────────────────────────────────────────────────────
 
-func (w *Worker) ResetContext(_ context.Context) error {
-	// ACP doesn't support in-place reset → terminate + restart handled by Bridge.
-	return worker.ErrNotImplemented
+func (w *Worker) ResetContext(ctx context.Context) error {
+	// Reuse the same process: cancel current turn, create new session.
+	// Equivalent to Clear() but called by Bridge.ResetSession.
+	return w.resetSession(ctx)
+}
+
+// InPlaceReset tells Bridge not to rebuild the forwardEvents goroutine.
+// The existing goroutine detects generation changes via resetGenerationer.
+func (w *Worker) InPlaceReset() bool { return true }
+
+// resetSession is the shared logic for Clear() and ResetContext():
+// cancel current turn, create new ACP session within the same process.
+func (w *Worker) resetSession(ctx context.Context) error {
+	w.Mu.Lock()
+	client := w.client
+	projectDir := w.projectDir
+	mcpServers := w.mcpServers
+	sessionID := w.acpSessionID
+	w.Mu.Unlock()
+
+	if client == nil {
+		return fmt.Errorf("acp: reset: worker not started")
+	}
+
+	hctx, hcancel := context.WithTimeout(ctx, 10*time.Second)
+	defer hcancel()
+
+	// Cancel any in-flight turn before creating new session.
+	_ = client.Cancel(hctx, sessionID)
+
+	result, err := client.NewSession(hctx, projectDir, mcpServers)
+	if err != nil {
+		return fmt.Errorf("acp: reset: new session: %w", err)
+	}
+
+	w.Mu.Lock()
+	w.acpSessionID = result.SessionID
+	w.mapper.Reset()
+	w.systemPromptInjected.Store(false)
+	w.IncResetGeneration()
+	w.Mu.Unlock()
+	return nil
 }
 
 // ─── WorkerCommander ─────────────────────────────────────────────────────────
@@ -469,39 +553,8 @@ func (w *Worker) Compact(_ context.Context, _ map[string]any) error {
 
 // Clear creates a new ACP session within the same process (equivalent to /clear).
 // The PID stays the same; only the acpSessionID changes.
-// I/O runs outside Mu to avoid blocking Terminate/Health during Cancel+NewSession.
 func (w *Worker) Clear(ctx context.Context) error {
-	// Snapshot all fields needed for I/O under one lock hold to avoid data races
-	// on projectDir (string), mcpServers (slice), and acpSessionID (string).
-	w.Mu.Lock()
-	client := w.client
-	projectDir := w.projectDir
-	mcpServers := w.mcpServers
-	sessionID := w.acpSessionID
-	w.Mu.Unlock()
-
-	if client == nil {
-		return fmt.Errorf("acp: clear: worker not started")
-	}
-
-	hctx, hcancel := context.WithTimeout(ctx, 10*time.Second)
-	defer hcancel()
-
-	// Cancel any in-flight turn before creating new session.
-	_ = client.Cancel(hctx, sessionID)
-
-	result, err := client.NewSession(hctx, projectDir, mcpServers)
-	if err != nil {
-		return fmt.Errorf("acp: clear: new session: %w", err)
-	}
-
-	w.Mu.Lock()
-	w.acpSessionID = result.SessionID
-	w.mapper.Reset()
-	w.systemPromptInjected.Store(false)
-	w.IncResetGeneration()
-	w.Mu.Unlock()
-	return nil
+	return w.resetSession(ctx)
 }
 
 // Rewind returns ErrNotImplemented — ACP has no rewind method.
@@ -598,12 +651,44 @@ func (w *Worker) HandlePermissionResponse(ctx context.Context, reqID string, all
 	return client.RespondPermission(ctx, pm.RequestID, outcome)
 }
 
-func (w *Worker) HandleQuestionResponse(_ context.Context, _ string, _ map[string]string) error {
-	return worker.ErrNotImplemented
+func (w *Worker) HandleQuestionResponse(ctx context.Context, reqID string, answers map[string]string) error {
+	req, ok := w.pendingRequests.LoadAndDelete(reqID)
+	if !ok {
+		return fmt.Errorf("acp: no pending question request: %s", reqID)
+	}
+	w.Mu.Lock()
+	client := w.client
+	w.Mu.Unlock()
+	if client == nil {
+		return fmt.Errorf("acp: question response: worker not started")
+	}
+	acpReq, ok := req.(*JSONRPCRequest)
+	if !ok {
+		return fmt.Errorf("acp: question response: invalid request type %T", req)
+	}
+	return client.RespondPermission(ctx, acpReq.ID, answers)
 }
 
-func (w *Worker) HandleElicitationResponse(_ context.Context, _, _ string, _ map[string]any) error {
-	return worker.ErrNotImplemented
+func (w *Worker) HandleElicitationResponse(ctx context.Context, reqID, action string, content map[string]any) error {
+	req, ok := w.pendingRequests.LoadAndDelete(reqID)
+	if !ok {
+		return fmt.Errorf("acp: no pending elicitation request: %s", reqID)
+	}
+	w.Mu.Lock()
+	client := w.client
+	w.Mu.Unlock()
+	if client == nil {
+		return fmt.Errorf("acp: elicitation response: worker not started")
+	}
+	outcome := map[string]any{"action": action}
+	if content != nil {
+		outcome["content"] = content
+	}
+	acpReq, ok := req.(*JSONRPCRequest)
+	if !ok {
+		return fmt.Errorf("acp: elicitation response: invalid request type %T", req)
+	}
+	return client.RespondPermission(ctx, acpReq.ID, outcome)
 }
 
 // ─── readLoop ────────────────────────────────────────────────────────────────
@@ -620,10 +705,14 @@ func (w *Worker) readLoop(ctx context.Context) {
 				"session_id", w.sessionID, "panic", r,
 				"stack", string(debug.Stack()))
 		}
-		// Clean up stale pending permission entries when read loop exits
+		// Clean up stale pending permission/request entries when read loop exits
 		// (agent disconnected, context cancelled, or panic recovered).
 		w.pendingPerm.Range(func(key, _ any) bool {
 			w.pendingPerm.Delete(key)
+			return true
+		})
+		w.pendingRequests.Range(func(key, _ any) bool {
+			w.pendingRequests.Delete(key)
 			return true
 		})
 	}()
@@ -671,6 +760,42 @@ func (w *Worker) handleServerRequest(ctx context.Context, req *JSONRPCRequest, c
 		conn.TrySend(pm.Envelope)
 
 	default:
-		w.Log.Warn("acp: unhandled server request", "method", req.Method)
+		// Non-permission server-initiated request (e.g. question, elicitation).
+		// Forward as Raw event so the client can display and respond.
+		w.pendingRequests.Store(string(req.ID), req)
+		var params any
+		_ = json.Unmarshal(req.Params, &params)
+		conn.TrySend(w.mapper.newEnvelope(events.Raw, events.RawData{
+			Kind: "acp.server_request." + req.Method,
+			Raw: map[string]any{
+				"id":     string(req.ID),
+				"method": req.Method,
+				"params": params,
+			},
+		}))
 	}
+}
+
+// Error Formatting (U-03)
+
+// fmtStartError produces an actionable error when the agent binary cannot be started.
+func (w *Worker) fmtStartError(binary string, err error) error {
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "executable file not found") ||
+		strings.Contains(errMsg, "no such file") ||
+		strings.Contains(errMsg, "command not found") {
+		return fmt.Errorf("acp: agent %q not found in PATH. Install the agent or set acp.command in config.yaml: %w", binary, err)
+	}
+	if strings.Contains(errMsg, "permission denied") {
+		return fmt.Errorf("acp: agent %q is not executable. Run: chmod +x $(which %s): %w", binary, binary, err)
+	}
+	return fmt.Errorf("acp: failed to start process %q: %w", binary, err)
+}
+
+// fmtHandshakeError produces an actionable error when the ACP handshake fails.
+func (w *Worker) fmtHandshakeError(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("acp: handshake timed out after 30s. Check: 1) agent is running 2) API keys are configured 3) network connectivity: %w", err)
+	}
+	return fmt.Errorf("acp: initialize handshake: %w", err)
 }

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -486,10 +486,13 @@ func (w *Worker) Health() worker.WorkerHealth {
 // initialize handshake. Returns true if the capability is absent (assume supported)
 // or explicitly true. Returns false only if explicitly set to false.
 func (w *Worker) supportsCapability(name string) bool {
-	if w.initResult == nil {
+	w.Mu.Lock()
+	ir := w.initResult
+	w.Mu.Unlock()
+	if ir == nil {
 		return true // no handshake result, assume supported
 	}
-	caps := w.initResult.AgentCapabilities
+	caps := ir.AgentCapabilities
 	if caps == nil {
 		return true // no capabilities declared, assume all supported
 	}
@@ -671,7 +674,7 @@ func (w *Worker) HandlePermissionResponse(ctx context.Context, reqID string, all
 	if client == nil {
 		return fmt.Errorf("acp: permission response: worker not started")
 	}
-	return client.RespondPermission(ctx, pm.RequestID, outcome)
+	return client.RespondRequest(ctx, pm.RequestID, outcome)
 }
 
 func (w *Worker) HandleQuestionResponse(ctx context.Context, reqID string, answers map[string]string) error {
@@ -703,7 +706,7 @@ func (w *Worker) respondToServerRequest(ctx context.Context, reqID, kind string,
 	if !ok {
 		return fmt.Errorf("acp: %s response: invalid request type %T", kind, req)
 	}
-	return client.RespondPermission(ctx, acpReq.ID, outcome)
+	return client.RespondRequest(ctx, acpReq.ID, outcome)
 }
 
 // ─── readLoop ────────────────────────────────────────────────────────────────
@@ -765,7 +768,7 @@ func (w *Worker) handleServerRequest(ctx context.Context, req *JSONRPCRequest, c
 
 		// Check auto-approve.
 		if w.autoApprove.Load() {
-			_ = w.client.RespondPermission(ctx, req.ID, pm.FormatAllowedOutcome())
+			_ = w.client.RespondRequest(ctx, req.ID, pm.FormatAllowedOutcome())
 			metrics.ACPPermissionRequestsTotal.WithLabelValues("approved").Inc()
 			return
 		}

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"os/exec"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -245,7 +247,9 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	if client == nil {
 		client = NewACPClient(stdin, stdout, w.Log)
 	}
+	w.Mu.Lock()
 	w.client = client
+	w.Mu.Unlock()
 
 	// Start read loop early — must run before handshake to receive responses.
 	childCtx, cancel := context.WithCancel(context.Background())
@@ -268,7 +272,9 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 		_ = w.Proc.Kill()
 		return w.fmtHandshakeError(err)
 	}
+	w.Mu.Lock()
 	w.initResult = initResult
+	w.Mu.Unlock()
 	w.Log.Info("acp: agent discovered",
 		"agent", initResult.AgentInfo.Name,
 		"version", initResult.AgentInfo.Version,
@@ -523,11 +529,14 @@ func (w *Worker) resetSession(ctx context.Context) error {
 		return fmt.Errorf("acp: reset: worker not started")
 	}
 
+	// Cancel any in-flight turn with a short, independent timeout
+	// so a slow Cancel doesn't eat into the NewSession budget.
+	cctx, ccancel := context.WithTimeout(ctx, 3*time.Second)
+	_ = client.Cancel(cctx, sessionID)
+	ccancel()
+
 	hctx, hcancel := context.WithTimeout(ctx, 10*time.Second)
 	defer hcancel()
-
-	// Cancel any in-flight turn before creating new session.
-	_ = client.Cancel(hctx, sessionID)
 
 	result, err := client.NewSession(hctx, projectDir, mcpServers)
 	if err != nil {
@@ -538,7 +547,15 @@ func (w *Worker) resetSession(ctx context.Context) error {
 	w.acpSessionID = result.SessionID
 	w.mapper.Reset()
 	w.systemPromptInjected.Store(false)
-	w.IncResetGeneration()
+	// Clear stale pending entries from the old session.
+	w.pendingPerm.Range(func(key, _ any) bool {
+		w.pendingPerm.Delete(key)
+		return true
+	})
+	w.pendingRequests.Range(func(key, _ any) bool {
+		w.pendingRequests.Delete(key)
+		return true
+	})
 	w.Mu.Unlock()
 	return nil
 }
@@ -553,8 +570,14 @@ func (w *Worker) Compact(_ context.Context, _ map[string]any) error {
 
 // Clear creates a new ACP session within the same process (equivalent to /clear).
 // The PID stays the same; only the acpSessionID changes.
+// IncResetGeneration is called here because the /clear path does NOT go through
+// Bridge.ResetSession (which calls it separately for the reset path).
 func (w *Worker) Clear(ctx context.Context) error {
-	return w.resetSession(ctx)
+	if err := w.resetSession(ctx); err != nil {
+		return err
+	}
+	w.IncResetGeneration()
+	return nil
 }
 
 // Rewind returns ErrNotImplemented — ACP has no rewind method.
@@ -652,41 +675,33 @@ func (w *Worker) HandlePermissionResponse(ctx context.Context, reqID string, all
 }
 
 func (w *Worker) HandleQuestionResponse(ctx context.Context, reqID string, answers map[string]string) error {
-	req, ok := w.pendingRequests.LoadAndDelete(reqID)
-	if !ok {
-		return fmt.Errorf("acp: no pending question request: %s", reqID)
-	}
-	w.Mu.Lock()
-	client := w.client
-	w.Mu.Unlock()
-	if client == nil {
-		return fmt.Errorf("acp: question response: worker not started")
-	}
-	acpReq, ok := req.(*JSONRPCRequest)
-	if !ok {
-		return fmt.Errorf("acp: question response: invalid request type %T", req)
-	}
-	return client.RespondPermission(ctx, acpReq.ID, answers)
+	return w.respondToServerRequest(ctx, reqID, "question", answers)
 }
 
 func (w *Worker) HandleElicitationResponse(ctx context.Context, reqID, action string, content map[string]any) error {
-	req, ok := w.pendingRequests.LoadAndDelete(reqID)
-	if !ok {
-		return fmt.Errorf("acp: no pending elicitation request: %s", reqID)
-	}
-	w.Mu.Lock()
-	client := w.client
-	w.Mu.Unlock()
-	if client == nil {
-		return fmt.Errorf("acp: elicitation response: worker not started")
-	}
 	outcome := map[string]any{"action": action}
 	if content != nil {
 		outcome["content"] = content
 	}
+	return w.respondToServerRequest(ctx, reqID, "elicitation", outcome)
+}
+
+// respondToServerRequest is the shared logic for forwarding client responses
+// back to the agent for non-permission server-initiated requests.
+func (w *Worker) respondToServerRequest(ctx context.Context, reqID, kind string, outcome any) error {
+	req, ok := w.pendingRequests.LoadAndDelete(reqID)
+	if !ok {
+		return fmt.Errorf("acp: no pending %s request: %s", kind, reqID)
+	}
+	w.Mu.Lock()
+	client := w.client
+	w.Mu.Unlock()
+	if client == nil {
+		return fmt.Errorf("acp: %s response: worker not started", kind)
+	}
 	acpReq, ok := req.(*JSONRPCRequest)
 	if !ok {
-		return fmt.Errorf("acp: elicitation response: invalid request type %T", req)
+		return fmt.Errorf("acp: %s response: invalid request type %T", kind, req)
 	}
 	return client.RespondPermission(ctx, acpReq.ID, outcome)
 }
@@ -764,7 +779,10 @@ func (w *Worker) handleServerRequest(ctx context.Context, req *JSONRPCRequest, c
 		// Forward as Raw event so the client can display and respond.
 		w.pendingRequests.Store(string(req.ID), req)
 		var params any
-		_ = json.Unmarshal(req.Params, &params)
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			w.Log.Warn("acp: malformed params in server request",
+				"method", req.Method, "error", err)
+		}
 		conn.TrySend(w.mapper.newEnvelope(events.Raw, events.RawData{
 			Kind: "acp.server_request." + req.Method,
 			Raw: map[string]any{
@@ -780,10 +798,21 @@ func (w *Worker) handleServerRequest(ctx context.Context, req *JSONRPCRequest, c
 
 // fmtStartError produces an actionable error when the agent binary cannot be started.
 func (w *Worker) fmtStartError(binary string, err error) error {
+	// Prefer structured error checks (cross-platform) over substring matching.
+	var execErr *exec.Error
+	if errors.As(err, &execErr) {
+		return fmt.Errorf("acp: agent %q not found in PATH. Install the agent or set acp.command in config.yaml: %w", binary, err)
+	}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) && os.IsPermission(pathErr.Err) {
+		return fmt.Errorf("acp: agent %q is not executable. Run: chmod +x $(which %s): %w", binary, binary, err)
+	}
+	// Fallback: substring matching for wrapped errors that lose type info.
 	errMsg := err.Error()
 	if strings.Contains(errMsg, "executable file not found") ||
 		strings.Contains(errMsg, "no such file") ||
-		strings.Contains(errMsg, "command not found") {
+		strings.Contains(errMsg, "command not found") ||
+		strings.Contains(errMsg, "cannot find the file") {
 		return fmt.Errorf("acp: agent %q not found in PATH. Install the agent or set acp.command in config.yaml: %w", binary, err)
 	}
 	if strings.Contains(errMsg, "permission denied") {

--- a/internal/worker/acp/worker_phase2_test.go
+++ b/internal/worker/acp/worker_phase2_test.go
@@ -1,0 +1,500 @@
+package acp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/worker"
+	"github.com/hrygo/hotplex/internal/worker/base"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// ─── FR-06: Question/Elicitation Response ─────────────────────────────────────
+
+func TestHandleServerRequest_UnknownMethod_RawPassthrough(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.mapper = newTestMapper()
+	conn := newACPConn("u1", "s1", nil)
+
+	req := &JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mustMarshal(42),
+		Method:  "session/request_question",
+		Params:  mustMarshal(map[string]any{"question": "What is 2+2?"}),
+	}
+
+	w.handleServerRequest(context.Background(), req, conn)
+
+	// Should forward as Raw event.
+	env := <-conn.Recv()
+	require.Equal(t, events.Raw, env.Event.Type)
+
+	rawBytes, err := json.Marshal(env.Event.Data)
+	require.NoError(t, err)
+	var raw events.RawData
+	require.NoError(t, json.Unmarshal(rawBytes, &raw))
+	require.Equal(t, "acp.server_request.session/request_question", raw.Kind)
+
+	rm, ok := raw.Raw.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "42", rm["id"])
+	require.Equal(t, "session/request_question", rm["method"])
+
+	// Should be stored in pendingRequests.
+	_, ok = w.pendingRequests.Load("42")
+	require.True(t, ok)
+}
+
+func TestHandleQuestionResponse_ForwardsToAgent(t *testing.T) {
+	t.Parallel()
+
+	req := &JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mustMarshal(99),
+		Method:  "session/request_question",
+	}
+
+	// agentStdinR/W: client writes requests here, agent reads them.
+	// agentStdoutR/W: agent writes responses here, client reads them.
+	agentStdinR, agentStdinW := io.Pipe()
+	agentStdoutR, agentStdoutW := io.Pipe()
+	defer agentStdinW.Close()
+	defer agentStdoutW.Close()
+
+	client := NewACPClient(agentStdinW, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.client = client
+	w.pendingRequests.Store("99", req)
+
+	// Agent goroutine: read the JSON-RPC response that the worker writes.
+	go func() {
+		scanner := NewScanner(agentStdinR)
+		scanner.Scan()
+		_ = scanner.Bytes()
+		agentStdoutW.Close()
+	}()
+
+	err := w.HandleQuestionResponse(ctx, "99", map[string]string{"answer": "42"})
+	require.NoError(t, err)
+}
+
+func TestHandleQuestionResponse_NoPendingRequest(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	err := w.HandleQuestionResponse(context.Background(), "nonexistent", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no pending question request")
+}
+
+func TestHandleElicitationResponse_ForwardsToAgent(t *testing.T) {
+	t.Parallel()
+
+	req := &JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mustMarshal(77),
+		Method:  "session/request_elicitation",
+	}
+
+	agentStdinR, agentStdinW := io.Pipe()
+	agentStdoutR, agentStdoutW := io.Pipe()
+	defer agentStdinW.Close()
+	defer agentStdoutW.Close()
+
+	client := NewACPClient(agentStdinW, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.client = client
+	w.pendingRequests.Store("77", req)
+
+	go func() {
+		scanner := NewScanner(agentStdinR)
+		scanner.Scan()
+		_ = scanner.Bytes()
+		agentStdoutW.Close()
+	}()
+
+	err := w.HandleElicitationResponse(ctx, "77", "accept", map[string]any{"file": "main.go"})
+	require.NoError(t, err)
+}
+
+func TestHandleElicitationResponse_NoPendingRequest(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	err := w.HandleElicitationResponse(context.Background(), "missing", "accept", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no pending elicitation request")
+}
+
+// ─── FR-07: ResetContext + InPlaceReset ────────────────────────────────────────
+
+func TestInPlaceReset_ReturnsTrue(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	require.True(t, w.InPlaceReset())
+}
+
+func TestResetContext_DelegatesToResetSession(t *testing.T) {
+	t.Parallel()
+	// Verify ResetContext no longer returns ErrNotImplemented.
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	err := w.ResetContext(context.Background())
+	require.Error(t, err)
+	// Should be "worker not started" not ErrNotImplemented.
+	require.False(t, errors.Is(err, worker.ErrNotImplemented))
+	require.Contains(t, err.Error(), "reset: worker not started")
+}
+
+func TestClear_DelegatesToResetSession(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	err := w.Clear(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reset: worker not started")
+}
+
+// ─── U-02: Agent Discovery ────────────────────────────────────────────────────
+
+func TestHealth_IncludesAgentInfo(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.initResult = &InitializeResult{
+		ProtocolVersion: 1,
+		AgentInfo:       AgentInfo{Name: "hermes", Version: "0.3.0"},
+	}
+
+	h := w.Health()
+	require.Equal(t, "hermes", h.AgentName)
+	require.Equal(t, "0.3.0", h.AgentVersion)
+	require.Equal(t, 1, h.ProtocolVersion)
+}
+
+func TestHealth_NoAgentInfo(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	h := w.Health()
+	require.Empty(t, h.AgentName)
+	require.Empty(t, h.AgentVersion)
+	require.Equal(t, 0, h.ProtocolVersion)
+}
+
+func TestSupportsCapability_AllVariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		init   *InitializeResult
+		cap    string
+		expect bool
+	}{
+		{
+			name:   "nil init result assumes supported",
+			init:   nil,
+			cap:    "loadSession",
+			expect: true,
+		},
+		{
+			name:   "nil capabilities assumes supported",
+			init:   &InitializeResult{AgentCapabilities: nil},
+			cap:    "loadSession",
+			expect: true,
+		},
+		{
+			name:   "missing capability assumes supported",
+			init:   &InitializeResult{AgentCapabilities: map[string]any{}},
+			cap:    "loadSession",
+			expect: true,
+		},
+		{
+			name:   "explicitly true",
+			init:   &InitializeResult{AgentCapabilities: map[string]any{"loadSession": true}},
+			cap:    "loadSession",
+			expect: true,
+		},
+		{
+			name:   "explicitly false",
+			init:   &InitializeResult{AgentCapabilities: map[string]any{"loadSession": false}},
+			cap:    "loadSession",
+			expect: false,
+		},
+		{
+			name:   "non-bool value assumes supported",
+			init:   &InitializeResult{AgentCapabilities: map[string]any{"loadSession": "yes"}},
+			cap:    "loadSession",
+			expect: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+			w.initResult = tc.init
+			require.Equal(t, tc.expect, w.supportsCapability(tc.cap))
+		})
+	}
+}
+
+// ─── U-03: Error Messages ─────────────────────────────────────────────────────
+
+func TestFmtStartError_BinaryNotFound(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	err := w.fmtStartError("hermes", errors.New("exec: executable file not found in $PATH"))
+	require.Contains(t, err.Error(), "not found in PATH")
+	require.Contains(t, err.Error(), "Install the agent")
+}
+
+func TestFmtStartError_PermissionDenied(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	err := w.fmtStartError("hermes", errors.New("fork/exec: permission denied"))
+	require.Contains(t, err.Error(), "not executable")
+	require.Contains(t, err.Error(), "chmod +x")
+}
+
+func TestFmtStartError_Other(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	err := w.fmtStartError("hermes", errors.New("some other error"))
+	require.Contains(t, err.Error(), "failed to start process")
+}
+
+func TestFmtHandshakeError_Timeout(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	err := w.fmtHandshakeError(context.DeadlineExceeded)
+	require.Contains(t, err.Error(), "timed out after 30s")
+	require.Contains(t, err.Error(), "agent is running")
+}
+
+func TestFmtHandshakeError_Other(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	err := w.fmtHandshakeError(errors.New("connection refused"))
+	require.Contains(t, err.Error(), "initialize handshake")
+}
+
+// ─── T-03: Client Extended Tests ───────────────────────────────────────────────
+
+func TestACPClient_Cancel_NoActiveTurn(t *testing.T) {
+	t.Parallel()
+
+	agentStdinR, agentStdinW := io.Pipe()
+	agentStdoutR, agentStdoutW := io.Pipe()
+	defer agentStdinW.Close()
+	defer agentStdoutW.Close()
+
+	client := NewACPClient(agentStdinW, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	// Agent goroutine: read the cancel request, respond with empty result.
+	go func() {
+		scanner := bufio.NewScanner(agentStdinR)
+		if scanner.Scan() {
+			var req struct {
+				ID json.RawMessage `json:"id"`
+			}
+			_ = json.Unmarshal(scanner.Bytes(), &req)
+			resp := &JSONRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  json.RawMessage(`{}`),
+			}
+			_ = WriteMessage(agentStdoutW, resp)
+		}
+	}()
+
+	err := client.Cancel(ctx, "nonexistent_session")
+	require.NoError(t, err)
+}
+
+func TestACPClient_ServerRequest_UnknownMethod(t *testing.T) {
+	t.Parallel()
+
+	// Simulate agent sending a request: agent writes to agentStdoutW, client reads from agentStdoutR.
+	agentStdoutR, agentStdoutW := io.Pipe()
+	client := NewACPClient(io.Discard, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	req := &JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mustMarshal(1),
+		Method:  "custom/unknown_method",
+		Params:  mustMarshal(map[string]any{"key": "value"}),
+	}
+	require.NoError(t, WriteMessage(agentStdoutW, req))
+
+	select {
+	case got := <-client.RequestCh:
+		require.Equal(t, "custom/unknown_method", got.Method)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+	agentStdoutW.Close()
+}
+
+func TestACPClient_Initialize_VersionMismatch(t *testing.T) {
+	t.Parallel()
+
+	agentStdinR, agentStdinW := io.Pipe()
+	agentStdoutR, agentStdoutW := io.Pipe()
+	defer agentStdinW.Close()
+	defer agentStdoutW.Close()
+
+	client := NewACPClient(agentStdinW, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	// Agent goroutine: read the initialize request, respond with protocol v2.
+	go func() {
+		scanner := bufio.NewScanner(agentStdinR)
+		if scanner.Scan() {
+			msg, _ := ReadMessage(bufio.NewScanner(strings.NewReader(string(scanner.Bytes()) + "\n")))
+			_ = msg
+			// Parse the request to get its ID.
+			var req struct {
+				ID json.RawMessage `json:"id"`
+			}
+			_ = json.Unmarshal(scanner.Bytes(), &req)
+
+			resp := &JSONRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result: mustMarshal(InitializeResult{
+					ProtocolVersion: 2,
+					AgentInfo:       AgentInfo{Name: "test", Version: "1.0"},
+				}),
+			}
+			_ = WriteMessage(agentStdoutW, resp)
+		}
+	}()
+
+	result, err := client.Initialize(ctx, map[string]string{"name": "test"})
+	require.NoError(t, err)
+	require.Equal(t, 2, result.ProtocolVersion)
+}
+
+func TestACPClient_Prompt_LargeContent(t *testing.T) {
+	t.Parallel()
+
+	agentStdinR, agentStdinW := io.Pipe()
+	agentStdoutR, agentStdoutW := io.Pipe()
+	defer agentStdinW.Close()
+	defer agentStdoutW.Close()
+
+	client := NewACPClient(agentStdinW, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	largeContent := strings.Repeat("x", 101*1024)
+
+	go func() {
+		scanner := bufio.NewScanner(agentStdinR)
+		scanner.Buffer(make([]byte, 256*1024), 256*1024)
+		if scanner.Scan() {
+			var req struct {
+				ID json.RawMessage `json:"id"`
+			}
+			_ = json.Unmarshal(scanner.Bytes(), &req)
+
+			resp := &JSONRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  mustMarshal(PromptResult{StopReason: "end_turn"}),
+			}
+			_ = WriteMessage(agentStdoutW, resp)
+		}
+	}()
+
+	result, err := client.Prompt(ctx, "sess_1", largeContent)
+	require.NoError(t, err)
+	require.Equal(t, "end_turn", result.StopReason)
+}
+
+// ─── T-02: Mapper Extended Tests ───────────────────────────────────────────────
+
+func TestMapNotification_UnknownUpdateType_Skipped(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	notif := &JSONRPCNotification{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params: mustMarshal(map[string]any{
+			"sessionId": "s1",
+			"update": map[string]any{
+				"sessionUpdate": "future_unknown_type",
+				"data":          "some data",
+			},
+		}),
+	}
+
+	envs := m.MapNotification(notif)
+	require.Nil(t, envs)
+}
+
+func TestMapNotification_NonSessionUpdate_Skipped(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	notif := &JSONRPCNotification{
+		JSONRPC: "2.0",
+		Method:  "some/other/method",
+		Params:  mustMarshal(map[string]any{}),
+	}
+
+	envs := m.MapNotification(notif)
+	require.Nil(t, envs)
+}
+
+func TestMapNotification_MalformedParams_Skipped(t *testing.T) {
+	t.Parallel()
+	m := newTestMapper()
+
+	notif := &JSONRPCNotification{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params:  json.RawMessage(`{invalid}`),
+	}
+
+	envs := m.MapNotification(notif)
+	require.Nil(t, envs)
+}
+
+// ─── Compile-time interface checks ─────────────────────────────────────────────
+
+func TestWorkerImplementsInPlaceReseter(t *testing.T) {
+	t.Parallel()
+	var _ worker.InPlaceReseter = (*Worker)(nil)
+}
+
+func TestWorkerImplementsMetadataHandler(t *testing.T) {
+	t.Parallel()
+	var _ interface {
+		HandlePermissionResponse(ctx context.Context, reqID string, allowed bool, reason string) error
+		HandleQuestionResponse(ctx context.Context, reqID string, answers map[string]string) error
+		HandleElicitationResponse(ctx context.Context, reqID string, action string, content map[string]any) error
+	} = (*Worker)(nil)
+}

--- a/internal/worker/acp/worker_phase2_test.go
+++ b/internal/worker/acp/worker_phase2_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -497,4 +499,193 @@ func TestWorkerImplementsMetadataHandler(t *testing.T) {
 		HandleQuestionResponse(ctx context.Context, reqID string, answers map[string]string) error
 		HandleElicitationResponse(ctx context.Context, reqID string, action string, content map[string]any) error
 	} = (*Worker)(nil)
+}
+
+// ─── Fix #8: resetSession happy path tests ──────────────────────────────────────
+
+func TestResetSession_UpdatesSessionIDAndClearsPending(t *testing.T) {
+	t.Parallel()
+
+	agentStdinR, agentStdinW := io.Pipe()
+	agentStdoutR, agentStdoutW := io.Pipe()
+	defer agentStdinW.Close()
+	defer agentStdoutW.Close()
+
+	client := NewACPClient(agentStdinW, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.client = client
+	w.acpSessionID = "old_session"
+	w.projectDir = "/tmp"
+	w.mcpServers = nil
+	w.mapper = newTestMapper()
+
+	// Store stale entries that should be cleared.
+	w.pendingRequests.Store("stale_req", &JSONRPCRequest{ID: mustMarshal(1)})
+	w.pendingPerm.Store("stale_perm", nil)
+
+	// Agent goroutine: handle Cancel then NewSession.
+	go func() {
+		scanner := bufio.NewScanner(agentStdinR)
+		for i := 0; i < 2; i++ {
+			if !scanner.Scan() {
+				return
+			}
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			_ = json.Unmarshal(scanner.Bytes(), &req)
+
+			var result any
+			switch req.Method {
+			case "session/cancel":
+				result = json.RawMessage(`{}`)
+			case "session/new":
+				result = SessionResult{SessionID: "new_session_42"}
+			default:
+				result = json.RawMessage(`{}`)
+			}
+			resp := &JSONRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  mustMarshal(result),
+			}
+			_ = WriteMessage(agentStdoutW, resp)
+		}
+	}()
+
+	err := w.resetSession(ctx)
+	require.NoError(t, err)
+
+	// Verify acpSessionID was updated.
+	w.Mu.Lock()
+	sid := w.acpSessionID
+	w.Mu.Unlock()
+	require.Equal(t, "new_session_42", sid)
+
+	// Verify pending maps were cleared.
+	_, ok := w.pendingRequests.Load("stale_req")
+	require.False(t, ok, "pendingRequests should be cleared after resetSession")
+	_, ok = w.pendingPerm.Load("stale_perm")
+	require.False(t, ok, "pendingPerm should be cleared after resetSession")
+}
+
+func TestClear_IncResetGeneration(t *testing.T) {
+	t.Parallel()
+
+	agentStdinR, agentStdinW := io.Pipe()
+	agentStdoutR, agentStdoutW := io.Pipe()
+	defer agentStdinW.Close()
+	defer agentStdoutW.Close()
+
+	client := NewACPClient(agentStdinW, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.client = client
+	w.acpSessionID = "old"
+	w.projectDir = "/tmp"
+	w.mcpServers = nil
+	w.mapper = newTestMapper()
+
+	genBefore := w.LoadResetGeneration()
+
+	go func() {
+		scanner := bufio.NewScanner(agentStdinR)
+		for i := 0; i < 2; i++ {
+			if !scanner.Scan() {
+				return
+			}
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			_ = json.Unmarshal(scanner.Bytes(), &req)
+			var result any = json.RawMessage(`{}`)
+			if req.Method == "session/new" {
+				result = SessionResult{SessionID: "new_sess"}
+			}
+			_ = WriteMessage(agentStdoutW, &JSONRPCResponse{
+				JSONRPC: "2.0", ID: req.ID, Result: mustMarshal(result),
+			})
+		}
+	}()
+
+	err := w.Clear(ctx)
+	require.NoError(t, err)
+
+	genAfter := w.LoadResetGeneration()
+	require.Equal(t, genBefore+1, genAfter, "Clear should increment reset generation exactly once")
+}
+
+func TestResetContext_DoesNotIncResetGeneration(t *testing.T) {
+	t.Parallel()
+
+	agentStdinR, agentStdinW := io.Pipe()
+	agentStdoutR, agentStdoutW := io.Pipe()
+	defer agentStdinW.Close()
+	defer agentStdoutW.Close()
+
+	client := NewACPClient(agentStdinW, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.client = client
+	w.acpSessionID = "old"
+	w.projectDir = "/tmp"
+	w.mcpServers = nil
+	w.mapper = newTestMapper()
+
+	genBefore := w.LoadResetGeneration()
+
+	go func() {
+		scanner := bufio.NewScanner(agentStdinR)
+		for i := 0; i < 2; i++ {
+			if !scanner.Scan() {
+				return
+			}
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			_ = json.Unmarshal(scanner.Bytes(), &req)
+			var result any = json.RawMessage(`{}`)
+			if req.Method == "session/new" {
+				result = SessionResult{SessionID: "new_sess"}
+			}
+			_ = WriteMessage(agentStdoutW, &JSONRPCResponse{
+				JSONRPC: "2.0", ID: req.ID, Result: mustMarshal(result),
+			})
+		}
+	}()
+
+	err := w.ResetContext(ctx)
+	require.NoError(t, err)
+
+	genAfter := w.LoadResetGeneration()
+	require.Equal(t, genBefore, genAfter, "ResetContext should NOT increment generation (Bridge does it)")
+}
+
+func TestFmtStartError_ExecError(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	err := w.fmtStartError("myagent", &exec.Error{Name: "myagent", Err: errors.New("executable file not found")})
+	require.Contains(t, err.Error(), "not found in PATH")
+	require.Contains(t, err.Error(), "Install the agent")
+}
+
+func TestFmtStartError_PathErrorPermission(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	err := w.fmtStartError("myagent", &os.PathError{Op: "fork/exec", Path: "/usr/local/bin/myagent", Err: os.ErrPermission})
+	require.Contains(t, err.Error(), "not executable")
+	require.Contains(t, err.Error(), "chmod +x")
 }

--- a/internal/worker/codexcli/types.go
+++ b/internal/worker/codexcli/types.go
@@ -36,10 +36,10 @@ type CodexItem struct {
 	SavedPath   string                     `json:"saved_path,omitempty"`
 	Phase       string                     `json:"phase,omitempty"`
 	// CollabToolCall fields
-	CollabTool string     `json:"collab_tool,omitempty"`
-	Agents     []string   `json:"agents,omitempty"`
+	CollabTool string   `json:"collab_tool,omitempty"`
+	Agents     []string `json:"agents,omitempty"`
 	// WebSearch fields
-	Results    json.RawMessage `json:"results,omitempty"`
+	Results json.RawMessage `json:"results,omitempty"`
 	// TodoList fields
 	TodoItems []CodexTodoItem `json:"todo_items,omitempty"`
 	Data      json.RawMessage `json:"data,omitempty"` // generic payload for error items
@@ -110,6 +110,7 @@ const (
 	ItemWebSearch        = "web_search"
 	ItemTodoList         = "todo_list"
 	ItemError            = "error"
+	ItemImageGeneration  = "image_generation"
 )
 
 // EnvBlocklist defines environment variable prefixes to strip from worker processes.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -133,6 +133,11 @@ type WorkerHealth struct {
 	Healthy   bool       `json:"healthy"`
 	Uptime    string     `json:"uptime"`
 	Error     string     `json:"error,omitempty"`
+
+	// Agent discovery fields (populated by ACP and similar workers).
+	AgentName       string `json:"agent_name,omitempty"`
+	AgentVersion    string `json:"agent_version,omitempty"`
+	ProtocolVersion int    `json:"protocol_version,omitempty"`
 }
 
 // InputRecoverer is an optional interface for session connections that cache


### PR DESCRIPTION
## Summary

ACP Worker Phase 2 实现 issue #588 中的 5 个子任务。

## Changes

### FR-06: Question/Elicitation Response Support
- `HandleQuestionResponse` / `HandleElicitationResponse` 将客户端响应通过 `RespondPermission` 转发回 agent
- `pendingRequests sync.Map` 跟踪非权限类 server-initiated 请求
- 未知 server request 作为 Raw event 转发给 gateway 处理

### FR-07: ResetContext Improvement
- 替换 `ErrNotImplemented` stub 为真实 `resetSession` 实现
- `InPlaceReset()` 返回 true — 保持 forwardEvents goroutine 存活
- `Clear()` 委托给 `resetSession` 确保状态一致清理
- Capability-gated `loadSession` 支持 reset 后的 session 恢复

### U-02: Agent Discovery & Health Check
- 存储 handshake 返回的 `initResult` 用于 agent 元数据
- `Health()` 报告 `agent_name`、`agent_version`、`protocol_version`
- `supportsCapability()` 支持优雅的功能降级

### U-03: Error Message Actionability
- `fmtStartError`: 针对 PATH/权限失败提供可操作建议
- `fmtHandshakeError`: 针对 timeout 提供专门诊断信息

### T-02/T-03: Extended Tests (25 tests)
- FR-06: server request passthrough、question/elicitation 响应
- FR-07: InPlaceReset、ResetContext、Clear 委托
- U-02: agent info in health、capability checks (6 subcases)
- U-03: error formatters (5 cases)
- T-02: mapper edge cases (3 cases)
- T-03: client cancel、unknown method、version mismatch、large content

## Files Changed

| File | Change |
|------|--------|
| `internal/worker/acp/worker.go` | +164/-34 — Phase 2 生产代码 |
| `internal/worker/acp/worker_phase2_test.go` | +490 — 25 个新测试 |
| `internal/worker/worker.go` | +5 — WorkerHealth 扩展字段 |

## Testing

- [x] `make check` 全部通过 (fmt + lint + test + build)
- [x] 87 个测试全部通过 (`-count=1 -race`)
- [x] 无回归

Closes #588