### PR TITLE
docs(patrol): 2026-06-01 — inject_exclude, ACP, cron config sync

### DIFF
--- a/docs/explanation/agent-config-system.md
+++ b/docs/explanation/agent-config-system.md
@@ -89,17 +89,18 @@ META-COGNITION 定义了 Worker 的**身份边界**——明确告知 Agent "你
 
 ### 配置加载流程
 
-`Load(dir, platform, botID)` 的完整执行路径：
+`Load(dir, platform, botID, injectExclude...)` 的完整执行路径：
 
 ```
 1. 路径安全检查：filepath.Base(botID) == botID（防止路径穿越）
 2. 逐文件加载（SOUL → AGENTS → SKILLS → USER → MEMORY）：
-   a. 调用 resolveFile(dir, platform, botID, fileName)
-   b. 按三级 fallback 查找文件
-   c. 读取文件内容，剥离 YAML frontmatter
-   d. 检查单文件大小限制（MaxFileChars = 8000 字符）
-   e. 检查总量预算（MaxTotalChars = 40000 字符）
-   f. 超出预算的文件截断并记录 warning
+   a. 检查 injectExclude：如文件名在排除列表中，跳过加载
+   b. 调用 resolveFile(dir, platform, botID, fileName)
+   c. 按三级 fallback 查找文件
+   d. 读取文件内容，剥离 YAML frontmatter
+   e. 检查单文件大小限制（MaxFileChars = 8000 字符）
+   f. 检查总量预算（MaxTotalChars = 40000 字符）
+   g. 超出预算的文件截断并记录 warning
 3. 返回 AgentConfigs 结构体
 ```
 
@@ -108,6 +109,47 @@ META-COGNITION 定义了 Worker 的**身份边界**——明确告知 Agent "你
 配置文件支持 Hugo 风格的 YAML frontmatter（`---` 包裹的元数据块），Gateway 在加载时自动剥离。Frontmatter 是给配置管理系统（如 Git、CMS）使用的元数据，不是给 LLM 看的。剥离操作节省 Worker 的 token 消耗。
 
 剥离逻辑处理畸形 frontmatter 的策略是"原样返回"——如果找不到闭合的 `---`，说明格式错误，不会截断内容，而是保留原文。
+
+### 文件排除（inject_exclude）
+
+`inject_exclude` 允许管理员跳过指定配置文件的加载，被排除文件对应的注入位置保持为空。这在多 Bot 场景下特别有用——例如某些 Bot 不需要 `MEMORY.md` 或 `USER.md` 的上下文。
+
+**三级 fallback**（通过 `ResolveInjectExclude` 解析）：
+
+```
+1. Bot 级（bots[].inject_exclude）           -- 最高优先级
+2. 平台级（messaging.*.inject_exclude）
+3. 全局级（agent_config.inject_exclude）      -- 默认
+```
+
+解析规则：
+- **非 nil 空切片**（YAML `inject_exclude: []`）表示"显式清空"——即使全局级有值，也会被覆盖为空
+- **nil**（未设置）表示"使用上级值"——fallback 到上级配置
+- **非空切片** 表示"使用此列表"——直接覆盖上级配置
+
+**匹配方式**：大小写不敏感。`SOUL.md` 和 `soul.md` 等效。
+
+**不可排除**：`META-COGNITION.md` 通过 `go:embed` 编译进二进制，始终注入，不受 `inject_exclude` 影响。
+
+**配置示例**：
+
+```yaml
+# 全局：排除所有 Bot 的 MEMORY.md
+agent_config:
+  inject_exclude: ["MEMORY.md"]
+
+# 平台级：Slack 平台排除 SOUL.md 和 MEMORY.md
+messaging:
+  slack:
+    inject_exclude: ["SOUL.md", "MEMORY.md"]
+
+# Bot 级：特定 Bot 排除 USER.md 和 MEMORY.md
+messaging:
+  slack:
+    bots:
+      - name: "dev-bot"
+        inject_exclude: ["USER.md", "MEMORY.md"]
+```
 
 ### XML Sanitizer：防止注入
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -737,6 +737,7 @@ hotplex cron create \
 | `--expires-at` | | `string` | | 否 | 自动禁用时间（RFC3339 格式） |
 | `--platform` | | `string` | | 否 | 目标投递平台：`slack`、`feishu`、`cron`（未设置时根据 `bot_id` 关联的 session 平台信息推断；若推断失败则默认为 `cron`，不投递结果） |
 | `--platform-key` | | `string` | | 否 | 平台路由键（JSON 对象），如 `'{"channel_id":"C123"}'` |
+| `--worker-type` | | `string` | | 否 | AI Agent 引擎类型：`claude_code`、`opencode_server`、`codex_cli`、`acp`。未设置时使用平台默认 |
 | `--config` | `-c` | `string` | `~/.hotplex/config.yaml` | 否 | 配置文件路径 |
 
 ### `hotplex cron list`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -313,6 +313,8 @@ ACP (Agent Communication Protocol) 通用 Worker，通过 JSON-RPC 2.0 over stdi
 |------|------|--------|----------|------|
 | `command` | string | `hermes acp` | `HOTPLEX_WORKER_ACP_COMMAND` | ACP Agent 启动命令。支持带子命令，如 `hermes acp` |
 | `auto_approve` | bool | `false` | `HOTPLEX_WORKER_ACP_AUTO_APPROVE` | 自动批准权限请求，无需用户确认 |
+| `args` | []string | `[]` | — | 附加到 command 之后的额外参数列表 |
+| `debug` | bool | `false` | — | 启用 JSON-RPC 协议 trace 日志（调试用） |
 
 **配置示例**：
 
@@ -321,6 +323,8 @@ worker:
   acp:
     command: "hermes acp"    # 或其他 ACP 兼容 Agent
     auto_approve: true       # 自动批准工具调用权限
+    args: ["--verbose"]      # 附加命令行参数
+    debug: true              # 启用协议 trace 日志
 ```
 
 **使用方式**：在 messaging 层指定 `worker_type: "acp"` 即可启用：
@@ -341,6 +345,7 @@ Agent B/C 通道配置加载器。
 |------|------|--------|----------|------|
 | `enabled` | bool | `true` | `HOTPLEX_AGENT_CONFIG_ENABLED` | 是否启用 Agent 配置加载（SOUL.md、AGENTS.md 等） |
 | `config_dir` | string | `~/.hotplex/agent-configs` | `HOTPLEX_AGENT_CONFIG_DIR` | 配置文件根目录。支持 `~` 和 `${VAR}` 展开 |
+| `inject_exclude` | []string | `[]` | — | 全局默认排除列表。列出的配置文件（如 `SOUL.md`、`MEMORY.md`）不会被加载和注入。平台级和 Bot 级可覆盖。`META-COGNITION.md` 始终注入（go:embed），不可排除 |
 
 **B 通道**（`<directives>`）：`META-COGNITION.md`（go:embed，始终首位）+ `SOUL.md` + `AGENTS.md` + `SKILLS.md`
 
@@ -368,6 +373,7 @@ AI-native 定时任务引擎：自然语言 prompt 作为 payload，结果投递
 | `max_concurrent_runs` | int | `3` | — | 最大并行 Job 执行数 |
 | `max_jobs` | int | `50` | — | 最大注册 Job 数 |
 | `default_timeout_sec` | int | `300` (5分钟) | — | 单 Job 执行超时（秒） |
+| `default_sandbox` | string | `""` | — | Cron Job 的默认 sandbox 模式覆盖。非空时应用于所有 cron Worker |
 | `tick_interval_sec` | int | `60` | — | 调度器 tick 间隔（秒） |
 | `yaml_config_path` | string | `""` | — | 外部 YAML 配置文件路径（可选） |
 | `jobs` | []map | `[]` | — | 内联 Job 定义（可选） |
@@ -452,6 +458,7 @@ webhook:
 | `dm_policy` | string | `allowlist` | `HOTPLEX_MESSAGING_{PLATFORM}_DM_POLICY` | 私聊消息策略：`allowlist` = 仅允许白名单用户 |
 | `group_policy` | string | `allowlist` | `HOTPLEX_MESSAGING_{PLATFORM}_GROUP_POLICY` | 群聊消息策略：`allowlist` = 仅允许白名单群组 |
 | `require_mention` | bool | `true` | `HOTPLEX_MESSAGING_{PLATFORM}_REQUIRE_MENTION` | 群聊中是否需要 @机器人 才响应 |
+| `inject_exclude` | []string | `[]` | — | 平台级默认排除列表。覆盖 `agent_config.inject_exclude`，被 Bot 级覆盖 |
 | `allow_from` | []string | `[]` | `HOTPLEX_MESSAGING_{PLATFORM}_ALLOW_FROM` | 全局白名单用户/群组（逗号分隔） |
 | `allow_dm_from` | []string | `[]` | `HOTPLEX_MESSAGING_{PLATFORM}_ALLOW_DM_FROM` | 私聊白名单用户（逗号分隔） |
 | `allow_group_from` | []string | `[]` | `HOTPLEX_MESSAGING_{PLATFORM}_ALLOW_GROUP_FROM` | 群聊白名单群组（逗号分隔） |
@@ -508,6 +515,7 @@ Yuanxin 是基于 Apache Pulsar 的企业消息平台适配器。
 | `worker_type` | string | 覆盖 Worker 类型 |
 | `sandbox` | string | 覆盖 CodexCLI sandbox 模式（bot 级） |
 | `acp_command` | string | 覆盖 ACP Agent 启动命令（bot 级，仅 `worker_type: acp` 时生效） |
+| `inject_exclude` | []string | 覆盖 agent config 排除列表（bot 级，覆盖平台级和全局级） |
 | `stt_*` | — | 覆盖 STT 配置（继承平台级 → messaging 级） |
 | `tts_*` | — | 覆盖 TTS 配置（继承平台级 → messaging 级） |
 
@@ -521,6 +529,7 @@ Yuanxin 是基于 Apache Pulsar 的企业消息平台适配器。
 | `worker_type` | string | 覆盖 Worker 类型 |
 | `sandbox` | string | 覆盖 CodexCLI sandbox 模式（bot 级） |
 | `acp_command` | string | 覆盖 ACP Agent 启动命令（bot 级，仅 `worker_type: acp` 时生效） |
+| `inject_exclude` | []string | 覆盖 agent config 排除列表（bot 级，覆盖平台级和全局级） |
 | `stt_*` | — | 覆盖 STT 配置 |
 | `tts_*` | — | 覆盖 TTS 配置 |
 
@@ -547,7 +556,13 @@ messaging.stt_*        ──→  slack.stt_* (如未设置)        ──→  s
 messaging.tts_*        ──→  slack.tts_* (如未设置)        ──→  slack.bots[i].tts_* (如未设置)
 ```
 
-**优先级**：`bot-level > platform-level (YAML/env) > messaging-level > Default()`
+`inject_exclude` 使用独立的三级 fallback（通过 `ResolveInjectExclude`）：
+
+```
+agent_config.inject_exclude  ──→  messaging.slack.inject_exclude  ──→  slack.bots[i].inject_exclude
+```
+
+**优先级**：`bot-level > platform-level (YAML/env) > global-level > Default()`
 
 仅 zero-value 字段被填充，已有值不会被覆盖。
 


### PR DESCRIPTION
## 变更摘要

文档中心巡逻 2026-06-01。自上次巡逻以来 28 个提交，映射到 7 处文档缺失。

## 修复内容

| 文档 | 修复 |
|------|------|
| `reference/configuration.md` §3.7.6 | ACP 新增 `args`、`debug` 配置字段 |
| `reference/configuration.md` §3.8 | agent_config 新增 `inject_exclude` 字段 |
| `reference/configuration.md` §3.10 | cron 新增 `default_sandbox` 字段 |
| `reference/configuration.md` §3.11.4 | 平台通用配置新增 `inject_exclude` |
| `reference/configuration.md` §3.11.8 | Slack/Feishu Bot 配置新增 per-bot `inject_exclude` + 传播链说明 |
| `explanation/agent-config-system.md` | 新增「文件排除」章节（inject_exclude 三级 fallback、解析规则、配置示例） |
| `reference/cli.md` | cron create 新增 `--worker-type` 标志 |

## 关联代码变更

- `feat(agentconfig): per-file injection control with inject_exclude (#594)`
- `feat(acp): Phase 3 — protocol version, multi-agent, debug trace (#595)`
- `feat(acp): Phase 2 — interaction completeness, reset optimization (#591)`
- `feat(worker/acp): Phase 1 — 核心功能补齐 (#590)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)