### PR TITLE
feat(acp): Phase 3 — protocol version, multi-agent, debug trace, ForkSession, JSON Schema

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -229,11 +229,14 @@ worker:
     auto_approve: false
     # Extra arguments appended after the command (e.g., model selection, verbose mode).
     # Override via HOTPLEX_WORKER_ACP_ARGS environment variable.
+    # Note: env var is split on whitespace; quoted values with spaces are not supported.
     # args:
     #   - "--model"
     #   - "claude-sonnet-4-6"
     # Enable protocol-level debug tracing to ~/.hotplex/logs/acp-trace-*.jsonl.
     # Override via HOTPLEX_WORKER_ACP_DEBUG environment variable.
+    # WARNING: trace files contain full prompts and agent responses, including
+    # potentially sensitive data. Enable only for debugging and delete after use.
     debug: false
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -227,6 +227,14 @@ worker:
     # WARNING: auto_approve: true grants full tool access without human review.
     # Consider keeping false in production environments.
     auto_approve: false
+    # Extra arguments appended after the command (e.g., model selection, verbose mode).
+    # Override via HOTPLEX_WORKER_ACP_ARGS environment variable.
+    # args:
+    #   - "--model"
+    #   - "claude-sonnet-4-6"
+    # Enable protocol-level debug tracing to ~/.hotplex/logs/acp-trace-*.jsonl.
+    # Override via HOTPLEX_WORKER_ACP_DEBUG environment variable.
+    debug: false
 
 # ─────────────────────────────────────────────────────────────────────────────
 # AGENT PERSONALITY & SKILLS (B/C Channels)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1036,6 +1036,8 @@ func Load(filePath string) (*Config, error) {
 	_ = v.BindEnv("worker.codex_cli.approval_mode")
 	_ = v.BindEnv("worker.acp.command")
 	_ = v.BindEnv("worker.acp.auto_approve")
+	_ = v.BindEnv("worker.acp.args")
+	_ = v.BindEnv("worker.acp.debug")
 	_ = v.BindEnv("worker.opencode_server.command")
 	_ = v.BindEnv("worker.opencode_server.idle_drain_period")
 	_ = v.BindEnv("worker.opencode_server.ready_timeout")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -607,8 +607,10 @@ type OpenCodeServerConfig struct {
 // ACPConfig holds ACP (Agent Client Protocol) worker settings.
 // ACP is a universal worker type that connects to any ACP-compatible agent via stdio.
 type ACPConfig struct {
-	Command     string `mapstructure:"command" json:"command"`                               // ACP agent binary (e.g. "hermes-acp")
-	AutoApprove bool   `mapstructure:"auto_approve,omitempty" json:"auto_approve,omitempty"` // auto-approve permission requests
+	Command     string   `mapstructure:"command" json:"command"`                               // ACP agent binary (e.g. "hermes-acp")
+	AutoApprove bool     `mapstructure:"auto_approve,omitempty" json:"auto_approve,omitempty"` // auto-approve permission requests
+	Args        []string `mapstructure:"args,omitempty" json:"args,omitempty"`                 // extra args appended after the command
+	Debug       bool     `mapstructure:"debug,omitempty" json:"debug,omitempty"`               // enable JSON-RPC protocol trace logging
 }
 
 // AutoRetryConfig controls automatic retry behavior when LLM provider returns

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -630,6 +630,7 @@ func (b *Bridge) buildWorkerInfo(sessionID, userID, workDir string, si *session.
 		ACPCommand:      si.PlatformKey[worker.ACPCommandPlatformKey],
 		ForkSession:     si.PlatformKey["_fork_session"] == "true",
 		JSONSchema:      si.PlatformKey["_json_schema"],
+		// TODO: wire _fork_session/_json_schema from platform adapters in UX follow-up (see #589 Phase 3).
 	}
 
 	// MCP config injection — 3 scenarios:

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -628,9 +628,9 @@ func (b *Bridge) buildWorkerInfo(sessionID, userID, workDir string, si *session.
 		ConfigBlocklist: b.workerEnvBlocklist,
 		Sandbox:         si.PlatformKey[worker.SandboxPlatformKey],
 		ACPCommand:      si.PlatformKey[worker.ACPCommandPlatformKey],
-		ForkSession:     si.PlatformKey["_fork_session"] == "true",
-		JSONSchema:      si.PlatformKey["_json_schema"],
-		// TODO: wire _fork_session/_json_schema from platform adapters in UX follow-up.
+		ForkSession:     si.PlatformKey[worker.ForkSessionPlatformKey] == "true",
+		JSONSchema:      si.PlatformKey[worker.JSONSchemaPlatformKey],
+		// TODO: wire ForkSession/JSONSchema from platform adapters in UX follow-up.
 	}
 
 	// MCP config injection — 3 scenarios:

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -628,6 +628,8 @@ func (b *Bridge) buildWorkerInfo(sessionID, userID, workDir string, si *session.
 		ConfigBlocklist: b.workerEnvBlocklist,
 		Sandbox:         si.PlatformKey[worker.SandboxPlatformKey],
 		ACPCommand:      si.PlatformKey[worker.ACPCommandPlatformKey],
+		ForkSession:     si.PlatformKey["_fork_session"] == "true",
+		JSONSchema:      si.PlatformKey["_json_schema"],
 	}
 
 	// MCP config injection — 3 scenarios:

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -630,7 +630,8 @@ func (b *Bridge) buildWorkerInfo(sessionID, userID, workDir string, si *session.
 		ACPCommand:      si.PlatformKey[worker.ACPCommandPlatformKey],
 		ForkSession:     si.PlatformKey[worker.ForkSessionPlatformKey] == "true",
 		JSONSchema:      si.PlatformKey[worker.JSONSchemaPlatformKey],
-		// TODO: wire ForkSession/JSONSchema from platform adapters in UX follow-up.
+		// TODO: platform adapters (Slack/Feishu) need to populate ForkSession/JSONSchema
+		// into PlatformKey for this wiring to take effect; tracked in UX follow-up.
 	}
 
 	// MCP config injection — 3 scenarios:

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -630,7 +630,7 @@ func (b *Bridge) buildWorkerInfo(sessionID, userID, workDir string, si *session.
 		ACPCommand:      si.PlatformKey[worker.ACPCommandPlatformKey],
 		ForkSession:     si.PlatformKey["_fork_session"] == "true",
 		JSONSchema:      si.PlatformKey["_json_schema"],
-		// TODO: wire _fork_session/_json_schema from platform adapters in UX follow-up (see #589 Phase 3).
+		// TODO: wire _fork_session/_json_schema from platform adapters in UX follow-up.
 	}
 
 	// MCP config injection — 3 scenarios:

--- a/internal/worker/acp/bench_test.go
+++ b/internal/worker/acp/bench_test.go
@@ -1,0 +1,185 @@
+package acp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// ─── T-04: Performance Benchmarks ──────────────────────────────────────────────
+
+// benchNotification returns a realistic session/update notification for benchmarking.
+func benchNotification(updateType, text string) *JSONRPCNotification {
+	params, _ := json.Marshal(map[string]any{
+		"sessionId": "sess_bench_123",
+		"update": map[string]any{
+			"sessionUpdate": updateType,
+			"content":       map[string]any{"text": text},
+		},
+	})
+	return &JSONRPCNotification{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params:  params,
+	}
+}
+
+func BenchmarkMapNotification(b *testing.B) {
+	m := NewACPMapper("sess_bench", "user_bench", slog.Default())
+	notif := benchNotification("agent_message_chunk", "Hello, this is a benchmark test message for the ACP mapper.")
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		m.MapNotification(notif)
+	}
+}
+
+func BenchmarkMapNotification_Stream(b *testing.B) {
+	m := NewACPMapper("sess_bench", "user_bench", slog.Default())
+	textNotif := benchNotification("agent_message_chunk", "Streaming text chunk for benchmark. ")
+	thoughtNotif := benchNotification("agent_thought_chunk", "Thinking about the answer... ")
+	toolNotif := &JSONRPCNotification{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params: marshalParams(map[string]any{
+			"sessionId": "sess_bench_123",
+			"update": map[string]any{
+				"sessionUpdate": "tool_call",
+				"id":            "tool_1",
+				"tool":          "read_file",
+				"arguments":     map[string]any{"path": "/tmp/test.txt"},
+			},
+		}),
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// Simulate a realistic stream: 80% text, 10% thought, 10% tool.
+		for j := 0; j < 1000; j++ {
+			switch j % 10 {
+			case 0:
+				m.MapNotification(thoughtNotif)
+			case 5:
+				m.MapNotification(toolNotif)
+			default:
+				m.MapNotification(textNotif)
+			}
+		}
+		m.Reset()
+	}
+}
+
+func BenchmarkCodec_WriteMessage(b *testing.B) {
+	req := &JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mustMarshal(1),
+		Method:  "session/prompt",
+		Params:  mustMarshal(map[string]any{"sessionId": "sess_1", "content": strings.Repeat("x", 100)}),
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		_ = WriteMessage(&buf, req)
+	}
+}
+
+func BenchmarkCodec_ReadMessage(b *testing.B) {
+	line := `{"jsonrpc":"2.0","id":1,"method":"session/prompt","params":{"sessionId":"sess_1","content":"` +
+		strings.Repeat("x", 100) + `"}}` + "\n"
+	msg := []byte(line)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		scanner := bufio.NewScanner(bytes.NewReader(msg))
+		scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
+		_, _ = ReadMessage(scanner)
+	}
+}
+
+// BenchmarkPrompt_FullTurn simulates a complete prompt→response cycle
+// with a mock agent, measuring the overhead of the ACP worker layer.
+func BenchmarkPrompt_FullTurn(b *testing.B) {
+	// Pre-build the prompt response.
+	promptResp := &JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      mustMarshal(1),
+		Result:  mustMarshal(map[string]any{"stopReason": "end_turn", "usage": map[string]any{"inputTokens": 100, "outputTokens": 50}}),
+	}
+	respLine, _ := json.Marshal(promptResp)
+
+	// Pre-build a notification.
+	notifObj := benchNotification("agent_message_chunk", "This is a streaming response from the agent. ")
+	notifLine, _ := json.Marshal(notifObj)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// Simulate client call: marshal request.
+		req := &JSONRPCRequest{
+			JSONRPC: "2.0",
+			ID:      mustMarshal(1),
+			Method:  "session/prompt",
+			Params:  mustMarshal(map[string]any{"sessionId": "sess_bench", "content": "Hello"}),
+		}
+		var buf bytes.Buffer
+		_ = WriteMessage(&buf, req)
+
+		// Simulate agent response: read notification + response.
+		scanner := bufio.NewScanner(bytes.NewReader(bytes.Join([][]byte{
+			append(notifLine, '\n'),
+			append(notifLine, '\n'),
+			append(respLine, '\n'),
+		}, nil)))
+		scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
+		for {
+			msg, _ := ReadMessage(scanner)
+			if resp, ok := msg.(*JSONRPCResponse); ok {
+				_ = resp
+				break
+			}
+		}
+	}
+}
+
+// BenchmarkMapNotification_Plan benchmarks plan event mapping.
+func BenchmarkMapNotification_Plan(b *testing.B) {
+	m := NewACPMapper("sess_bench", "user_bench", slog.Default())
+	planUpdate, _ := json.Marshal(map[string]any{
+		"sessionUpdate": "plan",
+		"items": []map[string]any{
+			{"id": "task_1", "text": "Step 1: Read files", "status": "completed"},
+			{"id": "task_2", "text": "Step 2: Analyze", "status": "in_progress"},
+			{"id": "task_3", "text": "Step 3: Report", "status": "pending"},
+		},
+	})
+	notif := &JSONRPCNotification{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params:  mustMarshal(map[string]any{"sessionId": "sess_bench", "update": planUpdate}),
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		m.MapNotification(notif)
+	}
+}
+
+// marshalParams is a test helper that panics on failure.
+func marshalParams(v any) json.RawMessage {
+	b, _ := json.Marshal(v)
+	return b
+}
+
+// Ensure the benchmark event types exist.
+var _ = events.Kind("")

--- a/internal/worker/acp/bench_test.go
+++ b/internal/worker/acp/bench_test.go
@@ -47,7 +47,7 @@ func BenchmarkMapNotification_Stream(b *testing.B) {
 	toolNotif := &JSONRPCNotification{
 		JSONRPC: "2.0",
 		Method:  "session/update",
-		Params: marshalParams(map[string]any{
+		Params: mustMarshal(map[string]any{
 			"sessionId": "sess_bench_123",
 			"update": map[string]any{
 				"sessionUpdate": "tool_call",
@@ -173,12 +173,6 @@ func BenchmarkMapNotification_Plan(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		m.MapNotification(notif)
 	}
-}
-
-// marshalParams is a test helper that panics on failure.
-func marshalParams(v any) json.RawMessage {
-	b, _ := json.Marshal(v)
-	return b
 }
 
 // Ensure the benchmark event types exist.

--- a/internal/worker/acp/bench_test.go
+++ b/internal/worker/acp/bench_test.go
@@ -7,8 +7,6 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
-
-	"github.com/hrygo/hotplex/pkg/events"
 )
 
 // ─── T-04: Performance Benchmarks ──────────────────────────────────────────────
@@ -174,6 +172,3 @@ func BenchmarkMapNotification_Plan(b *testing.B) {
 		m.MapNotification(notif)
 	}
 }
-
-// Ensure the benchmark event types exist.
-var _ = events.Kind("")

--- a/internal/worker/acp/client.go
+++ b/internal/worker/acp/client.go
@@ -27,7 +27,7 @@ type ACPClient struct {
 	mu      sync.Mutex
 	pending map[string]chan *JSONRPCResponse
 
-	writeMu sync.Mutex // serializes stdin writes (call + RespondPermission)
+	writeMu sync.Mutex // serializes stdin writes (call + RespondRequest)
 
 	// NotificationCh delivers session/update notifications to the worker's readLoop.
 	NotificationCh chan *JSONRPCNotification

--- a/internal/worker/acp/mapper.go
+++ b/internal/worker/acp/mapper.go
@@ -76,6 +76,7 @@ func (m *ACPMapper) SetTurnActive() { m.turnActive.Store(true) }
 // in a single unmarshal pass, eliminating triple-deserialization on the streaming path.
 func (m *ACPMapper) MapNotification(notif *JSONRPCNotification) []*events.Envelope {
 	if notif.Method != "session/update" {
+		m.log.Debug("acp mapper: skipping non-session/update notification", "method", notif.Method)
 		return nil
 	}
 
@@ -122,6 +123,8 @@ func (m *ACPMapper) MapNotification(notif *JSONRPCNotification) []*events.Envelo
 	case "user_message_chunk":
 		return nil // echo of user input, ignored
 	default:
+		m.log.Warn("acp mapper: unknown sessionUpdate type, skipping",
+			"type", disc.SessionUpdate)
 		return nil
 	}
 }

--- a/internal/worker/acp/trace.go
+++ b/internal/worker/acp/trace.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -33,10 +34,17 @@ func NewTraceWriter(dir, sessionID string) (*TraceWriter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("acp trace: open file: %w", err)
 	}
+	// Initialize byte counter from existing file size so rotation works
+	// correctly after process restart with a pre-existing trace file.
+	var written int64
+	if info, statErr := f.Stat(); statErr == nil {
+		written = info.Size()
+	}
 	return &TraceWriter{
-		file:    f,
-		path:    path,
-		maxSize: 50 * 1024 * 1024, // 50 MB
+		file:         f,
+		path:         path,
+		maxSize:      50 * 1024 * 1024, // 50 MB
+		writtenBytes: written,
 	}, nil
 }
 
@@ -83,11 +91,13 @@ func (tw *TraceWriter) rotateLocked() {
 	rotated := tw.path + ".1"
 	_ = os.Remove(rotated)
 	if err := os.Rename(tw.path, rotated); err != nil {
+		slog.Warn("acp trace: rename failed, trace data lost", "error", err, "path", tw.path)
 		tw.file = nil
 		return
 	}
 	f, err := os.OpenFile(tw.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
+		slog.Warn("acp trace: reopen failed after rotation", "error", err, "path", tw.path)
 		tw.file = nil
 		return
 	}

--- a/internal/worker/acp/trace.go
+++ b/internal/worker/acp/trace.go
@@ -3,7 +3,6 @@ package acp
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -45,6 +44,7 @@ func NewTraceWriter(dir, sessionID string) (*TraceWriter, error) {
 }
 
 // Log writes a single trace entry. Safe to call on a nil TraceWriter (no-op).
+// Also checks file size and triggers rotation when the configured max is exceeded.
 func (tw *TraceWriter) Log(direction string, msg any) {
 	if tw == nil {
 		return
@@ -55,8 +55,39 @@ func (tw *TraceWriter) Log(direction string, msg any) {
 		"msg": msg,
 	}
 	tw.mu.Lock()
+	if tw.enc == nil {
+		tw.mu.Unlock()
+		return
+	}
 	_ = tw.enc.Encode(entry)
+	// Check rotation after write (best-effort, ignore error).
+	if f, err := tw.file.Stat(); err == nil && f.Size() >= tw.maxSize {
+		tw.rotateLocked()
+	}
 	tw.mu.Unlock()
+}
+
+// rotateLocked performs file rotation. Caller must hold tw.mu.
+// On failure, tw.file is set to nil so subsequent Log() calls degrade gracefully.
+func (tw *TraceWriter) rotateLocked() {
+	if err := tw.file.Close(); err != nil {
+		return
+	}
+	rotated := tw.path + ".1"
+	_ = os.Remove(rotated)
+	if err := os.Rename(tw.path, rotated); err != nil {
+		tw.file = nil
+		tw.enc = nil
+		return
+	}
+	f, err := os.OpenFile(tw.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		tw.file = nil
+		tw.enc = nil
+		return
+	}
+	tw.file = f
+	tw.enc = json.NewEncoder(f)
 }
 
 // Close flushes and closes the trace file.
@@ -70,14 +101,16 @@ func (tw *TraceWriter) Close() error {
 }
 
 // Rotate checks the file size and rotates if it exceeds maxSize.
-// The old file is renamed with a .1 suffix and a new file is created.
+// Safe to call on nil TraceWriter. Rotation is also triggered automatically by Log().
 func (tw *TraceWriter) Rotate(maxSize int64) error {
 	if tw == nil {
 		return nil
 	}
 	tw.mu.Lock()
 	defer tw.mu.Unlock()
-
+	if tw.file == nil {
+		return nil
+	}
 	info, err := tw.file.Stat()
 	if err != nil {
 		return fmt.Errorf("acp trace: stat: %w", err)
@@ -85,26 +118,7 @@ func (tw *TraceWriter) Rotate(maxSize int64) error {
 	if info.Size() < maxSize {
 		return nil
 	}
-
-	// Close current file.
-	if err := tw.file.Close(); err != nil {
-		return fmt.Errorf("acp trace: close for rotate: %w", err)
-	}
-
-	// Rename old file.
-	rotated := tw.path + ".1"
-	_ = os.Remove(rotated) // ignore error if .1 doesn't exist
-	if err := os.Rename(tw.path, rotated); err != nil {
-		slog.Warn("acp trace: failed to rename for rotation", "error", err)
-	}
-
-	// Open new file.
-	f, err := os.OpenFile(tw.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-	if err != nil {
-		return fmt.Errorf("acp trace: reopen after rotate: %w", err)
-	}
-	tw.file = f
-	tw.enc = json.NewEncoder(f)
+	tw.rotateLocked()
 	return nil
 }
 

--- a/internal/worker/acp/trace.go
+++ b/internal/worker/acp/trace.go
@@ -1,0 +1,117 @@
+package acp
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// TraceWriter logs all JSON-RPC messages to a JSONL trace file for debugging.
+// Enabled via acp.debug: true in config.yaml.
+//
+// File location: {dir}/acp-trace-{sessionID}.jsonl
+// Each line: {"ts":"...","dir":"→|←","msg":{...}}
+// Rotation: when file exceeds maxSize, renamed to .1 and a new file is created.
+type TraceWriter struct {
+	mu      sync.Mutex
+	file    *os.File
+	enc     *json.Encoder
+	path    string
+	maxSize int64
+}
+
+// NewTraceWriter creates a trace writer that appends to a JSONL file.
+// Returns nil if the file cannot be created (logs a warning and continues).
+func NewTraceWriter(dir, sessionID string) (*TraceWriter, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("acp trace: create dir: %w", err)
+	}
+	path := filepath.Join(dir, "acp-trace-"+sessionID+".jsonl")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("acp trace: open file: %w", err)
+	}
+	enc := json.NewEncoder(f)
+	return &TraceWriter{
+		file:    f,
+		enc:     enc,
+		path:    path,
+		maxSize: 50 * 1024 * 1024, // 50 MB
+	}, nil
+}
+
+// Log writes a single trace entry. Safe to call on a nil TraceWriter (no-op).
+func (tw *TraceWriter) Log(direction string, msg any) {
+	if tw == nil {
+		return
+	}
+	entry := map[string]any{
+		"ts":  time.Now().Format(time.RFC3339Nano),
+		"dir": direction,
+		"msg": msg,
+	}
+	tw.mu.Lock()
+	_ = tw.enc.Encode(entry)
+	tw.mu.Unlock()
+}
+
+// Close flushes and closes the trace file.
+func (tw *TraceWriter) Close() error {
+	if tw == nil {
+		return nil
+	}
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	return tw.file.Close()
+}
+
+// Rotate checks the file size and rotates if it exceeds maxSize.
+// The old file is renamed with a .1 suffix and a new file is created.
+func (tw *TraceWriter) Rotate(maxSize int64) error {
+	if tw == nil {
+		return nil
+	}
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+
+	info, err := tw.file.Stat()
+	if err != nil {
+		return fmt.Errorf("acp trace: stat: %w", err)
+	}
+	if info.Size() < maxSize {
+		return nil
+	}
+
+	// Close current file.
+	if err := tw.file.Close(); err != nil {
+		return fmt.Errorf("acp trace: close for rotate: %w", err)
+	}
+
+	// Rename old file.
+	rotated := tw.path + ".1"
+	_ = os.Remove(rotated) // ignore error if .1 doesn't exist
+	if err := os.Rename(tw.path, rotated); err != nil {
+		slog.Warn("acp trace: failed to rename for rotation", "error", err)
+	}
+
+	// Open new file.
+	f, err := os.OpenFile(tw.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("acp trace: reopen after rotate: %w", err)
+	}
+	tw.file = f
+	tw.enc = json.NewEncoder(f)
+	return nil
+}
+
+// Path returns the current trace file path (for diagnostics).
+func (tw *TraceWriter) Path() string {
+	if tw == nil {
+		return ""
+	}
+	return tw.path
+}

--- a/internal/worker/acp/trace.go
+++ b/internal/worker/acp/trace.go
@@ -28,7 +28,7 @@ func NewTraceWriter(dir, sessionID string) (*TraceWriter, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("acp trace: create dir: %w", err)
 	}
-	path := filepath.Join(dir, "acp-trace-"+sessionID+".jsonl")
+	path := filepath.Join(dir, "acp-trace-"+filepath.Base(sessionID)+".jsonl")
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("acp trace: open file: %w", err)

--- a/internal/worker/acp/trace.go
+++ b/internal/worker/acp/trace.go
@@ -12,7 +12,7 @@ import (
 // TraceWriter logs all JSON-RPC messages to a JSONL trace file for debugging.
 // Enabled via acp.debug: true in config.yaml.
 //
-// File location: {dir}/acp-trace-{sessionID}.jsonl
+// File location: {dir}/acp-trace-{base(sessionID)}.jsonl
 // Each line: {"ts":"...","dir":"→|←","msg":{...}}
 // Rotation: when file exceeds maxSize, renamed to .1 and a new file is created.
 type TraceWriter struct {

--- a/internal/worker/acp/trace.go
+++ b/internal/worker/acp/trace.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -19,14 +18,12 @@ import (
 type TraceWriter struct {
 	mu           sync.Mutex
 	file         *os.File
-	enc          *json.Encoder
 	path         string
 	maxSize      int64
-	writtenBytes atomic.Int64
+	writtenBytes int64
 }
 
 // NewTraceWriter creates a trace writer that appends to a JSONL file.
-// Returns nil if the file cannot be created (logs a warning and continues).
 func NewTraceWriter(dir, sessionID string) (*TraceWriter, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("acp trace: create dir: %w", err)
@@ -36,17 +33,15 @@ func NewTraceWriter(dir, sessionID string) (*TraceWriter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("acp trace: open file: %w", err)
 	}
-	enc := json.NewEncoder(f)
 	return &TraceWriter{
 		file:    f,
-		enc:     enc,
 		path:    path,
 		maxSize: 50 * 1024 * 1024, // 50 MB
 	}, nil
 }
 
 // Log writes a single trace entry. Safe to call on a nil TraceWriter (no-op).
-// Uses an atomic byte counter to track size and triggers rotation without Stat() syscall.
+// Uses a byte counter under mutex to track size, avoiding Stat() syscall on every call.
 func (tw *TraceWriter) Log(direction string, msg any) {
 	if tw == nil {
 		return
@@ -68,11 +63,11 @@ func (tw *TraceWriter) Log(direction string, msg any) {
 		return
 	}
 	_, _ = tw.file.Write(line)
-	tw.writtenBytes.Add(int64(len(line)))
+	tw.writtenBytes += int64(len(line))
 
-	// Check rotation using byte counter (avoids Stat() syscall on every Log).
-	if tw.writtenBytes.Load() >= tw.maxSize {
-		tw.writtenBytes.Store(0)
+	// Check rotation using byte counter.
+	if tw.writtenBytes >= tw.maxSize {
+		tw.writtenBytes = 0
 		tw.rotateLocked()
 	}
 	tw.mu.Unlock()
@@ -83,24 +78,20 @@ func (tw *TraceWriter) Log(direction string, msg any) {
 func (tw *TraceWriter) rotateLocked() {
 	if err := tw.file.Close(); err != nil {
 		tw.file = nil
-		tw.enc = nil
 		return
 	}
 	rotated := tw.path + ".1"
 	_ = os.Remove(rotated)
 	if err := os.Rename(tw.path, rotated); err != nil {
 		tw.file = nil
-		tw.enc = nil
 		return
 	}
 	f, err := os.OpenFile(tw.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		tw.file = nil
-		tw.enc = nil
 		return
 	}
 	tw.file = f
-	tw.enc = json.NewEncoder(f)
 }
 
 // Close flushes and closes the trace file.
@@ -116,9 +107,9 @@ func (tw *TraceWriter) Close() error {
 	return tw.file.Close()
 }
 
-// Rotate checks the file size and rotates if it exceeds maxSize.
-// Safe to call on nil TraceWriter. Rotation is also triggered automatically by Log().
-func (tw *TraceWriter) Rotate(maxSize int64) error {
+// Rotate forces a rotation. Safe to call on nil TraceWriter.
+// Rotation is also triggered automatically by Log() when the file exceeds maxSize.
+func (tw *TraceWriter) Rotate() error {
 	if tw == nil {
 		return nil
 	}
@@ -127,10 +118,7 @@ func (tw *TraceWriter) Rotate(maxSize int64) error {
 	if tw.file == nil {
 		return nil
 	}
-	if tw.writtenBytes.Load() < maxSize {
-		return nil
-	}
-	tw.writtenBytes.Store(0)
+	tw.writtenBytes = 0
 	tw.rotateLocked()
 	return nil
 }

--- a/internal/worker/acp/trace.go
+++ b/internal/worker/acp/trace.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -16,11 +17,12 @@ import (
 // Each line: {"ts":"...","dir":"→|←","msg":{...}}
 // Rotation: when file exceeds maxSize, renamed to .1 and a new file is created.
 type TraceWriter struct {
-	mu      sync.Mutex
-	file    *os.File
-	enc     *json.Encoder
-	path    string
-	maxSize int64
+	mu           sync.Mutex
+	file         *os.File
+	enc          *json.Encoder
+	path         string
+	maxSize      int64
+	writtenBytes atomic.Int64
 }
 
 // NewTraceWriter creates a trace writer that appends to a JSONL file.
@@ -44,24 +46,33 @@ func NewTraceWriter(dir, sessionID string) (*TraceWriter, error) {
 }
 
 // Log writes a single trace entry. Safe to call on a nil TraceWriter (no-op).
-// Also checks file size and triggers rotation when the configured max is exceeded.
+// Uses an atomic byte counter to track size and triggers rotation without Stat() syscall.
 func (tw *TraceWriter) Log(direction string, msg any) {
 	if tw == nil {
 		return
 	}
-	entry := map[string]any{
+	// Marshal outside the lock to reduce contention.
+	line, err := json.Marshal(map[string]any{
 		"ts":  time.Now().Format(time.RFC3339Nano),
 		"dir": direction,
 		"msg": msg,
+	})
+	if err != nil {
+		return
 	}
+	line = append(line, '\n')
+
 	tw.mu.Lock()
-	if tw.enc == nil {
+	if tw.file == nil {
 		tw.mu.Unlock()
 		return
 	}
-	_ = tw.enc.Encode(entry)
-	// Check rotation after write (best-effort, ignore error).
-	if f, err := tw.file.Stat(); err == nil && f.Size() >= tw.maxSize {
+	_, _ = tw.file.Write(line)
+	tw.writtenBytes.Add(int64(len(line)))
+
+	// Check rotation using byte counter (avoids Stat() syscall on every Log).
+	if tw.writtenBytes.Load() >= tw.maxSize {
+		tw.writtenBytes.Store(0)
 		tw.rotateLocked()
 	}
 	tw.mu.Unlock()
@@ -71,6 +82,8 @@ func (tw *TraceWriter) Log(direction string, msg any) {
 // On failure, tw.file is set to nil so subsequent Log() calls degrade gracefully.
 func (tw *TraceWriter) rotateLocked() {
 	if err := tw.file.Close(); err != nil {
+		tw.file = nil
+		tw.enc = nil
 		return
 	}
 	rotated := tw.path + ".1"
@@ -97,6 +110,9 @@ func (tw *TraceWriter) Close() error {
 	}
 	tw.mu.Lock()
 	defer tw.mu.Unlock()
+	if tw.file == nil {
+		return nil
+	}
 	return tw.file.Close()
 }
 
@@ -111,13 +127,10 @@ func (tw *TraceWriter) Rotate(maxSize int64) error {
 	if tw.file == nil {
 		return nil
 	}
-	info, err := tw.file.Stat()
-	if err != nil {
-		return fmt.Errorf("acp trace: stat: %w", err)
-	}
-	if info.Size() < maxSize {
+	if tw.writtenBytes.Load() < maxSize {
 		return nil
 	}
+	tw.writtenBytes.Store(0)
 	tw.rotateLocked()
 	return nil
 }

--- a/internal/worker/acp/trace.go
+++ b/internal/worker/acp/trace.go
@@ -25,11 +25,11 @@ type TraceWriter struct {
 
 // NewTraceWriter creates a trace writer that appends to a JSONL file.
 func NewTraceWriter(dir, sessionID string) (*TraceWriter, error) {
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("acp trace: create dir: %w", err)
 	}
 	path := filepath.Join(dir, "acp-trace-"+sessionID+".jsonl")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("acp trace: open file: %w", err)
 	}
@@ -86,7 +86,7 @@ func (tw *TraceWriter) rotateLocked() {
 		tw.file = nil
 		return
 	}
-	f, err := os.OpenFile(tw.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(tw.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		tw.file = nil
 		return
@@ -109,18 +109,17 @@ func (tw *TraceWriter) Close() error {
 
 // Rotate forces a rotation. Safe to call on nil TraceWriter.
 // Rotation is also triggered automatically by Log() when the file exceeds maxSize.
-func (tw *TraceWriter) Rotate() error {
+func (tw *TraceWriter) Rotate() {
 	if tw == nil {
-		return nil
+		return
 	}
 	tw.mu.Lock()
 	defer tw.mu.Unlock()
 	if tw.file == nil {
-		return nil
+		return
 	}
 	tw.writtenBytes = 0
 	tw.rotateLocked()
-	return nil
 }
 
 // Path returns the current trace file path (for diagnostics).

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -75,6 +75,12 @@ func InitConfig(cfg config.ACPConfig) {
 	if args == nil {
 		args = []string{}
 	}
+	// Viper's BindEnv for []string produces a single-element slice from the
+	// raw env var value (e.g. ["--model gpt-4"] instead of ["--model", "gpt-4"]).
+	// Detect and split this case so env override works correctly.
+	if len(args) == 1 && strings.Contains(args[0], " ") {
+		args = strings.Fields(args[0])
+	}
 	configArgs.Store(args)
 	autoApproveDefault.Store(cfg.AutoApprove)
 	debugEnabled.Store(cfg.Debug)

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -808,7 +808,7 @@ func (w *Worker) fmtStartError(binary string, err error) error {
 	}
 	var pathErr *os.PathError
 	if errors.As(err, &pathErr) && os.IsPermission(pathErr.Err) {
-		return fmt.Errorf("acp: agent %q is not executable. Run: chmod +x $(which %s): %w", binary, binary, err)
+		return fmt.Errorf("acp: agent %q is not executable. Ensure the binary has execute permission, or set acp.command in config.yaml: %w", binary, err)
 	}
 	// Fallback: substring matching for wrapped errors that lose type info.
 	errMsg := err.Error()
@@ -819,7 +819,7 @@ func (w *Worker) fmtStartError(binary string, err error) error {
 		return fmt.Errorf("acp: agent %q not found in PATH. Install the agent or set acp.command in config.yaml: %w", binary, err)
 	}
 	if strings.Contains(errMsg, "permission denied") {
-		return fmt.Errorf("acp: agent %q is not executable. Run: chmod +x $(which %s): %w", binary, binary, err)
+		return fmt.Errorf("acp: agent %q is not executable. Ensure the binary has execute permission, or set acp.command in config.yaml: %w", binary, err)
 	}
 	return fmt.Errorf("acp: failed to start process %q: %w", binary, err)
 }

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -71,7 +71,11 @@ func InitConfig(cfg config.ACPConfig) {
 		return
 	}
 	commandParts.Store(parts)
-	configArgs.Store(cfg.Args)
+	args := cfg.Args
+	if args == nil {
+		args = []string{}
+	}
+	configArgs.Store(args)
 	autoApproveDefault.Store(cfg.AutoApprove)
 	debugEnabled.Store(cfg.Debug)
 	if err := security.RegisterCommand(parts[0]); err != nil {
@@ -628,6 +632,7 @@ func (w *Worker) resetSession(ctx context.Context) error {
 	w.acpSessionID = result.SessionID
 	w.mapper.Reset()
 	w.systemPromptInjected.Store(false)
+	w.jsonSchemaInjected.Store(false)
 	// Clear stale pending entries from the old session.
 	w.pendingPerm.Range(func(key, _ any) bool {
 		w.pendingPerm.Delete(key)

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -177,7 +177,8 @@ type Worker struct {
 	autoApprove atomic.Bool
 
 	// trace holds the optional protocol-level debug trace writer (nil when debug disabled).
-	trace *TraceWriter
+	// Protected by atomic.Pointer for concurrent access from Start/readLoop/Terminate.
+	trace atomic.Pointer[TraceWriter]
 
 	// testHooks for injection-based testing.
 	testClient *ACPClient
@@ -319,7 +320,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 			if err != nil {
 				w.Log.Warn("acp: failed to create trace file", "error", err)
 			} else {
-				w.trace = tw
+				w.trace.Store(tw)
 				w.Log.Info("acp: protocol trace enabled", "path", tw.Path())
 			}
 		}
@@ -333,11 +334,11 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	if session.WorkerSessionID != "" {
 		if session.ForkSession {
 			// Fork from existing session (AC-FR08-01).
-			forkResult, forkErr := client.ForkSession(hctx, session.WorkerSessionID)
+			forkResult, forkErr := client.ForkSession(ctx, session.WorkerSessionID)
 			if forkErr != nil {
 				w.Log.Warn("acp: session fork failed, falling back to new session",
 					"session_id", session.SessionID, "error", forkErr)
-				newSess, newErr := client.NewSession(hctx, session.ProjectDir, mcpServers)
+				newSess, newErr := client.NewSession(ctx, session.ProjectDir, mcpServers)
 				if newErr != nil {
 					_ = w.Proc.Kill()
 					return fmt.Errorf("acp: new session: %w", newErr)
@@ -455,7 +456,9 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	pctx, pcancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer pcancel()
 
-	w.trace.Log("→", map[string]string{"method": "session/prompt", "sessionId": w.GetWorkerSessionID(), "content": content})
+	if tw := w.trace.Load(); tw != nil {
+		tw.Log("→", map[string]string{"method": "session/prompt", "sessionId": w.GetWorkerSessionID(), "content": content})
+	}
 	result, promptErr := w.client.Prompt(pctx, w.GetWorkerSessionID(), content)
 	if promptErr != nil {
 		// Always emit error sequence to client.
@@ -490,9 +493,9 @@ func (w *Worker) Resume(ctx context.Context, session worker.SessionInfo) error {
 
 func (w *Worker) Terminate(ctx context.Context) error {
 	// Close trace writer if active.
-	if w.trace != nil {
-		_ = w.trace.Close()
-		w.trace = nil
+	tw := w.trace.Swap(nil)
+	if tw != nil {
+		_ = tw.Close()
 	}
 
 	if w.cancel != nil {
@@ -826,7 +829,9 @@ func (w *Worker) readLoop(ctx context.Context) {
 			if !ok {
 				return
 			}
-			w.trace.Log("←", notif)
+			if tw := w.trace.Load(); tw != nil {
+				tw.Log("←", notif)
+			}
 			w.SetLastIO(time.Now())
 			envelopes := w.mapper.MapNotification(notif)
 			for _, env := range envelopes {
@@ -836,7 +841,9 @@ func (w *Worker) readLoop(ctx context.Context) {
 			if !ok {
 				return
 			}
-			w.trace.Log("←", req)
+			if tw := w.trace.Load(); tw != nil {
+				tw.Log("←", req)
+			}
 			w.handleServerRequest(ctx, req, conn)
 		}
 	}

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -36,12 +37,19 @@ var (
 // commandParts stores the space-split command (binary + optional prefix args).
 var commandParts atomic.Value // []string
 
+// configArgs stores extra args from acp.args config, appended after commandParts.
+var configArgs atomic.Value // []string
+
+// debugEnabled stores the acp.debug config flag.
+var debugEnabled atomic.Bool
+
 // autoApproveDefault is the global default for auto-approve set from config.
 // Per-session overrides live on Worker.autoApprove.
 var autoApproveDefault atomic.Bool
 
 func init() {
 	commandParts.Store([]string{"hermes", "acp"})
+	configArgs.Store([]string{})
 	autoApproveDefault.Store(false)
 
 	worker.Register(worker.TypeACP, func() (worker.Worker, error) {
@@ -63,7 +71,9 @@ func InitConfig(cfg config.ACPConfig) {
 		return
 	}
 	commandParts.Store(parts)
+	configArgs.Store(cfg.Args)
 	autoApproveDefault.Store(cfg.AutoApprove)
+	debugEnabled.Store(cfg.Debug)
 	if err := security.RegisterCommand(parts[0]); err != nil {
 		slog.Default().Error("acp: failed to register command", "command", parts[0], "err", err)
 	}
@@ -150,12 +160,20 @@ type Worker struct {
 	systemPrompt         string
 	systemPromptInjected atomic.Bool
 
+	// jsonSchema holds the JSON Schema for structured output (from SessionInfo.JSONSchema).
+	// Injected as a prefix on the first user prompt, similar to systemPrompt.
+	jsonSchema         string
+	jsonSchemaInjected atomic.Bool
+
 	// mcpServers caches the parsed MCP servers from Start() so Clear() can reuse them.
 	mcpServers []any
 
 	// autoApprove controls per-session permission auto-approval.
 	// Initialized from global default, overridable via set_permission_mode.
 	autoApprove atomic.Bool
+
+	// trace holds the optional protocol-level debug trace writer (nil when debug disabled).
+	trace *TraceWriter
 
 	// testHooks for injection-based testing.
 	testClient *ACPClient
@@ -205,6 +223,8 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	}
 	w.systemPrompt = sp
 	w.systemPromptInjected.Store(false)
+	w.jsonSchema = session.JSONSchema
+	w.jsonSchemaInjected.Store(false)
 
 	// Phase 2: I/O-heavy operations outside the lock.
 
@@ -216,8 +236,11 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 		parts, _ = commandParts.Load().([]string)
 	}
 	binary := parts[0]
-	args := make([]string, len(parts)-1, len(parts)-1+len(session.Args))
-	copy(args, parts[1:])
+	// Merge: command prefix args + config-level args + session-level args.
+	ca, _ := configArgs.Load().([]string)
+	args := make([]string, 0, len(parts)-1+len(ca)+len(session.Args))
+	args = append(args, parts[1:]...)
+	args = append(args, ca...)
 	args = append(args, session.Args...)
 
 	// Build environment using shared security layer.
@@ -279,28 +302,72 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 		"agent", initResult.AgentInfo.Name,
 		"version", initResult.AgentInfo.Version,
 		"protocol", initResult.ProtocolVersion)
+	if initResult.ProtocolVersion > 1 {
+		w.Log.Warn("acp: agent uses newer protocol version, using best-effort compatibility",
+			"protocol", initResult.ProtocolVersion, "known", 1)
+	}
 
-	// Create or load session.
+	// Initialize protocol trace if debug mode is enabled.
+	if debugEnabled.Load() {
+		home, _ := os.UserHomeDir()
+		if home != "" {
+			tw, err := NewTraceWriter(filepath.Join(home, ".hotplex", "logs"), session.SessionID)
+			if err != nil {
+				w.Log.Warn("acp: failed to create trace file", "error", err)
+			} else {
+				w.trace = tw
+				w.Log.Info("acp: protocol trace enabled", "path", tw.Path())
+			}
+		}
+	}
+
+	// Create, load, or fork session.
 	mcpServers := parseMCPServers(session.MCPConfig)
 	w.mcpServers = mcpServers // cache for Clear()
 	var acpSessID string
 	var historyLost bool
-	if session.WorkerSessionID != "" && w.supportsCapability("loadSession") {
-		// Resume existing session (only if agent supports load).
-		sessResult, loadErr := client.LoadSession(hctx, session.WorkerSessionID, session.ProjectDir, mcpServers)
-		if loadErr != nil {
-			w.Log.Error("acp: session load failed, falling back to new session (history lost)",
-				"session_id", session.SessionID, "acp_session_id", session.WorkerSessionID,
-				"error", loadErr,
-				"hint", "check agent session storage and persistence")
-			newSess, newErr := client.NewSession(hctx, session.ProjectDir, mcpServers)
-			if newErr != nil {
-				_ = w.Proc.Kill()
-				return fmt.Errorf("acp: new session: %w", newErr)
+	if session.WorkerSessionID != "" {
+		if session.ForkSession {
+			// Fork from existing session (AC-FR08-01).
+			forkResult, forkErr := client.ForkSession(hctx, session.WorkerSessionID)
+			if forkErr != nil {
+				w.Log.Warn("acp: session fork failed, falling back to new session",
+					"session_id", session.SessionID, "error", forkErr)
+				newSess, newErr := client.NewSession(hctx, session.ProjectDir, mcpServers)
+				if newErr != nil {
+					_ = w.Proc.Kill()
+					return fmt.Errorf("acp: new session: %w", newErr)
+				}
+				acpSessID = newSess.SessionID
+				historyLost = true
+			} else {
+				acpSessID = forkResult.SessionID
 			}
-			acpSessID = newSess.SessionID
-			historyLost = true
+		} else if w.supportsCapability("loadSession") {
+			// Resume existing session (only if agent supports load).
+			sessResult, loadErr := client.LoadSession(hctx, session.WorkerSessionID, session.ProjectDir, mcpServers)
+			if loadErr != nil {
+				w.Log.Error("acp: session load failed, falling back to new session (history lost)",
+					"session_id", session.SessionID, "acp_session_id", session.WorkerSessionID,
+					"error", loadErr,
+					"hint", "check agent session storage and persistence")
+				newSess, newErr := client.NewSession(hctx, session.ProjectDir, mcpServers)
+				if newErr != nil {
+					_ = w.Proc.Kill()
+					return fmt.Errorf("acp: new session: %w", newErr)
+				}
+				acpSessID = newSess.SessionID
+				historyLost = true
+			} else {
+				acpSessID = sessResult.SessionID
+			}
 		} else {
+			// Agent does not support loadSession; create fresh.
+			sessResult, sessErr := client.NewSession(hctx, session.ProjectDir, mcpServers)
+			if sessErr != nil {
+				_ = w.Proc.Kill()
+				return fmt.Errorf("acp: new session: %w", sessErr)
+			}
 			acpSessID = sessResult.SessionID
 		}
 	} else {
@@ -369,6 +436,10 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	if w.systemPrompt != "" && w.systemPromptInjected.CompareAndSwap(false, true) {
 		content = fmt.Sprintf("[SYSTEM INSTRUCTIONS]\n%s\n[/SYSTEM INSTRUCTIONS]\n\n%s", w.systemPrompt, content)
 	}
+	// Inject JSON Schema on first user input for structured output support.
+	if w.jsonSchema != "" && w.jsonSchemaInjected.CompareAndSwap(false, true) {
+		content = fmt.Sprintf("[JSON SCHEMA]\n%s\n[/JSON SCHEMA]\n\n%s", w.jsonSchema, content)
+	}
 
 	// Cache input for crash recovery (InputRecoverer).
 	conn.lastInput.Store(&content)
@@ -380,6 +451,7 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	pctx, pcancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer pcancel()
 
+	w.trace.Log("→", map[string]string{"method": "session/prompt", "sessionId": w.GetWorkerSessionID(), "content": content})
 	result, promptErr := w.client.Prompt(pctx, w.GetWorkerSessionID(), content)
 	if promptErr != nil {
 		// Always emit error sequence to client.
@@ -413,6 +485,12 @@ func (w *Worker) Resume(ctx context.Context, session worker.SessionInfo) error {
 // ─── Terminate ───────────────────────────────────────────────────────────────
 
 func (w *Worker) Terminate(ctx context.Context) error {
+	// Close trace writer if active.
+	if w.trace != nil {
+		_ = w.trace.Close()
+		w.trace = nil
+	}
+
 	if w.cancel != nil {
 		w.cancel()
 	}
@@ -743,6 +821,7 @@ func (w *Worker) readLoop(ctx context.Context) {
 			if !ok {
 				return
 			}
+			w.trace.Log("←", notif)
 			w.SetLastIO(time.Now())
 			envelopes := w.mapper.MapNotification(notif)
 			for _, env := range envelopes {
@@ -752,6 +831,7 @@ func (w *Worker) readLoop(ctx context.Context) {
 			if !ok {
 				return
 			}
+			w.trace.Log("←", req)
 			w.handleServerRequest(ctx, req, conn)
 		}
 	}
@@ -780,6 +860,8 @@ func (w *Worker) handleServerRequest(ctx context.Context, req *JSONRPCRequest, c
 	default:
 		// Non-permission server-initiated request (e.g. question, elicitation).
 		// Forward as Raw event so the client can display and respond.
+		w.Log.Debug("acp: forwarding unknown server request as raw event",
+			"method", req.Method, "id", string(req.ID))
 		w.pendingRequests.Store(string(req.ID), req)
 		var params any
 		if err := json.Unmarshal(req.Params, &params); err != nil {

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -326,7 +326,10 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 		}
 	}
 
-	// Create, load, or fork session.
+	// Create, load, or fork session (dedicated timeout, independent of handshake).
+	sctx, scancel := context.WithTimeout(ctx, 30*time.Second)
+	defer scancel()
+
 	mcpServers := parseMCPServers(session.MCPConfig)
 	w.mcpServers = mcpServers // cache for Clear()
 	var acpSessID string
@@ -334,11 +337,11 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	if session.WorkerSessionID != "" {
 		if session.ForkSession {
 			// Fork from existing session (AC-FR08-01).
-			forkResult, forkErr := client.ForkSession(ctx, session.WorkerSessionID)
+			forkResult, forkErr := client.ForkSession(sctx, session.WorkerSessionID)
 			if forkErr != nil {
 				w.Log.Warn("acp: session fork failed, falling back to new session",
 					"session_id", session.SessionID, "error", forkErr)
-				newSess, newErr := client.NewSession(ctx, session.ProjectDir, mcpServers)
+				newSess, newErr := client.NewSession(sctx, session.ProjectDir, mcpServers)
 				if newErr != nil {
 					_ = w.Proc.Kill()
 					return fmt.Errorf("acp: new session: %w", newErr)
@@ -350,13 +353,13 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 			}
 		} else if w.supportsCapability("loadSession") {
 			// Resume existing session (only if agent supports load).
-			sessResult, loadErr := client.LoadSession(hctx, session.WorkerSessionID, session.ProjectDir, mcpServers)
+			sessResult, loadErr := client.LoadSession(sctx, session.WorkerSessionID, session.ProjectDir, mcpServers)
 			if loadErr != nil {
 				w.Log.Error("acp: session load failed, falling back to new session (history lost)",
 					"session_id", session.SessionID, "acp_session_id", session.WorkerSessionID,
 					"error", loadErr,
 					"hint", "check agent session storage and persistence")
-				newSess, newErr := client.NewSession(hctx, session.ProjectDir, mcpServers)
+				newSess, newErr := client.NewSession(sctx, session.ProjectDir, mcpServers)
 				if newErr != nil {
 					_ = w.Proc.Kill()
 					return fmt.Errorf("acp: new session: %w", newErr)
@@ -368,7 +371,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 			}
 		} else {
 			// Agent does not support loadSession; create fresh.
-			sessResult, sessErr := client.NewSession(hctx, session.ProjectDir, mcpServers)
+			sessResult, sessErr := client.NewSession(sctx, session.ProjectDir, mcpServers)
 			if sessErr != nil {
 				_ = w.Proc.Kill()
 				return fmt.Errorf("acp: new session: %w", sessErr)
@@ -376,7 +379,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 			acpSessID = sessResult.SessionID
 		}
 	} else {
-		sessResult, sessErr := client.NewSession(hctx, session.ProjectDir, mcpServers)
+		sessResult, sessErr := client.NewSession(sctx, session.ProjectDir, mcpServers)
 		if sessErr != nil {
 			_ = w.Proc.Kill()
 			return fmt.Errorf("acp: new session: %w", sessErr)
@@ -457,7 +460,7 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	defer pcancel()
 
 	if tw := w.trace.Load(); tw != nil {
-		tw.Log("→", map[string]string{"method": "session/prompt", "sessionId": w.GetWorkerSessionID(), "content": content})
+		tw.Log("→", map[string]any{"method": "session/prompt", "sessionId": w.GetWorkerSessionID(), "contentLen": len(content)})
 	}
 	result, promptErr := w.client.Prompt(pctx, w.GetWorkerSessionID(), content)
 	if promptErr != nil {
@@ -636,6 +639,7 @@ func (w *Worker) resetSession(ctx context.Context) error {
 	w.mapper.Reset()
 	w.systemPromptInjected.Store(false)
 	w.jsonSchemaInjected.Store(false)
+	// Note: systemPrompt and jsonSchema values are intentionally preserved across reset (set at Start time from session config).
 	// Clear stale pending entries from the old session.
 	w.pendingPerm.Range(func(key, _ any) bool {
 		w.pendingPerm.Delete(key)

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -314,15 +314,12 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 
 	// Initialize protocol trace if debug mode is enabled.
 	if debugEnabled.Load() {
-		home, _ := os.UserHomeDir()
-		if home != "" {
-			tw, err := NewTraceWriter(filepath.Join(home, ".hotplex", "logs"), session.SessionID)
-			if err != nil {
-				w.Log.Warn("acp: failed to create trace file", "error", err)
-			} else {
-				w.trace.Store(tw)
-				w.Log.Info("acp: protocol trace enabled", "path", tw.Path())
-			}
+		tw, err := NewTraceWriter(filepath.Join(config.HotplexHome(), "logs"), session.SessionID)
+		if err != nil {
+			w.Log.Warn("acp: failed to create trace file", "error", err)
+		} else {
+			w.trace.Store(tw)
+			w.Log.Info("acp: protocol trace enabled", "path", tw.Path())
 		}
 	}
 
@@ -332,6 +329,16 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 
 	mcpServers := parseMCPServers(session.MCPConfig)
 	w.mcpServers = mcpServers // cache for Clear()
+	// forceNewSession creates a fresh session, killing the process on failure.
+	forceNewSession := func() (string, error) {
+		sess, err := client.NewSession(sctx, session.ProjectDir, mcpServers)
+		if err != nil {
+			_ = w.Proc.Kill()
+			return "", fmt.Errorf("acp: new session: %w", err)
+		}
+		return sess.SessionID, nil
+	}
+
 	var acpSessID string
 	var historyLost bool
 	if session.WorkerSessionID != "" {
@@ -341,12 +348,11 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 			if forkErr != nil {
 				w.Log.Warn("acp: session fork failed, falling back to new session",
 					"session_id", session.SessionID, "error", forkErr)
-				newSess, newErr := client.NewSession(sctx, session.ProjectDir, mcpServers)
-				if newErr != nil {
-					_ = w.Proc.Kill()
-					return fmt.Errorf("acp: new session: %w", newErr)
+				id, err := forceNewSession()
+				if err != nil {
+					return err
 				}
-				acpSessID = newSess.SessionID
+				acpSessID = id
 				historyLost = true
 			} else {
 				acpSessID = forkResult.SessionID
@@ -359,32 +365,29 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 					"session_id", session.SessionID, "acp_session_id", session.WorkerSessionID,
 					"error", loadErr,
 					"hint", "check agent session storage and persistence")
-				newSess, newErr := client.NewSession(sctx, session.ProjectDir, mcpServers)
-				if newErr != nil {
-					_ = w.Proc.Kill()
-					return fmt.Errorf("acp: new session: %w", newErr)
+				id, err := forceNewSession()
+				if err != nil {
+					return err
 				}
-				acpSessID = newSess.SessionID
+				acpSessID = id
 				historyLost = true
 			} else {
 				acpSessID = sessResult.SessionID
 			}
 		} else {
 			// Agent does not support loadSession; create fresh.
-			sessResult, sessErr := client.NewSession(sctx, session.ProjectDir, mcpServers)
-			if sessErr != nil {
-				_ = w.Proc.Kill()
-				return fmt.Errorf("acp: new session: %w", sessErr)
+			id, err := forceNewSession()
+			if err != nil {
+				return err
 			}
-			acpSessID = sessResult.SessionID
+			acpSessID = id
 		}
 	} else {
-		sessResult, sessErr := client.NewSession(sctx, session.ProjectDir, mcpServers)
-		if sessErr != nil {
-			_ = w.Proc.Kill()
-			return fmt.Errorf("acp: new session: %w", sessErr)
+		id, err := forceNewSession()
+		if err != nil {
+			return err
 		}
-		acpSessID = sessResult.SessionID
+		acpSessID = id
 	}
 	w.SetWorkerSessionID(acpSessID)
 

--- a/internal/worker/acp/worker_phase2_test.go
+++ b/internal/worker/acp/worker_phase2_test.go
@@ -267,7 +267,7 @@ func TestFmtStartError_PermissionDenied(t *testing.T) {
 	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
 	err := w.fmtStartError("hermes", errors.New("fork/exec: permission denied"))
 	require.Contains(t, err.Error(), "not executable")
-	require.Contains(t, err.Error(), "chmod +x")
+	require.Contains(t, err.Error(), "execute permission")
 }
 
 func TestFmtStartError_Other(t *testing.T) {
@@ -687,5 +687,5 @@ func TestFmtStartError_PathErrorPermission(t *testing.T) {
 	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
 	err := w.fmtStartError("myagent", &os.PathError{Op: "fork/exec", Path: "/usr/local/bin/myagent", Err: os.ErrPermission})
 	require.Contains(t, err.Error(), "not executable")
-	require.Contains(t, err.Error(), "chmod +x")
+	require.Contains(t, err.Error(), "execute permission")
 }

--- a/internal/worker/acp/worker_phase3_test.go
+++ b/internal/worker/acp/worker_phase3_test.go
@@ -20,6 +20,9 @@ import (
 // ─── EX-01: InitConfig Args/Debug ───────────────────────────────────────────
 
 func TestInitConfig_ArgsStored(t *testing.T) {
+	t.Cleanup(func() {
+		InitConfig(config.ACPConfig{Command: "hermes acp"})
+	})
 
 	InitConfig(config.ACPConfig{
 		Command:     "test-agent serve",
@@ -35,20 +38,17 @@ func TestInitConfig_ArgsStored(t *testing.T) {
 	require.Equal(t, []string{"--model", "gpt-4"}, ca)
 
 	require.True(t, debugEnabled.Load())
-
-	// Restore defaults.
-	InitConfig(config.ACPConfig{Command: "hermes acp"})
 }
 
 func TestInitConfig_DefaultCommand(t *testing.T) {
+	t.Cleanup(func() {
+		InitConfig(config.ACPConfig{Command: "hermes acp"})
+	})
 
 	InitConfig(config.ACPConfig{Command: ""})
 
 	parts, _ := commandParts.Load().([]string)
 	require.Equal(t, []string{"hermes", "acp"}, parts)
-
-	// Restore defaults.
-	InitConfig(config.ACPConfig{Command: "hermes acp"})
 }
 
 // ─── EX-02: Protocol Version Warning ────────────────────────────────────────
@@ -119,16 +119,28 @@ func TestTraceWriter_Rotation(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = tw.Close() })
 
-	// Write enough data to exceed 100 bytes.
+	// Use a small threshold to actually trigger rotation.
+	tw.maxSize = 500
+
+	// Write enough data to exceed the threshold.
 	for i := 0; i < 50; i++ {
 		tw.Log("→", map[string]string{"method": "session/prompt", "content": strings.Repeat("x", 100)})
 	}
 	require.NoError(t, tw.Close())
 
-	// Verify file exists and has content.
+	// Verify rotation produced a .1 backup file.
+	rotated := tw.Path() + ".1"
+	_, err = os.Stat(rotated)
+	require.NoError(t, err, "rotated backup file should exist")
+
+	rotatedData, err := os.ReadFile(rotated)
+	require.NoError(t, err)
+	require.True(t, len(rotatedData) > 0, "rotated file should have content")
+
+	// Current file should also have content (new entries after rotation).
 	data, err := os.ReadFile(tw.Path())
 	require.NoError(t, err)
-	require.True(t, len(data) > 100, "trace file should have data")
+	require.True(t, len(data) > 0, "current trace file should have content")
 }
 
 func TestTraceWriter_DebugDisabledByDefault(t *testing.T) {
@@ -137,7 +149,7 @@ func TestTraceWriter_DebugDisabledByDefault(t *testing.T) {
 	require.False(t, debugEnabled.Load())
 }
 
-// ─── FR-08: ForkSession ───────────────────────────────
+// ─── FR-08: ForkSession ───────────────────────────────────────
 
 func TestClient_ForkSession_Success(t *testing.T) {
 	t.Parallel()
@@ -292,6 +304,9 @@ func TestJSONSchema_SchemaOnly_NoSystemPrompt(t *testing.T) {
 // ─── EX-01: Config Args Merging ─────────────────────────────────────────────
 
 func TestInitConfig_ArgsMergeOrder(t *testing.T) {
+	t.Cleanup(func() {
+		InitConfig(config.ACPConfig{Command: "hermes acp"})
+	})
 
 	// Set config-level args.
 	InitConfig(config.ACPConfig{
@@ -305,9 +320,6 @@ func TestInitConfig_ArgsMergeOrder(t *testing.T) {
 	// Verify commandParts are correct.
 	parts, _ := commandParts.Load().([]string)
 	require.Equal(t, []string{"agent", "run"}, parts)
-
-	// Restore defaults.
-	InitConfig(config.ACPConfig{Command: "hermes acp"})
 }
 
 // ─── U-04: TraceWriter Concurrent Writes ────────────────────────────────────

--- a/internal/worker/acp/worker_phase3_test.go
+++ b/internal/worker/acp/worker_phase3_test.go
@@ -21,7 +21,6 @@ import (
 // ─── EX-01: InitConfig Args/Debug ───────────────────────────────────────────
 
 func TestInitConfig_ArgsStored(t *testing.T) {
-	t.Parallel()
 
 	InitConfig(config.ACPConfig{
 		Command:     "test-agent serve",
@@ -43,7 +42,6 @@ func TestInitConfig_ArgsStored(t *testing.T) {
 }
 
 func TestInitConfig_DefaultCommand(t *testing.T) {
-	t.Parallel()
 
 	InitConfig(config.ACPConfig{Command: ""})
 
@@ -110,7 +108,7 @@ func TestTraceWriter_NilSafe(t *testing.T) {
 	// All operations on nil TraceWriter should be no-ops.
 	tw.Log("→", "test")
 	require.NoError(t, tw.Close())
-	require.NoError(t, tw.Rotate(1024))
+	require.NoError(t, tw.Rotate())
 	require.Equal(t, "", tw.Path())
 }
 
@@ -295,7 +293,6 @@ func TestJSONSchema_SchemaOnly_NoSystemPrompt(t *testing.T) {
 // ─── EX-01: Config Args Merging ─────────────────────────────────────────────
 
 func TestInitConfig_ArgsMergeOrder(t *testing.T) {
-	t.Parallel()
 
 	// Set config-level args.
 	InitConfig(config.ACPConfig{

--- a/internal/worker/acp/worker_phase3_test.go
+++ b/internal/worker/acp/worker_phase3_test.go
@@ -322,6 +322,29 @@ func TestInitConfig_ArgsMergeOrder(t *testing.T) {
 	require.Equal(t, []string{"agent", "run"}, parts)
 }
 
+func TestInitConfig_ArgsEnvSplit(t *testing.T) {
+	t.Cleanup(func() {
+		InitConfig(config.ACPConfig{Command: "hermes acp"})
+	})
+
+	// Simulate Viper BindEnv behavior: env var produces single-element slice.
+	InitConfig(config.ACPConfig{
+		Command: "agent run",
+		Args:    []string{"--model gpt-4"}, // single element with space (env override)
+	})
+
+	ca, _ := configArgs.Load().([]string)
+	require.Equal(t, []string{"--model", "gpt-4"}, ca, "single element with spaces should be split")
+
+	// Already-split args pass through unchanged.
+	InitConfig(config.ACPConfig{
+		Command: "agent run",
+		Args:    []string{"--model", "gpt-4"},
+	})
+	ca, _ = configArgs.Load().([]string)
+	require.Equal(t, []string{"--model", "gpt-4"}, ca)
+}
+
 // ─── U-04: TraceWriter Concurrent Writes ────────────────────────────────────
 
 func TestTraceWriter_ConcurrentWrites(t *testing.T) {

--- a/internal/worker/acp/worker_phase3_test.go
+++ b/internal/worker/acp/worker_phase3_test.go
@@ -1,0 +1,367 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/config"
+	"github.com/hrygo/hotplex/internal/worker/base"
+)
+
+// ─── EX-01: InitConfig Args/Debug ───────────────────────────────────────────
+
+func TestInitConfig_ArgsStored(t *testing.T) {
+	t.Parallel()
+
+	InitConfig(config.ACPConfig{
+		Command:     "test-agent serve",
+		Args:        []string{"--model", "gpt-4"},
+		AutoApprove: false,
+		Debug:       true,
+	})
+
+	parts, _ := commandParts.Load().([]string)
+	require.Equal(t, []string{"test-agent", "serve"}, parts)
+
+	ca, _ := configArgs.Load().([]string)
+	require.Equal(t, []string{"--model", "gpt-4"}, ca)
+
+	require.True(t, debugEnabled.Load())
+
+	// Restore defaults.
+	InitConfig(config.ACPConfig{Command: "hermes acp"})
+}
+
+func TestInitConfig_DefaultCommand(t *testing.T) {
+	t.Parallel()
+
+	InitConfig(config.ACPConfig{Command: ""})
+
+	parts, _ := commandParts.Load().([]string)
+	require.Equal(t, []string{"hermes", "acp"}, parts)
+
+	// Restore defaults.
+	InitConfig(config.ACPConfig{Command: "hermes acp"})
+}
+
+// ─── EX-02: Protocol Version Warning ────────────────────────────────────────
+
+func TestProtocolVersion_KnownVersion_NoWarn(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.initResult = &InitializeResult{ProtocolVersion: 1}
+	// Version 1 is known — no special behavior needed beyond logging.
+	require.Equal(t, 1, w.initResult.ProtocolVersion)
+}
+
+func TestProtocolVersion_FutureVersion_Stored(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.initResult = &InitializeResult{ProtocolVersion: 5}
+	// Future version should still be stored for capability checks.
+	require.Equal(t, 5, w.initResult.ProtocolVersion)
+}
+
+// ─── U-04: TraceWriter ──────────────────────────────────────────────────────
+
+func TestTraceWriter_CreateWriteRead(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	tw, err := NewTraceWriter(dir, "test-session-001")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tw.Close() })
+
+	require.Contains(t, tw.Path(), "acp-trace-test-session-001.jsonl")
+
+	// Write a trace entry.
+	tw.Log("→", map[string]string{"method": "session/prompt", "content": "hello"})
+
+	// Close to flush.
+	require.NoError(t, tw.Close())
+
+	// Read back the file.
+	data, err := os.ReadFile(tw.Path())
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"dir":"→"`)
+	require.Contains(t, string(data), `"method":"session/prompt"`)
+
+	// Verify it's valid JSONL.
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	require.Len(t, lines, 1)
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &entry))
+	require.Equal(t, "→", entry["dir"])
+}
+
+func TestTraceWriter_NilSafe(t *testing.T) {
+	t.Parallel()
+	var tw *TraceWriter
+	// All operations on nil TraceWriter should be no-ops.
+	tw.Log("→", "test")
+	require.NoError(t, tw.Close())
+	require.NoError(t, tw.Rotate(1024))
+	require.Equal(t, "", tw.Path())
+}
+
+func TestTraceWriter_Rotation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	tw, err := NewTraceWriter(dir, "test-rotate")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tw.Close() })
+
+	// Write enough data to exceed 100 bytes.
+	for i := 0; i < 50; i++ {
+		tw.Log("→", map[string]string{"method": "session/prompt", "content": strings.Repeat("x", 100)})
+	}
+	require.NoError(t, tw.Close())
+
+	// Verify file exists and has content.
+	data, err := os.ReadFile(tw.Path())
+	require.NoError(t, err)
+	require.True(t, len(data) > 100, "trace file should have data")
+}
+
+func TestTraceWriter_DebugDisabledByDefault(t *testing.T) {
+	t.Parallel()
+	// debugEnabled should be false by default.
+	require.False(t, debugEnabled.Load())
+}
+
+// ─── FR-08: ForkSession ───────────────────────────────
+
+func TestClient_ForkSession_Success(t *testing.T) {
+	t.Parallel()
+
+	agentStdinR, agentStdinW := io.Pipe()
+	agentStdoutR, agentStdoutW := io.Pipe()
+	defer agentStdinW.Close()
+	defer agentStdoutW.Close()
+
+	client := NewACPClient(agentStdinW, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	// Agent responds to fork with a new session ID.
+	go func() {
+		scanner := NewScanner(agentStdinR)
+		if scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			_ = json.Unmarshal(scanner.Bytes(), &req)
+			_ = WriteMessage(agentStdoutW, &JSONRPCResponse{
+				JSONRPC: "2.0", ID: req.ID,
+				Result: mustMarshal(SessionResult{SessionID: "forked_sess_42"}),
+			})
+		}
+	}()
+
+	result, err := client.ForkSession(ctx, "old_session")
+	require.NoError(t, err)
+	require.Equal(t, "forked_sess_42", result.SessionID)
+}
+
+func TestClient_ForkSession_Error(t *testing.T) {
+	t.Parallel()
+
+	agentStdinR, agentStdinW := io.Pipe()
+	agentStdoutR, agentStdoutW := io.Pipe()
+	defer agentStdinW.Close()
+	defer agentStdoutW.Close()
+
+	client := NewACPClient(agentStdinW, agentStdoutR, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.StartReadLoop(ctx)
+
+	// Agent responds with an error for fork.
+	go func() {
+		scanner := NewScanner(agentStdinR)
+		if scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			_ = json.Unmarshal(scanner.Bytes(), &req)
+			_ = WriteMessage(agentStdoutW, &JSONRPCResponse{
+				JSONRPC: "2.0", ID: req.ID,
+				Error: &JSONRPCError{Code: -32600, Message: "fork not supported"},
+			})
+		}
+	}()
+
+	_, err := client.ForkSession(ctx, "old_session")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fork not supported")
+}
+
+// ─── FR-09: JSON Schema Injection ─────────────────────────────────
+
+func TestJSONSchema_InjectedOnFirstPrompt(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.jsonSchema = `{"type":"object","properties":{"name":{"type":"string"}}}`
+
+	// First call should inject.
+	require.True(t, w.jsonSchemaInjected.CompareAndSwap(false, true))
+	content := "Hello"
+	content = fmt.Sprintf("[JSON SCHEMA]\n%s\n[/JSON SCHEMA]\n\n%s", w.jsonSchema, content)
+	require.Contains(t, content, "[JSON SCHEMA]")
+	require.Contains(t, content, `"type":"object"`)
+	require.True(t, strings.HasPrefix(content, "[JSON SCHEMA]"))
+	require.Contains(t, content, "Hello")
+
+	// Second CompareAndSwap should fail (already injected).
+	require.False(t, w.jsonSchemaInjected.CompareAndSwap(false, true))
+}
+
+func TestJSONSchema_EmptySchema_NoInjection(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	// jsonSchema is empty by default.
+	require.Empty(t, w.jsonSchema)
+	require.False(t, w.jsonSchemaInjected.Load())
+
+	// CompareAndSwap should succeed (false->true), but the outer if-check on
+	// jsonSchema != "" prevents injection.
+	require.True(t, w.jsonSchemaInjected.CompareAndSwap(false, true))
+}
+
+func TestJSONSchema_BothSystemPromptAndSchema(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.systemPrompt = "You are a helpful assistant."
+	w.jsonSchema = `{"type":"object","properties":{"result":{"type":"string"}}}`
+
+	// Both should be injectable independently.
+	require.True(t, w.systemPromptInjected.CompareAndSwap(false, true))
+	require.True(t, w.jsonSchemaInjected.CompareAndSwap(false, true))
+
+	// Simulate the Input() injection logic.
+	content := "Hello"
+	if w.systemPrompt != "" {
+		content = fmt.Sprintf("[SYSTEM INSTRUCTIONS]\n%s\n[/SYSTEM INSTRUCTIONS]\n\n%s", w.systemPrompt, content)
+	}
+	if w.jsonSchema != "" {
+		content = fmt.Sprintf("[JSON SCHEMA]\n%s\n[/JSON SCHEMA]\n\n%s", w.jsonSchema, content)
+	}
+
+	require.Contains(t, content, "[SYSTEM INSTRUCTIONS]")
+	require.Contains(t, content, "[JSON SCHEMA]")
+	require.Contains(t, content, "You are a helpful assistant.")
+	require.Contains(t, content, `"type":"object"`)
+	// JSON Schema should be injected AFTER system prompt (prepended).
+	require.True(t, strings.Contains(content, "[JSON SCHEMA]"))
+	require.True(t, strings.Contains(content, "Hello"))
+}
+
+func TestJSONSchema_SchemaOnly_NoSystemPrompt(t *testing.T) {
+	t.Parallel()
+	w := &Worker{BaseWorker: base.NewBaseWorker(nil, nil)}
+	w.jsonSchema = `{"type":"array","items":{"type":"number"}}`
+
+	// Only JSON Schema, no system prompt.
+	content := "List primes"
+	if w.systemPrompt != "" {
+		content = fmt.Sprintf("[SYSTEM INSTRUCTIONS]\n%s\n[/SYSTEM INSTRUCTIONS]\n\n%s", w.systemPrompt, content)
+	}
+	if w.jsonSchema != "" {
+		content = fmt.Sprintf("[JSON SCHEMA]\n%s\n[/JSON SCHEMA]\n\n%s", w.jsonSchema, content)
+	}
+
+	// System prompt should NOT be injected.
+	require.NotContains(t, content, "[SYSTEM INSTRUCTIONS]")
+	// JSON Schema should be injected.
+	require.Contains(t, content, "[JSON SCHEMA]")
+	require.Contains(t, content, `"type":"array"`)
+	require.Contains(t, content, "List primes")
+}
+
+// ─── EX-01: Config Args Merging ─────────────────────────────────────────────
+
+func TestInitConfig_ArgsMergeOrder(t *testing.T) {
+	t.Parallel()
+
+	// Set config-level args.
+	InitConfig(config.ACPConfig{
+		Command: "agent run",
+		Args:    []string{"--verbose", "--model=claude"},
+	})
+
+	ca, _ := configArgs.Load().([]string)
+	require.Equal(t, []string{"--verbose", "--model=claude"}, ca)
+
+	// Verify commandParts are correct.
+	parts, _ := commandParts.Load().([]string)
+	require.Equal(t, []string{"agent", "run"}, parts)
+
+	// Restore defaults.
+	InitConfig(config.ACPConfig{Command: "hermes acp"})
+}
+
+// ─── U-04: TraceWriter Concurrent Writes ────────────────────────────────────
+
+func TestTraceWriter_ConcurrentWrites(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	tw, err := NewTraceWriter(dir, "concurrent-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tw.Close() })
+
+	// Write from multiple goroutines simultaneously.
+	var wg atomic.Int32
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Add(-1)
+			tw.Log("→", map[string]any{"index": n, "data": strings.Repeat("x", 50)})
+		}(i)
+	}
+
+	require.Eventually(t, func() bool {
+		return wg.Load() == 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, tw.Close())
+
+	// Read back — should have exactly 10 valid JSONL lines.
+	data, err := os.ReadFile(tw.Path())
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	require.Len(t, lines, 10)
+
+	for _, line := range lines {
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry), "invalid JSONL: %s", line)
+	}
+}
+
+// ─── TraceWriter File Path ──────────────────────────────────────────────────
+
+func TestTraceWriter_PathFormat(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	tw, err := NewTraceWriter(dir, "my-session")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tw.Close() })
+
+	expected := filepath.Join(dir, "acp-trace-my-session.jsonl")
+	require.Equal(t, expected, tw.Path())
+}

--- a/internal/worker/acp/worker_phase3_test.go
+++ b/internal/worker/acp/worker_phase3_test.go
@@ -8,9 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
+	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -108,7 +107,7 @@ func TestTraceWriter_NilSafe(t *testing.T) {
 	// All operations on nil TraceWriter should be no-ops.
 	tw.Log("→", "test")
 	require.NoError(t, tw.Close())
-	require.NoError(t, tw.Rotate())
+	tw.Rotate()
 	require.Equal(t, "", tw.Path())
 }
 
@@ -322,18 +321,15 @@ func TestTraceWriter_ConcurrentWrites(t *testing.T) {
 	t.Cleanup(func() { _ = tw.Close() })
 
 	// Write from multiple goroutines simultaneously.
-	var wg atomic.Int32
+	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(n int) {
-			defer wg.Add(-1)
+			defer wg.Done()
 			tw.Log("→", map[string]any{"index": n, "data": strings.Repeat("x", 50)})
 		}(i)
 	}
-
-	require.Eventually(t, func() bool {
-		return wg.Load() == 0
-	}, 2*time.Second, 10*time.Millisecond)
+	wg.Wait()
 
 	require.NoError(t, tw.Close())
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -252,3 +252,13 @@ const SandboxPlatformKey = "_sandbox"
 // ACPCommandPlatformKey is the platformKey map key used to propagate per-bot
 // ACP command override from messaging bridge through session persistence to the ACP worker.
 const ACPCommandPlatformKey = "_acp_command"
+
+// ForkSessionPlatformKey is the platformKey map key used to signal that a session
+// should be forked from an existing session instead of resumed or created fresh.
+// TODO: wire from platform adapters in UX follow-up.
+const ForkSessionPlatformKey = "_fork_session"
+
+// JSONSchemaPlatformKey is the platformKey map key used to inject a JSON Schema
+// for structured output into the first prompt of a session.
+// TODO: wire from platform adapters in UX follow-up.
+const JSONSchemaPlatformKey = "_json_schema"

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -255,10 +255,10 @@ const ACPCommandPlatformKey = "_acp_command"
 
 // ForkSessionPlatformKey is the platformKey map key used to signal that a session
 // should be forked from an existing session instead of resumed or created fresh.
-// TODO: wire from platform adapters in UX follow-up.
+// Expected value: "true" (string, checked via == "true" in bridge).
 const ForkSessionPlatformKey = "_fork_session"
 
 // JSONSchemaPlatformKey is the platformKey map key used to inject a JSON Schema
 // for structured output into the first prompt of a session.
-// TODO: wire from platform adapters in UX follow-up.
+// Expected value: raw JSON Schema string (e.g. '{"type":"object","properties":{...}}').
 const JSONSchemaPlatformKey = "_json_schema"


### PR DESCRIPTION
## Summary

ACP Worker Phase 3 实现（除 UX-01~04 飞书/Slack 适配器渲染外全部内容）。

### Changes

| Feature | 描述 |
|---------|------|
| **EX-02** | 协议版本转发 + 高版本 warn log |
| **EX-01** | `acp.args` 配置 + per-session args 覆盖 |
| **U-04** | `acp.debug` 启用 JSON-RPC 协议 trace（50MB 轮转） |
| **FR-08** | ForkSession 桥接 + fallback to new session |
| **FR-09** | JSON Schema 首次 prompt 注入（独立于 system prompt） |
| **T-04** | 性能基准测试（MapNotification ≤6μs/op, Codec ≥38K ops/s） |

### Bug Fix

修复 `Input()` 方法中 JSON Schema `if` 块嵌套在 system prompt `if` 块内的 bug — 导致无 system prompt 时 JSON Schema 注入不生效。

### New Files

- `internal/worker/acp/trace.go` — TraceWriter（JSONL 协议调试）
- `internal/worker/acp/bench_test.go` — 性能基准测试
- `internal/worker/acp/worker_phase3_test.go` — Phase 3 单元测试

### Modified Files

| File | Change |
|------|--------|
| `internal/worker/acp/worker.go` | +108 行：configArgs/debug 全局变量、args 合并、trace 初始化、ForkSession 分支、JSON Schema 注入 |
| `internal/config/config.go` | ACPConfig 新增 Args/Debug 字段 |
| `internal/gateway/bridge.go` | buildWorkerInfo 新增 ForkSession/JSONSchema 传播 |
| `internal/worker/acp/mapper.go` | unknown sessionUpdate type warn log |

### Verification

- ✅ `make check` 全绿（fmt + lint + test + build）
- ✅ `go test -race` 无 data race
- ✅ `go test -bench` 性能达标

Closes #589