### PR TITLE
feat(agentconfig): per-file injection control with inject_exclude (#594)

### DIFF
--- a/.agents/rules/agentconfig.md
+++ b/.agents/rules/agentconfig.md
@@ -5,7 +5,7 @@ paths:
 
 # Agent Config
 
-`Load(dir, platform, botID)` 按三级 fallback 加载配置：`{botID}/` → `{platform}/` → 全局，每文件独立，命中即终止。
+`Load(dir, platform, botID, injectExclude...)` 按三级 fallback 加载配置：`{botID}/` → `{platform}/` → 全局，每文件独立，命中即终止。`injectExclude` 为黑名单（大小写不敏感），命中的文件跳过加载。
 
 **B/C 双通道**：冲突时 directives 无条件覆盖 context。
 
@@ -28,3 +28,4 @@ paths:
 - BotID：`Adapter.botID → Bridge → injectAgentConfig → Load`
 - 限制：单文件 8KB / 总量 40KB | YAML frontmatter 自动剥离
 - 安全：`filepath.Base(botID) == botID` 防路径穿越
+- 注入排除：`injectExclude` 按文件名（大小写不敏感）跳过加载；3 级配置（bot → platform → global），nil 继承，空 slice 覆盖清空

--- a/cmd/hotplex/admin_adapters.go
+++ b/cmd/hotplex/admin_adapters.go
@@ -94,8 +94,8 @@ type bridgeAdapter struct {
 	bridge *gateway.Bridge
 }
 
-func (a *bridgeAdapter) StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir, platform string, platformKey map[string]string, title string) error {
-	return a.bridge.StartSession(ctx, id, userID, botID, wt, allowedTools, workDir, platform, platformKey, title)
+func (a *bridgeAdapter) StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir, platform string, platformKey map[string]string, title string, injectExclude ...string) error {
+	return a.bridge.StartSession(ctx, id, userID, botID, wt, allowedTools, workDir, platform, platformKey, title, injectExclude...)
 }
 
 type configAdapter struct {

--- a/cmd/hotplex/bot_config_adapter.go
+++ b/cmd/hotplex/bot_config_adapter.go
@@ -45,7 +45,8 @@ func (a *botConfigAdapter) GetBotConfig(ctx context.Context, name string) (*admi
 	botID := entry.BotID
 
 	attrs := extractBotAttrs(cfg, platform, name)
-	summary := getAgentConfigSummary(platform, botID, a.agentConfigDir)
+	excl := a.resolveInjectExcludeForAdmin(platform, name)
+	summary := getAgentConfigSummary(platform, botID, a.agentConfigDir, excl...)
 
 	return &admin.BotConfigEntry{
 		Name:         entry.Name,
@@ -68,7 +69,8 @@ func (a *botConfigAdapter) ListBotConfigs(ctx context.Context) ([]admin.BotConfi
 	for _, e := range entries {
 		platform := string(e.Platform)
 		attrs := extractBotAttrs(cfg, platform, e.Name)
-		summary := getAgentConfigSummary(platform, e.BotID, a.agentConfigDir)
+		excl := a.resolveInjectExcludeForAdmin(platform, e.Name)
+		summary := getAgentConfigSummary(platform, e.BotID, a.agentConfigDir, excl...)
 
 		result = append(result, admin.BotConfigEntry{
 			Name:         e.Name,
@@ -90,7 +92,8 @@ func (a *botConfigAdapter) GetAgentConfigFile(ctx context.Context, botName strin
 		return nil, fmt.Errorf("bot %q not found in registry", botName)
 	}
 
-	configs, err := agentconfig.Load(a.agentConfigDir, platform, botID)
+	excl := a.resolveInjectExcludeForAdmin(platform, botName)
+	configs, err := agentconfig.Load(a.agentConfigDir, platform, botID, excl...)
 	if err != nil {
 		return nil, fmt.Errorf("load agent config: %w", err)
 	}
@@ -113,7 +116,8 @@ func (a *botConfigAdapter) GetSystemPromptPreview(ctx context.Context, botName s
 		return "", fmt.Errorf("bot %q not found in registry", botName)
 	}
 
-	configs, err := agentconfig.Load(a.agentConfigDir, platform, botID)
+	excl := a.resolveInjectExcludeForAdmin(platform, botName)
+	configs, err := agentconfig.Load(a.agentConfigDir, platform, botID, excl...)
 	if err != nil {
 		return "", fmt.Errorf("load agent config: %w", err)
 	}
@@ -287,6 +291,27 @@ func resolvePlatformAndBotID(name string) (platform, botID string, ok bool) {
 	return string(entry.Platform), entry.BotID, true
 }
 
+// resolveInjectExcludeForAdmin resolves the inject_exclude list for a bot
+// using 3-level fallback: bot → platform → global.
+func (a *botConfigAdapter) resolveInjectExcludeForAdmin(platform, botName string) []string {
+	cfg := a.cfgStore.Load()
+	global := cfg.AgentConfig.InjectExclude
+	var platformExcl, botExcl []string
+	switch platform {
+	case "slack":
+		platformExcl = cfg.Messaging.Slack.InjectExclude
+		if bc := resolveSlackBot(cfg, botName); bc != nil {
+			botExcl = bc.InjectExclude
+		}
+	case "feishu":
+		platformExcl = cfg.Messaging.Feishu.InjectExclude
+		if bc := resolveFeishuBot(cfg, botName); bc != nil {
+			botExcl = bc.InjectExclude
+		}
+	}
+	return config.ResolveInjectExclude(global, platformExcl, botExcl)
+}
+
 // extractBotAttrs builds BotConfigAttrs from the config for a specific bot.
 func extractBotAttrs(cfg *config.Config, platform, name string) *admin.BotConfigAttrs {
 	attrs := &admin.BotConfigAttrs{}
@@ -387,8 +412,8 @@ func extractBotAttrs(cfg *config.Config, platform, name string) *admin.BotConfig
 }
 
 // getAgentConfigSummary returns a summary of all agent config files for a bot.
-func getAgentConfigSummary(platform, botID, agentConfigDir string) *admin.AgentConfigSummary {
-	configs, err := agentconfig.Load(agentConfigDir, platform, botID)
+func getAgentConfigSummary(platform, botID, agentConfigDir string, injectExclude ...string) *admin.AgentConfigSummary {
+	configs, err := agentconfig.Load(agentConfigDir, platform, botID, injectExclude...)
 	if err != nil || configs == nil {
 		return nil
 	}

--- a/cmd/hotplex/bot_config_adapter.go
+++ b/cmd/hotplex/bot_config_adapter.go
@@ -45,7 +45,7 @@ func (a *botConfigAdapter) GetBotConfig(ctx context.Context, name string) (*admi
 	botID := entry.BotID
 
 	attrs := extractBotAttrs(cfg, platform, name)
-	excl := a.resolveInjectExcludeForAdmin(platform, name)
+	excl := resolveInjectExcludeForAdmin(cfg, platform, name)
 	summary := getAgentConfigSummary(platform, botID, a.agentConfigDir, excl...)
 
 	return &admin.BotConfigEntry{
@@ -69,7 +69,7 @@ func (a *botConfigAdapter) ListBotConfigs(ctx context.Context) ([]admin.BotConfi
 	for _, e := range entries {
 		platform := string(e.Platform)
 		attrs := extractBotAttrs(cfg, platform, e.Name)
-		excl := a.resolveInjectExcludeForAdmin(platform, e.Name)
+		excl := resolveInjectExcludeForAdmin(cfg, platform, e.Name)
 		summary := getAgentConfigSummary(platform, e.BotID, a.agentConfigDir, excl...)
 
 		result = append(result, admin.BotConfigEntry{
@@ -92,7 +92,7 @@ func (a *botConfigAdapter) GetAgentConfigFile(ctx context.Context, botName strin
 		return nil, fmt.Errorf("bot %q not found in registry", botName)
 	}
 
-	excl := a.resolveInjectExcludeForAdmin(platform, botName)
+	excl := resolveInjectExcludeForAdmin(a.cfgStore.Load(), platform, botName)
 	configs, err := agentconfig.Load(a.agentConfigDir, platform, botID, excl...)
 	if err != nil {
 		return nil, fmt.Errorf("load agent config: %w", err)
@@ -116,7 +116,7 @@ func (a *botConfigAdapter) GetSystemPromptPreview(ctx context.Context, botName s
 		return "", fmt.Errorf("bot %q not found in registry", botName)
 	}
 
-	excl := a.resolveInjectExcludeForAdmin(platform, botName)
+	excl := resolveInjectExcludeForAdmin(a.cfgStore.Load(), platform, botName)
 	configs, err := agentconfig.Load(a.agentConfigDir, platform, botID, excl...)
 	if err != nil {
 		return "", fmt.Errorf("load agent config: %w", err)
@@ -293,8 +293,7 @@ func resolvePlatformAndBotID(name string) (platform, botID string, ok bool) {
 
 // resolveInjectExcludeForAdmin resolves the inject_exclude list for a bot
 // using 3-level fallback: bot → platform → global.
-func (a *botConfigAdapter) resolveInjectExcludeForAdmin(platform, botName string) []string {
-	cfg := a.cfgStore.Load()
+func resolveInjectExcludeForAdmin(cfg *config.Config, platform, botName string) []string {
 	global := cfg.AgentConfig.InjectExclude
 	var platformExcl, botExcl []string
 	switch platform {
@@ -308,6 +307,8 @@ func (a *botConfigAdapter) resolveInjectExcludeForAdmin(platform, botName string
 		if bc := resolveFeishuBot(cfg, botName); bc != nil {
 			botExcl = bc.InjectExclude
 		}
+	case "yuanxin":
+		platformExcl = cfg.Messaging.Yuanxin.InjectExclude
 	}
 	return config.ResolveInjectExclude(global, platformExcl, botExcl)
 }

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -986,6 +986,9 @@ func buildMCPConfigJSON(cfg *config.Config) string {
 // buildAgentConfigExclude builds the platform → inject_exclude map for non-platform
 // sessions (webchat/API/cron). The "" key holds the global default; platform-specific
 // keys override it. Nil values are omitted (meaning "not configured, fall through").
+//
+// NOTE: keep platform keys in sync with resolveInjectExcludeForAdmin (bot_config_adapter.go)
+// and applyInjectExclude callers (messaging_init.go).
 func buildAgentConfigExclude(cfg *config.Config) map[string][]string {
 	m := make(map[string][]string)
 	if cfg.AgentConfig.InjectExclude != nil {

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -997,6 +997,9 @@ func buildAgentConfigExclude(cfg *config.Config) map[string][]string {
 	if cfg.Messaging.Feishu.InjectExclude != nil {
 		m["feishu"] = cfg.Messaging.Feishu.InjectExclude
 	}
+	if cfg.Messaging.Yuanxin.InjectExclude != nil {
+		m["yuanxin"] = cfg.Messaging.Yuanxin.InjectExclude
+	}
 	if len(m) == 0 {
 		return nil
 	}

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -264,6 +264,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		WorkerEnvBlocklist: cfg.Worker.EnvBlocklist,
 		CronEnv:            buildCronEnv(cfg),
 		MCPConfigJSON:      buildMCPConfigJSON(cfg),
+		AgentConfigExclude: buildAgentConfigExclude(cfg),
 	})
 
 	skillsLocator := skills.NewLocator(log, cfg.Skills.CacheTTL)
@@ -972,6 +973,26 @@ func buildMCPConfigJSON(cfg *config.Config) string {
 		return ""
 	}
 	return string(b)
+}
+
+// buildAgentConfigExclude builds the platform → inject_exclude map for non-platform
+// sessions (webchat/API/cron). The "" key holds the global default; platform-specific
+// keys override it. Nil values are omitted (meaning "not configured, fall through").
+func buildAgentConfigExclude(cfg *config.Config) map[string][]string {
+	m := make(map[string][]string)
+	if cfg.AgentConfig.InjectExclude != nil {
+		m[""] = cfg.AgentConfig.InjectExclude
+	}
+	if cfg.Messaging.Slack.InjectExclude != nil {
+		m["slack"] = cfg.Messaging.Slack.InjectExclude
+	}
+	if cfg.Messaging.Feishu.InjectExclude != nil {
+		m["feishu"] = cfg.Messaging.Feishu.InjectExclude
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 func releaseDBStatsManual(log *slog.Logger) {

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -335,6 +335,14 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 			log.Info("config: MCP servers updated", "count", len(next.Worker.ClaudeCode.MCPServers))
 		}
 	})
+	cfgStore.RegisterFunc(func(prev, next *config.Config) {
+		prevExcl := buildAgentConfigExclude(prev)
+		nextExcl := buildAgentConfigExclude(next)
+		if !reflect.DeepEqual(prevExcl, nextExcl) {
+			bridge.UpdateAgentConfigExclude(nextExcl)
+			log.Info("config: agent config inject_exclude updated")
+		}
+	})
 
 	// Assemble deps and start HTTP + messaging
 

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -451,6 +451,8 @@ func fillYuanxinExtras(acfg *messaging.AdapterConfig, appCfg *config.Config) {
 	if platformCfg.Namespace != "" {
 		acfg.Extras["namespace"] = platformCfg.Namespace
 	}
+
+	applyInjectExclude(acfg, appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, func() []string { return nil })
 }
 
 func buildFeishuTranscriber(sttCfg config.STTConfig, appID, appSecret string, log *slog.Logger) stt.Transcriber {

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -368,12 +368,11 @@ func fillSlackExtras(acfg *messaging.AdapterConfig, appCfg *config.Config, botCf
 		acfg.Extras["tts_pipeline"] = p
 	}
 
-	applyInjectExclude(acfg, appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, func() []string {
-		if botCfg != nil {
-			return botCfg.InjectExclude
-		}
-		return nil
-	})
+	var slackBotExcl []string
+	if botCfg != nil {
+		slackBotExcl = botCfg.InjectExclude
+	}
+	applyInjectExclude(acfg, appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, slackBotExcl)
 }
 
 // fillFeishuExtras populates AdapterConfig.Extras for a Feishu bot.
@@ -408,18 +407,16 @@ func fillFeishuExtras(acfg *messaging.AdapterConfig, appCfg *config.Config, botC
 		acfg.Extras["tts_pipeline"] = p
 	}
 
-	applyInjectExclude(acfg, appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, func() []string {
-		if botCfg != nil {
-			return botCfg.InjectExclude
-		}
-		return nil
-	})
+	var feishuBotExcl []string
+	if botCfg != nil {
+		feishuBotExcl = botCfg.InjectExclude
+	}
+	applyInjectExclude(acfg, appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, feishuBotExcl)
 }
 
 // applyInjectExclude resolves the 3-level inject_exclude fallback (bot → platform → global)
-// and stores the result in acfg.Extras when configured. Shared by fillSlackExtras and fillFeishuExtras.
-func applyInjectExclude(acfg *messaging.AdapterConfig, global, platformExcl []string, botExclFn func() []string) {
-	botExcl := botExclFn()
+// and stores the result in acfg.Extras when configured. Shared by all fill*Extras functions.
+func applyInjectExclude(acfg *messaging.AdapterConfig, global, platformExcl, botExcl []string) {
 	if excl := config.ResolveInjectExclude(global, platformExcl, botExcl); excl != nil {
 		acfg.Extras["inject_exclude"] = excl
 	}
@@ -452,7 +449,7 @@ func fillYuanxinExtras(acfg *messaging.AdapterConfig, appCfg *config.Config) {
 		acfg.Extras["namespace"] = platformCfg.Namespace
 	}
 
-	applyInjectExclude(acfg, appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, func() []string { return nil })
+	applyInjectExclude(acfg, appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, nil)
 }
 
 func buildFeishuTranscriber(sttCfg config.STTConfig, appID, appSecret string, log *slog.Logger) stt.Transcriber {

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -367,6 +367,15 @@ func fillSlackExtras(acfg *messaging.AdapterConfig, appCfg *config.Config, botCf
 	if p := buildSlackTTSPipeline(ttsCfg, botToken, appToken, log); p != nil {
 		acfg.Extras["tts_pipeline"] = p
 	}
+
+	// Agent config injection exclusion: bot → platform → global fallback.
+	var botExcl []string
+	if botCfg != nil {
+		botExcl = botCfg.InjectExclude
+	}
+	if excl := config.ResolveInjectExclude(appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, botExcl); excl != nil {
+		acfg.Extras["inject_exclude"] = excl
+	}
 }
 
 // fillFeishuExtras populates AdapterConfig.Extras for a Feishu bot.
@@ -399,6 +408,15 @@ func fillFeishuExtras(acfg *messaging.AdapterConfig, appCfg *config.Config, botC
 	}
 	if p := buildFeishuTTSPipeline(ttsCfg, appID, appSecret, log); p != nil {
 		acfg.Extras["tts_pipeline"] = p
+	}
+
+	// Agent config injection exclusion: bot → platform → global fallback.
+	var botExcl []string
+	if botCfg != nil {
+		botExcl = botCfg.InjectExclude
+	}
+	if excl := config.ResolveInjectExclude(appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, botExcl); excl != nil {
+		acfg.Extras["inject_exclude"] = excl
 	}
 }
 

--- a/cmd/hotplex/messaging_init.go
+++ b/cmd/hotplex/messaging_init.go
@@ -368,14 +368,12 @@ func fillSlackExtras(acfg *messaging.AdapterConfig, appCfg *config.Config, botCf
 		acfg.Extras["tts_pipeline"] = p
 	}
 
-	// Agent config injection exclusion: bot → platform → global fallback.
-	var botExcl []string
-	if botCfg != nil {
-		botExcl = botCfg.InjectExclude
-	}
-	if excl := config.ResolveInjectExclude(appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, botExcl); excl != nil {
-		acfg.Extras["inject_exclude"] = excl
-	}
+	applyInjectExclude(acfg, appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, func() []string {
+		if botCfg != nil {
+			return botCfg.InjectExclude
+		}
+		return nil
+	})
 }
 
 // fillFeishuExtras populates AdapterConfig.Extras for a Feishu bot.
@@ -410,12 +408,19 @@ func fillFeishuExtras(acfg *messaging.AdapterConfig, appCfg *config.Config, botC
 		acfg.Extras["tts_pipeline"] = p
 	}
 
-	// Agent config injection exclusion: bot → platform → global fallback.
-	var botExcl []string
-	if botCfg != nil {
-		botExcl = botCfg.InjectExclude
-	}
-	if excl := config.ResolveInjectExclude(appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, botExcl); excl != nil {
+	applyInjectExclude(acfg, appCfg.AgentConfig.InjectExclude, platformCfg.InjectExclude, func() []string {
+		if botCfg != nil {
+			return botCfg.InjectExclude
+		}
+		return nil
+	})
+}
+
+// applyInjectExclude resolves the 3-level inject_exclude fallback (bot → platform → global)
+// and stores the result in acfg.Extras when configured. Shared by fillSlackExtras and fillFeishuExtras.
+func applyInjectExclude(acfg *messaging.AdapterConfig, global, platformExcl []string, botExclFn func() []string) {
+	botExcl := botExclFn()
+	if excl := config.ResolveInjectExclude(global, platformExcl, botExcl); excl != nil {
 		acfg.Extras["inject_exclude"] = excl
 	}
 }

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -52,7 +52,7 @@ type HubProvider interface {
 }
 
 type BridgeProvider interface {
-	StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir string, platform string, platformKey map[string]string, title string) error
+	StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir string, platform string, platformKey map[string]string, title string, injectExclude ...string) error
 }
 
 type ConfigProvider interface {

--- a/internal/admin/handlers_test.go
+++ b/internal/admin/handlers_test.go
@@ -82,7 +82,7 @@ func (m *mockHub) NextSeqPeek(string) int64 { return 42 }
 
 type mockBridge struct{ err error }
 
-func (m *mockBridge) StartSession(context.Context, string, string, string, worker.WorkerType, []string, string, string, map[string]string, string) error {
+func (m *mockBridge) StartSession(context.Context, string, string, string, worker.WorkerType, []string, string, string, map[string]string, string, ...string) error {
 	return m.err
 }
 

--- a/internal/agentconfig/loader.go
+++ b/internal/agentconfig/loader.go
@@ -111,9 +111,8 @@ func shouldExclude(baseName string, exclude []string) bool {
 	if len(exclude) == 0 {
 		return false
 	}
-	upper := strings.ToUpper(baseName)
 	for _, name := range exclude {
-		if strings.ToUpper(name) == upper {
+		if strings.EqualFold(name, baseName) {
 			return true
 		}
 	}

--- a/internal/agentconfig/loader.go
+++ b/internal/agentconfig/loader.go
@@ -36,8 +36,11 @@ const MaxTotalChars = 40_000
 // Each file resolves independently. Missing files fall through to the next level.
 // Platform can be "slack", "feishu", "webchat", or "" (no platform-level lookup).
 // botID is used directly as directory name (e.g., Slack UserID, Feishu OpenID).
+// injectExclude lists file base names to skip (e.g., ["SOUL.md", "MEMORY.md"]).
+// Files listed in injectExclude are not loaded; their corresponding config fields
+// remain empty. META-COGNITION.md is never excluded (go:embed, always injected).
 // Returns AgentConfigs with frontmatter stripped and size limits enforced.
-func Load(dir, platform, botID string) (*AgentConfigs, error) {
+func Load(dir, platform, botID string, injectExclude ...string) (*AgentConfigs, error) {
 	if dir == "" {
 		return &AgentConfigs{}, nil
 	}
@@ -51,6 +54,9 @@ func Load(dir, platform, botID string) (*AgentConfigs, error) {
 	var total int
 
 	load := func(baseName string, target *string) error {
+		if shouldExclude(baseName, injectExclude) {
+			return nil
+		}
 		content, err := resolveFile(dir, platform, botID, baseName)
 		if err != nil {
 			return err
@@ -97,6 +103,22 @@ func Load(dir, platform, botID string) (*AgentConfigs, error) {
 
 // configFiles lists recognized agent config file names.
 var configFiles = []string{"SOUL.md", "AGENTS.md", "SKILLS.md", "USER.md", "MEMORY.md"}
+
+// shouldExclude reports whether a config file should be skipped from injection.
+// baseName is matched case-insensitively against the exclude list.
+// META-COGNITION.md is never excluded (it is go:embed, always injected outside Load).
+func shouldExclude(baseName string, exclude []string) bool {
+	if len(exclude) == 0 {
+		return false
+	}
+	upper := strings.ToUpper(baseName)
+	for _, name := range exclude {
+		if strings.ToUpper(name) == upper {
+			return true
+		}
+	}
+	return false
+}
 
 // HasGlobalFiles reports whether any config file exists at the global level (dir/<file>).
 func HasGlobalFiles(dir string) bool {

--- a/internal/agentconfig/loader.go
+++ b/internal/agentconfig/loader.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -104,6 +105,11 @@ func Load(dir, platform, botID string, injectExclude ...string) (*AgentConfigs, 
 // configFiles lists recognized agent config file names.
 var configFiles = []string{"SOUL.md", "AGENTS.md", "SKILLS.md", "USER.md", "MEMORY.md"}
 
+// KnownFiles returns the list of recognized config file names for validation/logging.
+func KnownFiles() []string {
+	return slices.Clone(configFiles)
+}
+
 // shouldExclude reports whether a config file should be skipped from injection.
 // baseName is matched case-insensitively against the exclude list.
 // META-COGNITION.md is never excluded (it is go:embed, always injected outside Load).
@@ -117,6 +123,25 @@ func shouldExclude(baseName string, exclude []string) bool {
 		}
 	}
 	return false
+}
+
+// ValidateExcludeList returns entries from exclude that do not match any known
+// config file name. Matching is case-insensitive. Returns nil if all entries are valid.
+func ValidateExcludeList(exclude []string) []string {
+	var unknown []string
+	for _, name := range exclude {
+		found := false
+		for _, cfg := range configFiles {
+			if strings.EqualFold(name, cfg) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			unknown = append(unknown, name)
+		}
+	}
+	return unknown
 }
 
 // HasGlobalFiles reports whether any config file exists at the global level (dir/<file>).

--- a/internal/agentconfig/loader_test.go
+++ b/internal/agentconfig/loader_test.go
@@ -345,3 +345,101 @@ func writeFile(t *testing.T, dir, name, content string) {
 	err := os.WriteFile(fullPath, []byte(content), 0o644)
 	require.NoError(t, err)
 }
+
+func TestShouldExclude(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		baseName string
+		exclude  []string
+		want     bool
+	}{
+		{"nil exclude", "SOUL.md", nil, false},
+		{"empty exclude", "SOUL.md", []string{}, false},
+		{"exact match", "SOUL.md", []string{"SOUL.md"}, true},
+		{"case insensitive", "soul.md", []string{"SOUL.MD"}, true},
+		{"case insensitive reverse", "SOUL.MD", []string{"soul.md"}, true},
+		{"mixed case", "Soul.Md", []string{"sOul.mD"}, true},
+		{"no match", "SOUL.md", []string{"AGENTS.md"}, false},
+		{"multiple exclude one match", "USER.md", []string{"SOUL.md", "USER.md"}, true},
+		{"multiple exclude no match", "SKILLS.md", []string{"SOUL.md", "USER.md"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldExclude(tt.baseName, tt.exclude)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLoadWithInjectExclude(t *testing.T) {
+	t.Parallel()
+
+	t.Run("excludes specified file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "I am soul.")
+		writeFile(t, dir, "AGENTS.md", "Rules here.")
+		writeFile(t, dir, "USER.md", "User data.")
+
+		cfg, err := Load(dir, "", "", "SOUL.md")
+		require.NoError(t, err)
+		require.Empty(t, cfg.Soul, "SOUL.md should be excluded")
+		require.Equal(t, "Rules here.", cfg.Agents)
+		require.Equal(t, "User data.", cfg.User)
+	})
+
+	t.Run("excludes multiple files", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "Soul content.")
+		writeFile(t, dir, "AGENTS.md", "Agents content.")
+		writeFile(t, dir, "USER.md", "User content.")
+		writeFile(t, dir, "MEMORY.md", "Memory content.")
+
+		cfg, err := Load(dir, "", "", "SOUL.md", "MEMORY.md")
+		require.NoError(t, err)
+		require.Empty(t, cfg.Soul, "SOUL.md should be excluded")
+		require.Empty(t, cfg.Memory, "MEMORY.md should be excluded")
+		require.Equal(t, "Agents content.", cfg.Agents)
+		require.Equal(t, "User content.", cfg.User)
+	})
+
+	t.Run("exclude is case insensitive", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "Soul content.")
+
+		cfg, err := Load(dir, "", "", "soul.md")
+		require.NoError(t, err)
+		require.Empty(t, cfg.Soul, "soul.md (lowercase) should exclude SOUL.md")
+	})
+
+	t.Run("no exclude loads all files", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "Soul content.")
+		writeFile(t, dir, "AGENTS.md", "Agents content.")
+
+		cfg, err := Load(dir, "", "")
+		require.NoError(t, err)
+		require.Equal(t, "Soul content.", cfg.Soul)
+		require.Equal(t, "Agents content.", cfg.Agents)
+	})
+
+	t.Run("exclude with platform fallback still works", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "Global soul.")
+		writeFile(t, dir, "slack/SOUL.md", "Slack soul.")
+		writeFile(t, dir, "AGENTS.md", "Rules.")
+
+		cfg, err := Load(dir, "slack", "", "SOUL.md")
+		require.NoError(t, err)
+		require.Empty(t, cfg.Soul, "excluded file should not load from any level")
+		require.Equal(t, "Rules.", cfg.Agents)
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,8 +246,9 @@ type MessagingPlatformConfig struct {
 	AllowDMFrom    []string `mapstructure:"allow_dm_from"`
 	AllowGroupFrom []string `mapstructure:"allow_group_from"`
 
-	STTConfig `mapstructure:",squash"`
-	TTSConfig `mapstructure:",squash"`
+	InjectExclude []string `mapstructure:"inject_exclude"` // platform-level default: files to skip from agent config injection
+	STTConfig     `mapstructure:",squash"`
+	TTSConfig     `mapstructure:",squash"`
 }
 
 // MaxBotsPerPlatform is the maximum number of bots allowed per messaging platform.
@@ -294,6 +295,9 @@ type SlackBotConfig struct {
 	AllowDMFrom    []string `mapstructure:"allow_dm_from,omitempty"`
 	AllowGroupFrom []string `mapstructure:"allow_group_from,omitempty"`
 
+	// Per-bot agent config injection override (falls back to platform-level when nil).
+	InjectExclude []string `mapstructure:"inject_exclude,omitempty"`
+
 	// Per-bot branding override (falls back to platform-level when empty).
 	DisplayName string `mapstructure:"display_name,omitempty"`
 	IconEmoji   string `mapstructure:"icon_emoji,omitempty"`
@@ -333,6 +337,9 @@ type FeishuBotConfig struct {
 	AllowFrom      []string `mapstructure:"allow_from,omitempty"`
 	AllowDMFrom    []string `mapstructure:"allow_dm_from,omitempty"`
 	AllowGroupFrom []string `mapstructure:"allow_group_from,omitempty"`
+
+	// Per-bot agent config injection override (falls back to platform-level when nil).
+	InjectExclude []string `mapstructure:"inject_exclude,omitempty"`
 
 	STTConfig `mapstructure:",squash"`
 	TTSConfig `mapstructure:",squash"`
@@ -679,8 +686,9 @@ type PoolConfig struct {
 }
 
 type AgentConfig struct {
-	Enabled   bool   `mapstructure:"enabled"`    // enable agent config loading
-	ConfigDir string `mapstructure:"config_dir"` // default: ~/.hotplex/agent-configs/
+	Enabled       bool     `mapstructure:"enabled"`        // enable agent config loading
+	ConfigDir     string   `mapstructure:"config_dir"`     // default: ~/.hotplex/agent-configs/
+	InjectExclude []string `mapstructure:"inject_exclude"` // global default: files to skip from agent config injection
 }
 
 // SkillsConfig holds skill discovery and caching settings.
@@ -1598,4 +1606,19 @@ func setSliceField(target any, field, value string) error {
 	}
 	f.Set(reflect.ValueOf(slice))
 	return nil
+}
+
+// ResolveInjectExclude resolves the inject_exclude list using 3-level fallback:
+// bot → platform → global. A nil slice means "not configured" and falls back;
+// a non-nil empty slice (e.g. YAML `inject_exclude: []`) means "explicitly clear,
+// override parent level". Returns nil when no exclusion is configured at any level,
+// which means full injection (backward-compatible default).
+func ResolveInjectExclude(global, platform, bot []string) []string {
+	if bot != nil {
+		return bot
+	}
+	if platform != nil {
+		return platform
+	}
+	return global
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -296,7 +296,9 @@ type SlackBotConfig struct {
 	AllowGroupFrom []string `mapstructure:"allow_group_from,omitempty"`
 
 	// Per-bot agent config injection override (falls back to platform-level when nil).
-	InjectExclude []string `mapstructure:"inject_exclude,omitempty"`
+	// No omitempty: inject_exclude: [] must produce a non-nil empty slice to
+	// explicitly clear the parent-level exclusion (nil = inherit, [] = clear).
+	InjectExclude []string `mapstructure:"inject_exclude"`
 
 	// Per-bot branding override (falls back to platform-level when empty).
 	DisplayName string `mapstructure:"display_name,omitempty"`
@@ -339,7 +341,9 @@ type FeishuBotConfig struct {
 	AllowGroupFrom []string `mapstructure:"allow_group_from,omitempty"`
 
 	// Per-bot agent config injection override (falls back to platform-level when nil).
-	InjectExclude []string `mapstructure:"inject_exclude,omitempty"`
+	// No omitempty: inject_exclude: [] must produce a non-nil empty slice to
+	// explicitly clear the parent-level exclusion (nil = inherit, [] = clear).
+	InjectExclude []string `mapstructure:"inject_exclude"`
 
 	STTConfig `mapstructure:",squash"`
 	TTSConfig `mapstructure:",squash"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1055,3 +1055,29 @@ func TestResolveAPIKeyUsers(t *testing.T) {
 func assertNilKeyMap(t *testing.T, v map[string]string) {
 	require.Nil(t, v)
 }
+
+func TestResolveInjectExclude(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		global, platform, bot []string
+		want                  []string
+	}{
+		{"all nil", nil, nil, nil, nil},
+		{"bot wins", []string{"A"}, []string{"B"}, []string{"C"}, []string{"C"}},
+		{"platform wins when bot nil", []string{"A"}, []string{"B"}, nil, []string{"B"}},
+		{"global wins when rest nil", []string{"A"}, nil, nil, []string{"A"}},
+		{"bot empty slice overrides", []string{"A"}, []string{"B"}, []string{}, []string{}},
+		{"platform empty slice overrides", []string{"A"}, []string{}, nil, []string{}},
+		{"global empty slice is returned", []string{}, nil, nil, []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveInjectExclude(tt.global, tt.platform, tt.bot)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -15,7 +15,7 @@ import (
 
 // BridgeStarter is the narrow interface the executor needs from the gateway Bridge.
 type BridgeStarter interface {
-	StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir, platform string, platformKey map[string]string, title string) error
+	StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir, platform string, platformKey map[string]string, title string, injectExclude ...string) error
 }
 
 // SessionStateChecker polls session state for completion detection.

--- a/internal/cron/executor_test.go
+++ b/internal/cron/executor_test.go
@@ -18,7 +18,7 @@ type mockBridge struct {
 	startErr error
 }
 
-func (m *mockBridge) StartSession(_ context.Context, _, _, _ string, _ worker.WorkerType, _ []string, _, _ string, _ map[string]string, _ string) error {
+func (m *mockBridge) StartSession(_ context.Context, _, _, _ string, _ worker.WorkerType, _ []string, _, _ string, _ map[string]string, _ string, _ ...string) error {
 	return m.startErr
 }
 

--- a/internal/cron/timer_test.go
+++ b/internal/cron/timer_test.go
@@ -289,7 +289,7 @@ func TestGenerateJobID(t *testing.T) {
 // panicBridge panics on StartSession to test panic recovery in onTick.
 type panicBridge struct{}
 
-func (panicBridge) StartSession(_ context.Context, _, _, _ string, _ worker.WorkerType, _ []string, _, _ string, _ map[string]string, _ string) error {
+func (panicBridge) StartSession(_ context.Context, _, _, _ string, _ worker.WorkerType, _ []string, _, _ string, _ map[string]string, _ string, _ ...string) error {
 	panic("test panic in bridge")
 }
 

--- a/internal/gateway/api_test.go
+++ b/internal/gateway/api_test.go
@@ -115,7 +115,7 @@ type mockAPIBridge struct {
 	mock.Mock
 }
 
-func (m *mockAPIBridge) StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir string, platform string, platformKey map[string]string, title string) error {
+func (m *mockAPIBridge) StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir string, platform string, platformKey map[string]string, title string, _ ...string) error {
 	return m.Called(ctx, id, userID, botID, wt, allowedTools, workDir, platform, platformKey, title).Error(0)
 }
 

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -67,6 +67,7 @@ type Bridge struct {
 	workerEnvBlocklist []string      // extra blocklist entries from worker.env_blocklist config
 	cronEnv            []string      // env vars injected only into cron platform sessions
 	mcpConfigJSON      atomic.Value  // pre-serialized MCP config JSON string; "" = not configured
+	agentConfigExclude atomic.Value  // map[string][]string: platform → inject_exclude (global default at "" key)
 
 	accum map[string]*sessionAccumulator // per-session stats accumulator
 	// accumMu protects accum. RWMutex allows concurrent reads in getOrInitAccum
@@ -111,6 +112,7 @@ func NewBridge(deps BridgeDeps) *Bridge {
 		shutdownCancel:     shutdownCancel,
 	}
 	b.mcpConfigJSON.Store(deps.MCPConfigJSON)
+	b.agentConfigExclude.Store(deps.AgentConfigExclude)
 	return b
 }
 
@@ -126,7 +128,7 @@ func (b *Bridge) UpdateMCPConfig(json string) {
 }
 
 // StartSession creates a new session and starts a worker.
-func (b *Bridge) StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir, platform string, platformKey map[string]string, title string) error {
+func (b *Bridge) StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir, platform string, platformKey map[string]string, title string, injectExclude ...string) error {
 	if b.closed.Load() {
 		return fmt.Errorf("bridge: rejecting new session during shutdown")
 	}
@@ -324,7 +326,7 @@ var _ = events.Clone // compile-time check that Clone is accessible
 //  3. No worker, state=CREATED → Start (--session-id)
 //  4. No worker, state=RUNNING/IDLE/TERMINATED → Resume (--resume)
 //     If Resume fails (files gone/corrupted), fall back to Start (--session-id)
-func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, sandbox, platform string, platformKey map[string]string, botID string) error {
+func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, sandbox, platform string, platformKey map[string]string, botID string, injectExclude ...string) error {
 	b.log.Debug("bridge: StartPlatformSession called", "session_id", sessionID, "owner_id", ownerID, "worker_type", workerType, "work_dir", workDir, "sandbox", sandbox, "platform", platform, "platform_key", platformKey, "bot_id", botID)
 	injectSandbox(platformKey, sandbox)
 	si, err := b.sm.Get(ctx, sessionID)
@@ -344,7 +346,7 @@ func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, w
 		// Orphan: session record exists but worker is gone.
 		if si.State == events.StateCreated {
 			b.log.Info("bridge: orphan platform session unstarted, starting fresh", "session_id", sessionID)
-			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID)
+			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID, injectExclude...)
 		}
 		// RUNNING/IDLE/TERMINATED — try Resume to preserve conversation history.
 		// If Resume fails (session files deleted or corrupted), fall back to Start.
@@ -355,7 +357,7 @@ func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, w
 		if err := b.ResumeSession(ctx, sessionID, workDir); err != nil {
 			b.log.Warn("bridge: resume failed, falling back to new session",
 				"session_id", sessionID, "state", si.State, "err", err)
-			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID)
+			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID, injectExclude...)
 		}
 		return nil
 	}
@@ -371,8 +373,8 @@ func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, w
 // startOrResumeOnInUse attempts StartSession; if the worker reports its session
 // files are already in use (leftover from a crashed session), falls back to
 // ResumeSession to recover the existing conversation history.
-func (b *Bridge) startOrResumeOnInUse(ctx context.Context, sessionID, ownerID string, wt worker.WorkerType, workDir, platform string, platformKey map[string]string, botID string) error {
-	if err := b.StartSession(ctx, sessionID, ownerID, botID, wt, nil, workDir, platform, platformKey, ""); err != nil {
+func (b *Bridge) startOrResumeOnInUse(ctx context.Context, sessionID, ownerID string, wt worker.WorkerType, workDir, platform string, platformKey map[string]string, botID string, injectExclude ...string) error {
+	if err := b.StartSession(ctx, sessionID, ownerID, botID, wt, nil, workDir, platform, platformKey, "", injectExclude...); err != nil {
 		if isWorkerInUseError(err) {
 			b.log.Info("bridge: worker rejected as in-use, switching to resume", "session_id", sessionID, "err", err)
 			return b.ResumeSession(ctx, sessionID, workDir)

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -539,7 +539,11 @@ func (b *Bridge) SwitchWorkDir(ctx context.Context, oldSessionID, newWorkDir str
 	}
 
 	if !resumed {
-		excl := b.resolveInjectExclude(si.Platform, nil)
+		// TODO(#603-per-bot-excl): per-bot injectExclude from the messaging adapter
+		// is not persisted in the session record, so SwitchWorkDir falls back to
+		// platform/global from the atomic config map. Fix requires storing
+		// injectExclude in the session record or giving bridge access to adapters.
+		excl := b.resolveInjectExclude(si.Platform, si.BotID, nil)
 		if err := b.StartSession(ctx, newID, si.UserID, si.BotID, si.WorkerType, si.AllowedTools, expanded, si.Platform, si.PlatformKey, si.Title, excl...); err != nil {
 			return nil, fmt.Errorf("switch-workdir: start session: %w", err)
 		}

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -166,12 +166,13 @@ func (b *Bridge) StartSession(ctx context.Context, id, userID, botID string, wt 
 	}
 
 	if _, err := b.createAndLaunchWorker(workerLaunchParams{
-		ctx:         ctx,
-		wt:          wt,
-		workerInfo:  workerInfo,
-		platform:    platform,
-		botID:       botID,
-		forwardOpts: &forwardOpts{workDir: workDir},
+		ctx:           ctx,
+		wt:            wt,
+		workerInfo:    workerInfo,
+		platform:      platform,
+		botID:         botID,
+		forwardOpts:   &forwardOpts{workDir: workDir},
+		injectExclude: injectExclude,
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if err := w.Start(ctx, info); err != nil {
@@ -373,7 +374,7 @@ func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, w
 		return fmt.Errorf("bridge: no worker_type configured for platform session %s", sessionID)
 	}
 
-	return b.startOrResumeOnInUse(ctx, sessionID, ownerID, wt, workDir, platform, platformKey, botID)
+	return b.startOrResumeOnInUse(ctx, sessionID, ownerID, wt, workDir, platform, platformKey, botID, injectExclude...)
 }
 
 // startOrResumeOnInUse attempts StartSession; if the worker reports its session
@@ -538,7 +539,8 @@ func (b *Bridge) SwitchWorkDir(ctx context.Context, oldSessionID, newWorkDir str
 	}
 
 	if !resumed {
-		if err := b.StartSession(ctx, newID, si.UserID, si.BotID, si.WorkerType, si.AllowedTools, expanded, si.Platform, si.PlatformKey, si.Title); err != nil {
+		excl := b.resolveInjectExclude(si.Platform, nil)
+		if err := b.StartSession(ctx, newID, si.UserID, si.BotID, si.WorkerType, si.AllowedTools, expanded, si.Platform, si.PlatformKey, si.Title, excl...); err != nil {
 			return nil, fmt.Errorf("switch-workdir: start session: %w", err)
 		}
 		b.log.Info("switch-workdir: created fresh session",

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -539,7 +539,7 @@ func (b *Bridge) SwitchWorkDir(ctx context.Context, oldSessionID, newWorkDir str
 	}
 
 	if !resumed {
-		// TODO(#603-per-bot-excl): per-bot injectExclude from the messaging adapter
+		// TODO(inject-per-bot): per-bot injectExclude from the messaging adapter
 		// is not persisted in the session record, so SwitchWorkDir falls back to
 		// platform/global from the atomic config map. Fix requires storing
 		// injectExclude in the session record or giving bridge access to adapters.

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -127,6 +127,12 @@ func (b *Bridge) UpdateMCPConfig(json string) {
 	b.mcpConfigJSON.Store(json)
 }
 
+// UpdateAgentConfigExclude atomically updates the platform → inject_exclude map.
+// Used by config hot-reload for non-platform sessions (webchat/API/cron).
+func (b *Bridge) UpdateAgentConfigExclude(m map[string][]string) {
+	b.agentConfigExclude.Store(m)
+}
+
 // StartSession creates a new session and starts a worker.
 func (b *Bridge) StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir, platform string, platformKey map[string]string, title string, injectExclude ...string) error {
 	if b.closed.Load() {

--- a/internal/gateway/bridge_test.go
+++ b/internal/gateway/bridge_test.go
@@ -391,7 +391,7 @@ func TestBridge_InjectAgentConfig_BotIDResolution(t *testing.T) {
 			})
 
 			info := &worker.SessionInfo{}
-			b.injectAgentConfig(info, tt.platform, tt.botID)
+			b.injectAgentConfig(info, tt.platform, tt.botID, nil)
 
 			if tt.wantEmpty {
 				assert.Empty(t, info.SystemPrompt)

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -168,7 +168,7 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 		platform:      si.Platform,
 		botID:         si.BotID,
 		forwardOpts:   &forwardOpts{workDir: p.workDir},
-		injectExclude: b.resolveInjectExclude(si.Platform, nil),
+		injectExclude: b.resolveInjectExclude(si.Platform, si.BotID, nil),
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if err := b.sm.Transition(ctx, p.sessionID, events.StateRunning); err != nil {
@@ -247,8 +247,10 @@ func (b *Bridge) cleanupCrashedWorker(sessionID string, crashedWorker worker.Wor
 
 // resolveInjectExclude returns the inject_exclude list for a platform, falling
 // back from the per-session value to the platform/global default in the atomic
-// config map. Used by injectAgentConfig and crash recovery paths.
-func (b *Bridge) resolveInjectExclude(platform string, perSession []string) []string {
+// config map. botID is reserved for future per-bot resolution (currently unused
+// because per-bot excludes are resolved at adapter time and not persisted in
+// the session record). Used by injectAgentConfig and crash recovery paths.
+func (b *Bridge) resolveInjectExclude(platform, _ string, perSession []string) []string {
 	if perSession != nil {
 		return perSession
 	}
@@ -272,7 +274,7 @@ func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID str
 	if b.agentConfigDir == "" {
 		return
 	}
-	injectExclude = b.resolveInjectExclude(platform, injectExclude)
+	injectExclude = b.resolveInjectExclude(platform, botID, injectExclude)
 	b.log.Debug("bridge: loading agent config", "dir", b.agentConfigDir, "platform", platform, "bot_id", botID, "exclude", injectExclude)
 	configs, err := agentconfig.Load(b.agentConfigDir, platform, botID, injectExclude...)
 	if err != nil {

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -162,12 +162,13 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 	workerInfo := b.prepareWorkerInfo(si.ID, si.UserID, p.workDir, si)
 
 	w, err := b.createAndLaunchWorker(workerLaunchParams{
-		ctx:         context.Background(),
-		wt:          si.WorkerType,
-		workerInfo:  workerInfo,
-		platform:    si.Platform,
-		botID:       si.BotID,
-		forwardOpts: &forwardOpts{workDir: p.workDir},
+		ctx:           context.Background(),
+		wt:            si.WorkerType,
+		workerInfo:    workerInfo,
+		platform:      si.Platform,
+		botID:         si.BotID,
+		forwardOpts:   &forwardOpts{workDir: p.workDir},
+		injectExclude: b.resolveInjectExclude(si.Platform, nil),
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if err := b.sm.Transition(ctx, p.sessionID, events.StateRunning); err != nil {
@@ -244,6 +245,24 @@ func (b *Bridge) cleanupCrashedWorker(sessionID string, crashedWorker worker.Wor
 	b.crashTrackerMu.Unlock()
 }
 
+// resolveInjectExclude returns the inject_exclude list for a platform, falling
+// back from the per-session value to the platform/global default in the atomic
+// config map. Used by injectAgentConfig and crash recovery paths.
+func (b *Bridge) resolveInjectExclude(platform string, perSession []string) []string {
+	if perSession != nil {
+		return perSession
+	}
+	if m, ok := b.agentConfigExclude.Load().(map[string][]string); ok {
+		if excl, found := m[platform]; found {
+			return excl
+		}
+		if excl, found := m[""]; found {
+			return excl
+		}
+	}
+	return nil
+}
+
 // injectAgentConfig loads agent config files and injects the unified system
 // prompt into session info. A no-op when config dir is empty or agent config
 // is not configured.
@@ -253,16 +272,7 @@ func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID str
 	if b.agentConfigDir == "" {
 		return
 	}
-	// Resolve exclude list: per-session override → platform default from config map.
-	if injectExclude == nil {
-		if m, ok := b.agentConfigExclude.Load().(map[string][]string); ok {
-			if excl, found := m[platform]; found {
-				injectExclude = excl
-			} else if excl, found := m[""]; found {
-				injectExclude = excl
-			}
-		}
-	}
+	injectExclude = b.resolveInjectExclude(platform, injectExclude)
 	b.log.Debug("bridge: loading agent config", "dir", b.agentConfigDir, "platform", platform, "bot_id", botID, "exclude", injectExclude)
 	configs, err := agentconfig.Load(b.agentConfigDir, platform, botID, injectExclude...)
 	if err != nil {

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -256,10 +257,10 @@ func (b *Bridge) resolveInjectExclude(platform, _ string, perSession []string) [
 	}
 	if m, ok := b.agentConfigExclude.Load().(map[string][]string); ok {
 		if excl, found := m[platform]; found {
-			return excl
+			return slices.Clone(excl)
 		}
 		if excl, found := m[""]; found {
-			return excl
+			return slices.Clone(excl)
 		}
 	}
 	return nil

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -169,7 +169,7 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 		platform:      si.Platform,
 		botID:         si.BotID,
 		forwardOpts:   &forwardOpts{workDir: p.workDir},
-		injectExclude: b.resolveInjectExclude(si.Platform, si.BotID, nil),
+		injectExclude: nil, // resolved by injectAgentConfig
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if err := b.sm.Transition(ctx, p.sessionID, events.StateRunning); err != nil {
@@ -276,6 +276,10 @@ func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID str
 		return
 	}
 	injectExclude = b.resolveInjectExclude(platform, botID, injectExclude)
+	if unknown := agentconfig.ValidateExcludeList(injectExclude); len(unknown) > 0 {
+		b.log.Warn("bridge: inject_exclude contains unknown config files",
+			"unknown", unknown, "valid", agentconfig.KnownFiles())
+	}
 	b.log.Debug("bridge: loading agent config", "dir", b.agentConfigDir, "platform", platform, "bot_id", botID, "exclude", injectExclude)
 	configs, err := agentconfig.Load(b.agentConfigDir, platform, botID, injectExclude...)
 	if err != nil {

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -24,12 +24,13 @@ type forwardOpts struct {
 
 // workerLaunchParams holds the parameters for createAndLaunchWorker.
 type workerLaunchParams struct {
-	ctx         context.Context
-	wt          worker.WorkerType
-	workerInfo  worker.SessionInfo
-	platform    string
-	botID       string
-	forwardOpts *forwardOpts
+	ctx           context.Context
+	wt            worker.WorkerType
+	workerInfo    worker.SessionInfo
+	platform      string
+	botID         string
+	forwardOpts   *forwardOpts
+	injectExclude []string // per-session agent config files to skip; nil = use platform default
 }
 
 // workerStartFunc is called after AttachWorker and injectAgentConfig.
@@ -69,7 +70,7 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 		return nil, fmt.Errorf("bridge: attach worker: %w", err)
 	}
 
-	b.injectAgentConfig(&params.workerInfo, params.platform, params.botID)
+	b.injectAgentConfig(&params.workerInfo, params.platform, params.botID, params.injectExclude)
 
 	if err := startFn(params.ctx, w, params.workerInfo); err != nil {
 		b.sm.DetachWorker(sid)
@@ -246,12 +247,24 @@ func (b *Bridge) cleanupCrashedWorker(sessionID string, crashedWorker worker.Wor
 // injectAgentConfig loads agent config files and injects the unified system
 // prompt into session info. A no-op when config dir is empty or agent config
 // is not configured.
-func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID string) {
+// injectExclude lists file base names to skip; when nil, falls back to the
+// platform-level default from the atomic config map.
+func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botID string, injectExclude []string) {
 	if b.agentConfigDir == "" {
 		return
 	}
-	b.log.Debug("bridge: loading agent config", "dir", b.agentConfigDir, "platform", platform, "bot_id", botID)
-	configs, err := agentconfig.Load(b.agentConfigDir, platform, botID)
+	// Resolve exclude list: per-session override → platform default from config map.
+	if injectExclude == nil {
+		if m, ok := b.agentConfigExclude.Load().(map[string][]string); ok {
+			if excl, found := m[platform]; found {
+				injectExclude = excl
+			} else if excl, found := m[""]; found {
+				injectExclude = excl
+			}
+		}
+	}
+	b.log.Debug("bridge: loading agent config", "dir", b.agentConfigDir, "platform", platform, "bot_id", botID, "exclude", injectExclude)
+	configs, err := agentconfig.Load(b.agentConfigDir, platform, botID, injectExclude...)
 	if err != nil {
 		if strings.Contains(err.Error(), "invalid botID") {
 			b.log.Error("bridge: agent config rejected botID",

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -50,7 +50,7 @@ type connAuth interface {
 // used by Conn (called once during the AEP init handshake).
 type SessionStarter interface {
 	StartSession(ctx context.Context, id, userID, botID string,
-		wt worker.WorkerType, allowedTools []string, workDir string, platform string, platformKey map[string]string, title string) error
+		wt worker.WorkerType, allowedTools []string, workDir string, platform string, platformKey map[string]string, title string, injectExclude ...string) error
 	ResumeSession(ctx context.Context, id string, workDir string) error
 	SwitchWorkDir(ctx context.Context, oldSessionID, newWorkDir string) (*SwitchWorkDirResult, error)
 }

--- a/internal/gateway/deps.go
+++ b/internal/gateway/deps.go
@@ -28,8 +28,9 @@ type BridgeDeps struct {
 	RetryCtrl          *LLMRetryController
 	AgentConfigDir     string
 	TurnTimeout        time.Duration
-	WorkerEnv          []string // extra env vars from worker.environment config
-	WorkerEnvBlocklist []string // extra blocklist entries from worker.env_blocklist config
-	CronEnv            []string // env vars injected only into cron platform sessions (e.g. admin API creds)
-	MCPConfigJSON      string   // pre-serialized MCP config JSON; "" = not configured → Claude Code default discovery
+	WorkerEnv          []string            // extra env vars from worker.environment config
+	WorkerEnvBlocklist []string            // extra blocklist entries from worker.env_blocklist config
+	CronEnv            []string            // env vars injected only into cron platform sessions (e.g. admin API creds)
+	MCPConfigJSON      string              // pre-serialized MCP config JSON; "" = not configured → Claude Code default discovery
+	AgentConfigExclude map[string][]string // platform → inject_exclude (global default at "" key)
 }

--- a/internal/messaging/bridge.go
+++ b/internal/messaging/bridge.go
@@ -95,10 +95,12 @@ func (b *Bridge) Handle(ctx context.Context, env *events.Envelope, pc PlatformCo
 			platformKey[worker.ACPCommandPlatformKey] = b.acpCommand
 		}
 		var botID string
+		var injectExclude []string
 		if a := b.getAdapter(); a != nil {
 			botID = a.GetBotID()
+			injectExclude = a.GetInjectExclude()
 		}
-		if err := b.starter.StartPlatformSession(ctx, env.SessionID, env.OwnerID, b.workerType, b.workDir, b.sandbox, platform, platformKey, botID); err != nil {
+		if err := b.starter.StartPlatformSession(ctx, env.SessionID, env.OwnerID, b.workerType, b.workDir, b.sandbox, platform, platformKey, botID, injectExclude...); err != nil {
 			return fmt.Errorf("messaging bridge: session start failed: %w", err)
 		}
 	}

--- a/internal/messaging/bridge_test.go
+++ b/internal/messaging/bridge_test.go
@@ -134,6 +134,7 @@ func (m *mockBotIDAdapter) HandleTextMessage(_ context.Context, _, _, _, _, _, _
 func (m *mockBotIDAdapter) Close(_ context.Context) error       { return nil }
 func (m *mockBotIDAdapter) ConfigureWith(_ AdapterConfig) error { return nil }
 func (m *mockBotIDAdapter) GetBotID() string                    { return m.botID }
+func (m *mockBotIDAdapter) GetInjectExclude() []string          { return nil }
 
 // mockHandler implements HandlerInterface.
 type mockHandler struct{}
@@ -145,7 +146,7 @@ type mockStarter struct {
 	startFn func(ctx context.Context, sessionID, ownerID, workerType, workDir, sandbox, platform string, platformKey map[string]string, botID string) error
 }
 
-func (s *mockStarter) StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, sandbox, platform string, platformKey map[string]string, botID string) error {
+func (s *mockStarter) StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, sandbox, platform string, platformKey map[string]string, botID string, _ ...string) error {
 	if s.startFn != nil {
 		return s.startFn(ctx, sessionID, ownerID, workerType, workDir, sandbox, platform, platformKey, botID)
 	}

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -37,6 +37,7 @@ type Adapter struct {
 	wsClient           *ws.Client
 	larkClient         *lark.Client
 	botOpenID          string
+	injectExclude      []string
 	transcriber        Transcriber
 	turnSummaryEnabled bool
 	ttsPipeline        *TTSPipeline
@@ -53,7 +54,8 @@ func (a *Adapter) Platform() messaging.PlatformType { return messaging.PlatformF
 
 var _ messaging.PlatformAdapterInterface = (*Adapter)(nil)
 
-func (a *Adapter) GetBotID() string { return a.botOpenID }
+func (a *Adapter) GetBotID() string           { return a.botOpenID }
+func (a *Adapter) GetInjectExclude() []string { return a.injectExclude }
 
 func (a *Adapter) SetPhrases(p *phrases.Phrases) {
 	if p != nil {
@@ -89,6 +91,10 @@ func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 	}
 
 	a.Extras = config.Extras
+
+	if v, ok := config.Extras["inject_exclude"].([]string); ok {
+		a.injectExclude = v
+	}
 
 	return nil
 }

--- a/internal/messaging/platform_adapter.go
+++ b/internal/messaging/platform_adapter.go
@@ -75,3 +75,7 @@ func (a *PlatformAdapter) CloseSharedState() {
 		a.Dedup = nil
 	}
 }
+
+// GetInjectExclude returns nil by default. Adapters that support per-bot inject_exclude
+// should override this method or embed the value from their Extras.
+func (a *PlatformAdapter) GetInjectExclude() []string { return nil }

--- a/internal/messaging/platform_interfaces.go
+++ b/internal/messaging/platform_interfaces.go
@@ -28,6 +28,10 @@ type PlatformAdapterInterface interface {
 
 	// GetBotID returns the platform bot identity (Slack UserID, Feishu OpenID, etc.).
 	GetBotID() string
+
+	// GetInjectExclude returns the per-bot agent config files to skip from injection.
+	// Returns nil when no exclusion is configured (full injection).
+	GetInjectExclude() []string
 }
 
 // CronResultSender sends a cron job execution result to a platform target.
@@ -49,5 +53,5 @@ type HandlerInterface interface {
 // SessionStarter creates a new gateway session for a platform message.
 // Implemented by gateway.Bridge and injected during wiring.
 type SessionStarter interface {
-	StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, sandbox, platform string, platformKey map[string]string, botID string) error
+	StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, sandbox, platform string, platformKey map[string]string, botID string, injectExclude ...string) error
 }

--- a/internal/messaging/slack/adapter.go
+++ b/internal/messaging/slack/adapter.go
@@ -89,6 +89,7 @@ type Adapter struct {
 	socketMode         *socketmode.Client
 	botID              string
 	teamID             string
+	injectExclude      []string
 	userCache          *UserCache
 	statusMgr          *StatusManager
 	isAssistantCapable atomic.Bool
@@ -111,7 +112,8 @@ func (a *Adapter) Platform() messaging.PlatformType { return messaging.PlatformS
 
 var _ messaging.PlatformAdapterInterface = (*Adapter)(nil)
 
-func (a *Adapter) GetBotID() string { return a.botID }
+func (a *Adapter) GetBotID() string           { return a.botID }
+func (a *Adapter) GetInjectExclude() []string { return a.injectExclude }
 
 func (a *Adapter) SetPhrases(p *phrases.Phrases) {
 	if p != nil {
@@ -157,6 +159,10 @@ func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 	}
 
 	a.Extras = config.Extras
+
+	if v, ok := config.Extras["inject_exclude"].([]string); ok {
+		a.injectExclude = v
+	}
 
 	if config.BotName != "" {
 		a.botName = config.BotName

--- a/internal/messaging/yuanxin/adapter.go
+++ b/internal/messaging/yuanxin/adapter.go
@@ -35,6 +35,7 @@ type Adapter struct {
 	tenant        string
 	ns            string
 	producerTopic string
+	injectExclude []string
 	client        pulsar.Client
 	consumer      pulsar.Consumer
 	producer      pulsar.Producer
@@ -48,7 +49,8 @@ func (a *Adapter) Platform() messaging.PlatformType { return messaging.PlatformY
 var _ messaging.PlatformAdapterInterface = (*Adapter)(nil)
 var _ messaging.CronResultSender = (*Adapter)(nil)
 
-func (a *Adapter) GetBotID() string { return a.appID }
+func (a *Adapter) GetBotID() string           { return a.appID }
+func (a *Adapter) GetInjectExclude() []string { return a.injectExclude }
 
 // ConfigureWith initializes adapter fields. Must be called before Start;
 // after Start returns, these fields are read-only and accessed without locks.
@@ -80,6 +82,11 @@ func (a *Adapter) ConfigureWith(config messaging.AdapterConfig) error {
 	if a.appID == "" {
 		return fmt.Errorf("yuanxin: app_id is required")
 	}
+
+	if v, ok := config.Extras["inject_exclude"].([]string); ok {
+		a.injectExclude = v
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Add configurable blacklist to skip specific agent config files from injection into worker sessions. Enables host agent frameworks (e.g. Hermes) with their own personality system to exclude conflicting files like SOUL.md or MEMORY.md.

## Problem

When running HotPlex with an agent framework that has its own personality system (e.g. Hermes), the injected SOUL.md conflicts with the framework's native personality. Users need per-file granularity to control which config files get injected.

## Solution

**Blacklist pattern with 3-level fallback**: bot → platform → global

```yaml
# Global default
agent_config:
  inject_exclude: ["SOUL.md", "MEMORY.md"]

# Platform override (clears global)
messaging:
  slack:
    inject_exclude: []

# Per-bot override
messaging:
  slack:
    bots:
      - name: "hermes-bot"
        inject_exclude: ["SOUL.md"]
```

**nil-slice semantics**: `nil` = inherit from parent, `[]string{}` = explicit override to clear

## Changes (25 files, +318/-46)

| Layer | Files | Description |
|-------|-------|-------------|
| Config | `config.go` | `InjectExclude` fields + `ResolveInjectExclude` 3-level helper |
| Loader | `loader.go` | `Load()` variadic `injectExclude` + `shouldExclude` case-insensitive |
| Gateway | `bridge.go`, `bridge_worker.go`, `conn.go`, `deps.go` | `injectExclude` threading + `AgentConfigExclude` map |
| Messaging | `platform_interfaces.go`, `platform_adapter.go`, `bridge.go` | `GetInjectExclude()` interface + adapter extraction |
| Adapters | `slack/adapter.go`, `feishu/adapter.go` | `injectExclude` field + `ConfigureWith` reads from Extras |
| Wiring | `messaging_init.go`, `gateway_run.go` | `fillSlackExtras`/`fillFeishuExtras` resolve + `buildAgentConfigExclude` |
| Admin | `admin.go`, `admin_adapters.go`, `bot_config_adapter.go` | Interface signature + admin API exclude resolution |
| Tests | 7 test files | `TestShouldExclude` + `TestLoadWithInjectExclude` + `TestResolveInjectExclude` |

## Testing

- [x] `make check` passes (quality + build)
- [x] Unit tests: `TestShouldExclude` (9 table-driven cases)
- [x] Unit tests: `TestLoadWithInjectExclude` (5 scenarios)
- [x] Unit tests: `TestResolveInjectExclude` (7 fallback cases)
- [x] All 7 mock interface implementations updated
- [x] Pre-commit hooks pass

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)