### PR TITLE
fix(gateway): forwardEvents 阻塞风险 + StartSession 孤儿 worker + Delete/Attach 竞态 (#600, #599)

### DIFF
--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -50,10 +50,12 @@ type Bridge struct {
 	wf           WorkerFactory
 	retryCtrl    *LLMRetryController
 
-	fwdWg         sync.WaitGroup // tracks active forwardEvents goroutines
-	closed        atomic.Bool    // set during shutdown to skip crash detection
-	retryCancelMu sync.Mutex
-	retryCancel   map[string]chan struct{} // sessionID → cancel channel
+	fwdWg          sync.WaitGroup // tracks active forwardEvents goroutines
+	closed         atomic.Bool    // set during shutdown to skip crash detection
+	shutdownCtx    context.Context
+	shutdownCancel context.CancelFunc // cancels shutdownCtx on Shutdown()
+	retryCancelMu  sync.Mutex
+	retryCancel    map[string]chan struct{} // sessionID → cancel channel
 
 	agentConfigDir     string        // agent config directory path; "" = disabled
 	turnTimeout        time.Duration // per-turn timeout; 0 = disabled
@@ -84,6 +86,7 @@ const (
 
 // NewBridge creates a new bridge.
 func NewBridge(deps BridgeDeps) *Bridge {
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	b := &Bridge{
 		log:                deps.Log.With("component", "bridge"),
 		hub:                deps.Hub,
@@ -100,6 +103,8 @@ func NewBridge(deps BridgeDeps) *Bridge {
 		retryCancel:        make(map[string]chan struct{}),
 		accum:              make(map[string]*sessionAccumulator),
 		crashTracker:       make(map[string]*crashHistory),
+		shutdownCtx:        shutdownCtx,
+		shutdownCancel:     shutdownCancel,
 	}
 	b.mcpConfigJSON.Store(deps.MCPConfigJSON)
 	return b
@@ -173,7 +178,16 @@ func (b *Bridge) StartSession(ctx context.Context, id, userID, botID string, wt 
 
 	// Transition to RUNNING. (StateNotifier will emit state event automatically)
 	if err := b.sm.Transition(ctx, id, events.StateRunning); err != nil {
-		b.log.Warn("bridge: transition to running failed", "session_id", id, "worker_type", wt, "err", err)
+		// Kill the worker to prevent orphan — without this, the worker runs
+		// indefinitely while the session stays in CREATED state, invisible to GC.
+		// forwardEvents will detect the exit and cleanupCrashedWorker transitions
+		// the session to TERMINATED for eventual GC reclamation.
+		b.log.Error("bridge: transition to running failed, terminating orphan worker",
+			"session_id", id, "worker_type", wt, "err", err)
+		if w := b.sm.GetWorker(id); w != nil {
+			_ = w.Terminate(context.Background())
+		}
+		return fmt.Errorf("bridge: transition to running: %w", err)
 	}
 
 	return nil
@@ -539,9 +553,11 @@ func isWorkerInUseError(err error) bool {
 
 // Shutdown signals the bridge that the gateway is shutting down.
 // It sets the closed flag so forwardEvents goroutines skip crash detection,
+// cancels the shutdown context to abort pending auto-retries,
 // then waits for all forwardEvents goroutines to complete or ctx to expire.
 func (b *Bridge) Shutdown(ctx context.Context) {
 	b.closed.Store(true)
+	b.shutdownCancel()
 	done := make(chan struct{})
 	go func() {
 		b.fwdWg.Wait()

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -50,8 +50,12 @@ type Bridge struct {
 	wf           WorkerFactory
 	retryCtrl    *LLMRetryController
 
-	fwdWg          sync.WaitGroup // tracks active forwardEvents goroutines
-	closed         atomic.Bool    // set during shutdown to skip crash detection
+	fwdWg  sync.WaitGroup // tracks active forwardEvents goroutines
+	closed atomic.Bool    // set during shutdown to skip crash detection
+	// shutdownCtx is stored as a struct field to broadcast shutdown to async
+	// autoRetry goroutines. This is an intentional exception to the "no ctx in
+	// struct" convention — the alternative (passing ctx through every call site)
+	// doesn't reach goroutines spawned from processForwardedEvent.
 	shutdownCtx    context.Context
 	shutdownCancel context.CancelFunc // cancels shutdownCtx on Shutdown()
 	retryCancelMu  sync.Mutex

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -18,6 +18,11 @@ import (
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
+// waitKillTimeout is the maximum time to wait for Worker.Wait() to return
+// after calling Kill(). If Wait() still hasn't returned, forwardEvents
+// abandons the wait to prevent permanent goroutine blocking.
+const waitKillTimeout = 5 * time.Second
+
 // forwardContext carries per-session mutable state for the event forwarding loop.
 // Ownership: exclusively owned by the single forwardEvents goroutine per session.
 // No concurrent access — all fields are read/written from that goroutine only,
@@ -426,7 +431,7 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 		// Secondary timeout: if Wait() still doesn't return after Kill()
 		// (e.g., Go runtime deadlock or zombie process), abandon the wait
 		// instead of blocking forwardEvents forever.
-		killTimeout := time.NewTimer(5 * time.Second)
+		killTimeout := time.NewTimer(waitKillTimeout)
 		defer killTimeout.Stop()
 		select {
 		case <-ch:

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -232,13 +232,19 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	if env.Event.Type == events.Done && b.retryCtrl != nil && (!opts.resumed || fc.turnText.Len() > 0) {
 		if shouldRetry, attempt := b.retryCtrl.ShouldRetry(sessionID, fc.lastError); shouldRetry {
 			fc.pendingError = nil
+			// Pre-register cancel channel before launching goroutine to close
+			// the race window where CancelRetry can't find the channel.
+			cancelCh := make(chan struct{})
+			b.retryCancelMu.Lock()
+			b.retryCancel[sessionID] = cancelCh
+			b.retryCancelMu.Unlock()
 			// Run autoRetry asynchronously so forwardEvents continues reading
 			// from recvCh. This prevents the goroutine from blocking during
 			// the backoff period — if the worker crashes, the for-range loop
 			// detects recvCh closure immediately instead of waiting for the
 			// backoff timer to expire. The goroutine uses shutdownCtx so it
 			// cancels promptly during bridge shutdown.
-			go b.autoRetry(b.shutdownCtx, w, sessionID, attempt)
+			go b.autoRetry(b.shutdownCtx, w, sessionID, attempt, cancelCh)
 			fc.turnText.Reset()
 			if b.collector != nil {
 				b.collector.ResetSession(sessionID)

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -232,7 +232,13 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	if env.Event.Type == events.Done && b.retryCtrl != nil && (!opts.resumed || fc.turnText.Len() > 0) {
 		if shouldRetry, attempt := b.retryCtrl.ShouldRetry(sessionID, fc.lastError); shouldRetry {
 			fc.pendingError = nil
-			b.autoRetry(context.Background(), w, sessionID, attempt)
+			// Run autoRetry asynchronously so forwardEvents continues reading
+			// from recvCh. This prevents the goroutine from blocking during
+			// the backoff period — if the worker crashes, the for-range loop
+			// detects recvCh closure immediately instead of waiting for the
+			// backoff timer to expire. The goroutine uses shutdownCtx so it
+			// cancels promptly during bridge shutdown.
+			go b.autoRetry(b.shutdownCtx, w, sessionID, attempt)
 			fc.turnText.Reset()
 			if b.collector != nil {
 				b.collector.ResetSession(sessionID)
@@ -411,7 +417,18 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 	case <-time.After(waitTimeout):
 		b.log.Warn("bridge: Wait() timed out, force-killing", "session_id", p.sessionID, "worker_type", workerType)
 		_ = w.Kill()
-		<-ch
+		// Secondary timeout: if Wait() still doesn't return after Kill()
+		// (e.g., Go runtime deadlock or zombie process), abandon the wait
+		// instead of blocking forwardEvents forever.
+		killTimeout := time.NewTimer(5 * time.Second)
+		defer killTimeout.Stop()
+		select {
+		case <-ch:
+			// Wait completed after Kill.
+		case <-killTimeout.C:
+			b.log.Warn("bridge: Wait() did not return after Kill(), abandoning",
+				"session_id", p.sessionID, "worker_type", workerType)
+		}
 	}
 
 	// Resume retry: skip during shutdown and for SIGTERM (exit 143).

--- a/internal/gateway/bridge_retry.go
+++ b/internal/gateway/bridge_retry.go
@@ -20,7 +20,9 @@ func (b *Bridge) CancelRetry(sessionID string) {
 }
 
 // autoRetry performs exponential backoff then sends the retry input to the worker.
-func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID string, attempt int) {
+// cancelCh is pre-registered by the caller to eliminate the race window between
+// goroutine launch and cancel channel registration.
+func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID string, attempt int, cancelCh chan struct{}) {
 	delay := b.retryCtrl.Delay(attempt)
 
 	// Notify user if enabled.
@@ -30,11 +32,7 @@ func (b *Bridge) autoRetry(ctx context.Context, w worker.Worker, sessionID strin
 		_ = b.hub.SendToSession(ctx, notifyEnv)
 	}
 
-	// Register cancel channel.
-	cancelCh := make(chan struct{})
-	b.retryCancelMu.Lock()
-	b.retryCancel[sessionID] = cancelCh
-	b.retryCancelMu.Unlock()
+	// Clean up cancel channel on exit (registered by caller before goroutine launch).
 	defer func() {
 		b.retryCancelMu.Lock()
 		delete(b.retryCancel, sessionID)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -677,6 +677,9 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 	}
 
 	ms.mu.Lock()
+	hadWorkerBefore := ms.worker != nil
+	workerType := ms.info.WorkerType
+	uid := ms.info.UserID
 	wasRunning := ms.info.State == events.StateRunning
 	// Copy-on-write: build candidate, persist, commit on success.
 	candidate := ms.info
@@ -697,18 +700,21 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 	m.mu.Lock()
 	if _, exists := m.sessions[id]; exists {
 		// Re-check worker under lock: AttachWorker may have attached during DB write gap.
-		// If a new worker appeared, the session was resurrected — abort deletion
-		// to avoid creating an orphan worker with no session record.
 		ms.mu.Lock()
-		workerAppeared := ms.worker != nil
+		hasWorkerAfter := ms.worker != nil
 		ms.mu.Unlock()
-		if workerAppeared {
+		// If worker appeared during the gap (was nil before, now non-nil),
+		// a concurrent AttachWorker resurrected the session — abort deletion.
+		// If the worker was already there (hadWorkerBefore), proceed normally.
+		if !hadWorkerBefore && hasWorkerAfter {
 			m.mu.Unlock()
 			m.log.Warn("session: worker attached during delete gap, aborting deletion",
 				"session_id", id)
-			// DB already has DELETED state — next worker exit will trigger cleanup
-			// via Transition(TERMINATED) which is valid from DELETED's predecessor.
 			return nil
+		}
+		if hasWorkerAfter {
+			metrics.WorkersRunning.WithLabelValues(string(workerType)).Dec()
+			m.pool.Release(uid)
 		}
 		delete(m.sessions, id)
 		if wasRunning {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -576,6 +576,16 @@ func (m *Manager) AttachWorker(id string, w worker.Worker) error {
 		metrics.PoolAcquireTotal.WithLabelValues("toctou_retry").Inc()
 		return ErrWorkerAttached
 	}
+	// Reject attach if session is no longer active — prevents Delete/Attach
+	// race where Delete releases locks during DB write and a concurrent
+	// AttachWorker slips in, creating an orphan worker with no session record.
+	if !ms.info.State.IsActive() {
+		ms.mu.Unlock()
+		m.mu.Unlock()
+		m.pool.Release(userID)
+		metrics.PoolAcquireTotal.WithLabelValues("toctou_retry").Inc()
+		return ErrSessionNotFound
+	}
 	ms.worker = w
 	ms.startedAt = time.Now()
 	metrics.PoolAcquireTotal.WithLabelValues("success").Inc()
@@ -667,9 +677,6 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 	}
 
 	ms.mu.Lock()
-	hasWorker := ms.worker != nil
-	workerType := ms.info.WorkerType
-	uid := ms.info.UserID
 	wasRunning := ms.info.State == events.StateRunning
 	// Copy-on-write: build candidate, persist, commit on success.
 	candidate := ms.info
@@ -690,14 +697,18 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 	m.mu.Lock()
 	if _, exists := m.sessions[id]; exists {
 		// Re-check worker under lock: AttachWorker may have attached during DB write gap.
+		// If a new worker appeared, the session was resurrected — abort deletion
+		// to avoid creating an orphan worker with no session record.
 		ms.mu.Lock()
-		if ms.worker != nil {
-			hasWorker = true
-		}
+		workerAppeared := ms.worker != nil
 		ms.mu.Unlock()
-		if hasWorker {
-			metrics.WorkersRunning.WithLabelValues(string(workerType)).Dec()
-			m.pool.Release(uid)
+		if workerAppeared {
+			m.mu.Unlock()
+			m.log.Warn("session: worker attached during delete gap, aborting deletion",
+				"session_id", id)
+			// DB already has DELETED state — next worker exit will trigger cleanup
+			// via Transition(TERMINATED) which is valid from DELETED's predecessor.
+			return nil
 		}
 		delete(m.sessions, id)
 		if wasRunning {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -23,6 +23,7 @@ import (
 // Errors returned by the session manager.
 var (
 	ErrSessionNotFound   = errors.New("session: not found")
+	ErrSessionNotActive  = errors.New("session: not active")
 	ErrSessionBusy       = errors.New("session: busy")
 	ErrInvalidTransition = errors.New("session: invalid state transition")
 	ErrPoolExhausted     = errors.New("session: pool exhausted")
@@ -584,7 +585,7 @@ func (m *Manager) AttachWorker(id string, w worker.Worker) error {
 		m.mu.Unlock()
 		m.pool.Release(userID)
 		metrics.PoolAcquireTotal.WithLabelValues("toctou_retry").Inc()
-		return ErrSessionNotFound
+		return ErrSessionNotActive
 	}
 	ms.worker = w
 	ms.startedAt = time.Now()
@@ -692,30 +693,37 @@ func (m *Manager) Delete(ctx context.Context, id string) error {
 		return err
 	}
 
-	// Persist succeeded — commit the candidate in-memory.
-	ms.mu.Lock()
-	ms.info = candidate
-	ms.mu.Unlock()
-
+	// Persist succeeded — validate gap before committing in-memory.
+	// This must happen BEFORE setting ms.info = candidate to prevent
+	// leaving the session in DELETED state with a running worker when
+	// a concurrent AttachWorker slipped in during the DB write window.
 	m.mu.Lock()
 	if _, exists := m.sessions[id]; exists {
-		// Re-check worker under lock: AttachWorker may have attached during DB write gap.
 		ms.mu.Lock()
 		hasWorkerAfter := ms.worker != nil
-		ms.mu.Unlock()
 		// If worker appeared during the gap (was nil before, now non-nil),
 		// a concurrent AttachWorker resurrected the session — abort deletion.
-		// If the worker was already there (hadWorkerBefore), proceed normally.
 		if !hadWorkerBefore && hasWorkerAfter {
+			ms.mu.Unlock()
 			m.mu.Unlock()
-			m.log.Warn("session: worker attached during delete gap, aborting deletion",
+			m.log.Warn("session: worker attached during delete gap, rolling back",
 				"session_id", id)
+			// Rollback DB: restore original state (ms.info hasn't been mutated yet).
+			ms.mu.RLock()
+			original := ms.info
+			ms.mu.RUnlock()
+			if rbErr := m.store.Upsert(ctx, &original); rbErr != nil {
+				m.log.Error("session: delete rollback failed", "session_id", id, "err", rbErr)
+			}
 			return nil
 		}
+		// No gap worker — commit candidate and delete atomically under both locks.
+		ms.info = candidate
 		if hasWorkerAfter {
 			metrics.WorkersRunning.WithLabelValues(string(workerType)).Dec()
 			m.pool.Release(uid)
 		}
+		ms.mu.Unlock()
 		delete(m.sessions, id)
 		if wasRunning {
 			m.removeFromRunningIndex(id)


### PR DESCRIPTION
## Summary

Batch PR 修复 2 个高优先级 gateway 可靠性问题：

- **#600**: `forwardEvents` 阻塞风险 — autoRetry 退避 + Wait() 无二次超时
- **#599**: StartSession transition 失败留孤儿 worker + Delete/Attach 竞态泄漏

## Fixes

Closes #600, Closes #599

## Changes by Issue

### #600 — forwardEvents 阻塞风险

**问题 1: autoRetry 阻塞 forwardEvents goroutine**
- `autoRetry` 以 `context.Background()` 同步调用，退避期间 forwardEvents 无法读取 recvCh
- Worker crash 在退避结束后才被检测（秒到分钟延迟）

**修复**: autoRetry 改为异步 goroutine + Bridge shutdownCtx
- `forwardEvents` for-range 循环不再被阻塞，worker crash 通过 recvCh 关闭立即检测
- Bridge 新增 `shutdownCtx`/`shutdownCancel`，Shutdown 时取消所有 pending retry
- autoRetry goroutine 在 shutdown 时通过 ctx.Done() 立即退出

**问题 2: Wait() 死锁永久阻塞**
- Kill() 后 `<-ch` 等待 Wait() 完成，但 Wait() 本身可能死锁
- forwardEvents goroutine 永久阻塞 → fwdWg 不递减 → Shutdown 超时 → pool slot 永久泄漏

**修复**: Kill 后增加 5s 二次超时兜底
- 超时后 log Warn 并放弃等待，forwardEvents 正常退出

### #599 — StartSession 孤儿 worker + Delete/Attach 竞态

**问题 1: StartSession transition 失败留孤儿 worker**
- `createAndLaunchWorker` 启动 worker 成功，但 `Transition(RUNNING)` DB 错误
- 代码仅 log warning，worker 继续运行，session 停留 CREATED 状态
- GC 不可见（CREATED 不在 running index），pool slot 泄漏 + ~512MB RSS

**修复**: transition 失败时 Terminate worker
- forwardEvents 检测到 exit 后 cleanupCrashedWorker 转 TERMINATED
- GC 正常回收

**问题 2: Delete/Attach 竞态**
- Delete 释放 m.mu + ms.mu 后执行 DB 写入，AttachWorker 在此窗口挂载新 worker
- Delete 重新获取锁后释放新 worker 的 quota 并删除 session → 新 worker 变孤儿

**修复**: 
- AttachWorker TOCTOU 增加 `ms.info.State.IsActive()` 检查，拒绝 DELETED session
- Delete 对比 `hadWorkerBefore`/`hasWorkerAfter`，仅 gap 期间新挂载的 worker 才中止删除

## Testing

- [x] Unit tests pass (all packages, -race)
- [x] E2E tests pass (TestE2E_SessionDelete verified)
- [x] Linter passes (`golangci-lint`)
- [x] Full test suite: 30+ packages, 0 failures

## Changes

| File | Changes |
|------|---------|
| `internal/gateway/bridge.go` | +shutdownCtx/cancel, StartSession orphan kill, Shutdown cancel |
| `internal/gateway/bridge_forward.go` | autoRetry async + Wait() secondary timeout |
| `internal/session/manager.go` | AttachWorker state check + Delete gap detection |
