### PR TITLE
fix: batch reliability fixes for #598, #597, #596, #522

### DIFF
--- a/cmd/hotplex/admin_adapters.go
+++ b/cmd/hotplex/admin_adapters.go
@@ -122,10 +122,16 @@ type botListerAdapter struct {
 }
 
 func toAdminBotEntry(e *messaging.BotEntry) admin.BotEntry {
+	botID := e.BotID
+	if botID == "" {
+		// Fallback when platform BotID is not yet available (adapter not started).
+		// Use platform:name to guarantee uniqueness across platforms.
+		botID = string(e.Platform) + ":" + e.Name
+	}
 	return admin.BotEntry{
 		Name:        e.Name,
 		Platform:    string(e.Platform),
-		BotID:       e.BotID,
+		BotID:       botID,
 		Status:      string(e.Status),
 		ConnectedAt: e.ConnectedAt.Format("2006-01-02T15:04:05Z"),
 		WorkerType:  e.WorkerType,

--- a/cmd/hotplex/admin_adapters.go
+++ b/cmd/hotplex/admin_adapters.go
@@ -126,6 +126,8 @@ func toAdminBotEntry(e *messaging.BotEntry) admin.BotEntry {
 	if botID == "" {
 		// Fallback when platform BotID is not yet available (adapter not started).
 		// Use platform:name to guarantee uniqueness across platforms.
+		// NOTE: assumes bot Name does not contain colons — safe for Slack/Feishu
+		// auto-generated names ("default") and all known platform bot name formats.
 		botID = string(e.Platform) + ":" + e.Name
 	}
 	return admin.BotEntry{

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -379,6 +379,37 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	return nil
 }
 
+// forceTerminateInMemory performs in-memory state cleanup when transitionState fails
+// (DB error or invalid transition). It mirrors transitionState's side effects
+// (metrics, quota release, worker nil) without DB persistence.
+// Caller must hold ms.mu for write. Returns worker to kill outside lock.
+func (m *Manager) forceTerminateInMemory(ctx context.Context, ms *managedSession, from events.SessionState, termReason string) worker.Worker {
+	var workerToKill worker.Worker
+	ms.info.State = events.StateTerminated
+	ms.info.UpdatedAt = time.Now()
+
+	// Record worker execution duration.
+	if !ms.startedAt.IsZero() && ms.worker != nil {
+		metrics.WorkerExecDuration.WithLabelValues(string(ms.info.WorkerType)).Observe(time.Since(ms.startedAt).Seconds())
+	}
+	// Release quota and decrement running gauge.
+	if ms.worker != nil {
+		metrics.WorkersRunning.WithLabelValues(string(ms.info.WorkerType)).Dec()
+		m.releaseWorkerQuota(ms)
+		workerToKill = ms.worker
+		ms.worker = nil // prevent DetachWorker double-release
+	}
+
+	m.updateRunningIndexForTransition(ms.info.ID, from, events.StateTerminated)
+	metrics.SessionsActive.WithLabelValues(string(from)).Dec()
+	metrics.SessionsActive.WithLabelValues(string(events.StateTerminated)).Inc()
+	metrics.SessionsTerminated.WithLabelValues(termReason).Inc()
+
+	m.notifyStateChange(ctx, ms.info.ID, events.StateTerminated, termReason)
+
+	return workerToKill
+}
+
 // Transition atomically transitions a session to a new state.
 // Both the in-memory state and the DB are updated.
 // When transitioning to IDLE, sets idle_expires_at = now + IdleTimeout.
@@ -447,17 +478,13 @@ func (m *Manager) TransitionWithInput(ctx context.Context, id string, to events.
 					// appear active in DB after restart until GC reaps it.
 					m.log.Error("session: max-turns state transition failed, force-terminating in-memory state",
 						"session_id", id, "err", err)
-					ms.info.State = events.StateTerminated
-					workerToKill = ms.worker
-					m.updateRunningIndexForTransition(id, from, events.StateTerminated)
+					workerToKill = m.forceTerminateInMemory(ctx, ms, from, "max_turns")
 				}
 			} else {
 				// Escape hatch: invalid transition — force-terminate in-memory.
 				m.log.Warn("session: max-turns transition invalid, force-terminating in-memory state",
 					"session_id", id, "from_state", from)
-				ms.info.State = events.StateTerminated
-				workerToKill = ms.worker
-				m.updateRunningIndexForTransition(id, from, events.StateTerminated)
+				workerToKill = m.forceTerminateInMemory(ctx, ms, from, "max_turns")
 			}
 			ms.mu.Unlock()
 			// Kill worker outside lock only if transitionState did not handle it.
@@ -539,6 +566,7 @@ func (m *Manager) AttachWorker(id string, w worker.Worker) error {
 	}
 	ms.worker = w
 	ms.startedAt = time.Now()
+	metrics.PoolAcquireTotal.WithLabelValues("success").Inc()
 	metrics.WorkerStartsTotal.WithLabelValues(string(ms.info.WorkerType), "success").Inc()
 	metrics.WorkersRunning.WithLabelValues(string(ms.info.WorkerType)).Inc()
 	ms.mu.Unlock()

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -383,10 +383,20 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 // (DB error or invalid transition). It mirrors transitionState's side effects
 // (metrics, quota release, worker nil) without DB persistence.
 // Caller must hold ms.mu for write. Returns worker to kill outside lock.
+//
+// Design note: the returned worker is Kill()'d (hard) by the caller, whereas
+// transitionState uses Terminate() (graceful SIGTERM + 5s timeout). This is
+// intentional — when DB persistence fails we cannot track the graceful-shutdown
+// window, so a hard kill is the safer choice to guarantee process cleanup.
 func (m *Manager) forceTerminateInMemory(ctx context.Context, ms *managedSession, from events.SessionState, termReason string) worker.Worker {
 	var workerToKill worker.Worker
 	ms.info.State = events.StateTerminated
 	ms.info.UpdatedAt = time.Now()
+
+	// Guard termReason to avoid empty Prometheus label (matches transitionState behavior).
+	if termReason == "" {
+		termReason = "terminated"
+	}
 
 	// Record worker execution duration.
 	if !ms.startedAt.IsZero() && ms.worker != nil {
@@ -397,8 +407,8 @@ func (m *Manager) forceTerminateInMemory(ctx context.Context, ms *managedSession
 		metrics.WorkersRunning.WithLabelValues(string(ms.info.WorkerType)).Dec()
 		m.releaseWorkerQuota(ms)
 		workerToKill = ms.worker
-		ms.worker = nil // prevent DetachWorker double-release
 	}
+	ms.worker = nil // unconditional nil — matches transitionState, prevents double-release
 
 	m.updateRunningIndexForTransition(ms.info.ID, from, events.StateTerminated)
 	metrics.SessionsActive.WithLabelValues(string(from)).Dec()
@@ -555,6 +565,7 @@ func (m *Manager) AttachWorker(id string, w worker.Worker) error {
 	if !ok {
 		m.mu.Unlock()
 		m.pool.Release(userID)
+		metrics.PoolAcquireTotal.WithLabelValues("toctou_retry").Inc()
 		return ErrSessionNotFound
 	}
 	ms.mu.Lock()
@@ -562,6 +573,7 @@ func (m *Manager) AttachWorker(id string, w worker.Worker) error {
 		ms.mu.Unlock()
 		m.mu.Unlock()
 		m.pool.Release(userID)
+		metrics.PoolAcquireTotal.WithLabelValues("toctou_retry").Inc()
 		return ErrWorkerAttached
 	}
 	ms.worker = w

--- a/internal/session/pool.go
+++ b/internal/session/pool.go
@@ -82,7 +82,9 @@ func (p *PoolManager) Acquire(userID string) error {
 	if p.maxSize > 0 {
 		metrics.PoolUtilization.Set(float64(p.totalCount) / float64(p.maxSize))
 	}
-	metrics.PoolAcquireTotal.WithLabelValues("success").Inc()
+	// Note: PoolAcquireTotal["success"] is NOT recorded here because the
+	// overall attach may still fail (e.g., memory quota). The caller records
+	// the final outcome after all checks pass.
 	p.log.Debug("pool: acquired", "user_id", userID, "total", p.totalCount)
 	return nil
 }

--- a/internal/worker/claudecode/mapper.go
+++ b/internal/worker/claudecode/mapper.go
@@ -192,10 +192,14 @@ func (m *Mapper) mapResult(p *ResultPayload) ([]*events.Envelope, error) {
 	}
 
 	if !p.Success {
+		msg := p.Message
+		if msg == "" {
+			msg = "worker execution failed"
+		}
 		return []*events.Envelope{
 			events.NewEnvelope(aep.NewID(), m.sessionID, m.seqGen(), events.Error, events.ErrorData{
 				Code:    events.ErrCodeInternalError,
-				Message: p.Message,
+				Message: msg,
 			}),
 			events.NewEnvelope(aep.NewID(), m.sessionID, m.seqGen(), events.Done, events.DoneData{
 				Success: false,

--- a/internal/worker/codexcli/mapper.go
+++ b/internal/worker/codexcli/mapper.go
@@ -247,6 +247,9 @@ func (m *Mapper) mapTurnFailed() []*events.Envelope {
 }
 
 func (m *Mapper) mapError(msg string) []*events.Envelope {
+	if msg == "" {
+		msg = "unknown error"
+	}
 	return []*events.Envelope{
 		newEnvelope(events.Error, events.ErrorData{
 			Code: "CODEX_ERROR", Message: msg,

--- a/internal/worker/opencodeserver/converter.go
+++ b/internal/worker/opencodeserver/converter.go
@@ -161,7 +161,10 @@ func (c *Converter) handleStepFailed(sessionID string, props json.RawMessage) []
 		msg = evt.Error.Message
 	}
 	return []*events.Envelope{
-		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Error, events.ErrorData{Message: msg}),
+		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Error, events.ErrorData{
+			Code:    events.ErrCodeInternalError,
+			Message: msg,
+		}),
 	}
 }
 
@@ -329,7 +332,10 @@ func (c *Converter) handleSessionError(sessionID string, props json.RawMessage) 
 	}
 	delete(c.states, sessionID)
 	return []*events.Envelope{
-		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Error, events.ErrorData{Message: msg}),
+		events.NewEnvelope(aep.NewID(), sessionID, 0, events.Error, events.ErrorData{
+			Code:    events.ErrCodeInternalError,
+			Message: msg,
+		}),
 	}
 }
 


### PR DESCRIPTION
## Summary

Batch PR implementing 4 high-priority reliability fixes across gateway/session/worker layers.

## Issues Closed

Closes #598, Closes #597, Closes #596, Closes #522

## Changes by Issue

### #598 — P1: TransitionWithInput escape hatch 泄漏 pool quota
**Problem**: `TransitionWithInput` max-turns escape hatch 直接赋值 `ms.info.State` 绕过 `transitionState()`，导致 pool quota 永久泄漏、metrics 不更新、DB 不同步。

**Fix**: 新增 `forceTerminateInMemory()` 辅助方法，完整执行 metrics 更新、quota 释放、worker nil、state notification。两个 escape hatch 路径统一调用。

**Files**: `internal/session/manager.go`

### #597 — error 事件缺少 message/code
**Problem**: 3 个 Worker mapper 构造 error 事件时可能发送空 message 或空 code → 前端 `INTERNAL_ERROR message=none`。

**Fix**:
- claudecode mapper: 空 `p.Message` 回退为 `"worker execution failed"`
- codexcli mapper: 空 msg 回退为 `"unknown error"`
- opencodeserver converter: 补充缺失的 `Code: ErrCodeInternalError`（2 处）

**Files**: `internal/worker/claudecode/mapper.go`, `internal/worker/codexcli/mapper.go`, `internal/worker/opencodeserver/converter.go`

### #596 — bot API 返回重复 bot_id
**Problem**: admin bot API 初始 BotID 为空字符串，两个平台的 default bot 都产生空 bot_id → React key 碰撞。

**Fix**: `toAdminBotEntry` 中空 BotID 回退为 `platform:name`（如 `slack:default`），保证唯一。

**Files**: `cmd/hotplex/admin_adapters.go`

### #522 — PoolAcquireTotal double-counted
**Problem**: `pool.Acquire()` 成功记录 `success`，随后 `AcquireMemory` 失败又记录 `memory_exceeded` → 一次 attach 尝试产生 2 个计数。

**Fix**: 将 `PoolAcquireTotal["success"]` 从 `pool.Acquire()` 移至 `AttachWorker` 完整验证成功后记录，每次 attach 恰好一个结果。

**Files**: `internal/session/pool.go`, `internal/session/manager.go`

## Testing

- [x] `go test -count=1 -race -short ./internal/session/...` — PASS
- [x] `go test -count=1 -race -short ./internal/worker/...` — PASS (all 7 packages)
- [x] `go test -count=1 -race -short ./cmd/hotplex/...` — PASS
- [x] `golangci-lint run` — 0 issues
- [x] Pre-commit + pre-push hooks — all passed

## Breaking Changes

None. All changes are backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)