### PR TITLE
fix(acp): align buildStats output with gateway sessionAccumulator format

### DIFF
--- a/internal/worker/acp/mapper.go
+++ b/internal/worker/acp/mapper.go
@@ -458,26 +458,36 @@ func (m *ACPMapper) buildStats(result *PromptResult) map[string]any {
 		return stats
 	}
 	stats["stop_reason"] = result.StopReason
+
+	// Wrap token data in nested "usage" map for compatibility with the
+	// gateway's sessionAccumulator.mergePerTurnStats (Claude Code format).
+	// Keep the key names matching Anthropic API fields so the shared
+	// accumulator can extract them without a third format branch.
+	usage := map[string]any{}
 	if result.Usage.InputTokens > 0 {
-		stats["input_tokens"] = result.Usage.InputTokens
+		usage["input_tokens"] = result.Usage.InputTokens
 	}
 	if result.Usage.OutputTokens > 0 {
-		stats["output_tokens"] = result.Usage.OutputTokens
+		usage["output_tokens"] = result.Usage.OutputTokens
 	}
 	if result.Usage.ThoughtTokens > 0 {
-		stats["thought_tokens"] = result.Usage.ThoughtTokens
+		usage["thought_tokens"] = result.Usage.ThoughtTokens
 	}
 	if result.Usage.CachedReadTokens > 0 {
-		stats["cached_read_tokens"] = result.Usage.CachedReadTokens
+		usage["cache_read_input_tokens"] = result.Usage.CachedReadTokens
 	}
 	if result.Usage.CachedWriteTokens > 0 {
-		stats["cached_write_tokens"] = result.Usage.CachedWriteTokens
+		usage["cache_creation_input_tokens"] = result.Usage.CachedWriteTokens
 	}
 	if result.Usage.TotalTokens > 0 {
-		stats["total_tokens"] = result.Usage.TotalTokens
+		usage["total_tokens"] = result.Usage.TotalTokens
+	}
+	if len(usage) > 0 {
+		stats["usage"] = usage
 	}
 
 	// Include accumulated usage_update data (context size, cost).
+	// Cost stored as float64 for compatibility with events.ToFloat64().
 	m.usageMu.Lock()
 	if m.usage.ContextSize > 0 {
 		stats["context_size"] = m.usage.ContextSize
@@ -486,8 +496,7 @@ func (m *ACPMapper) buildStats(result *PromptResult) map[string]any {
 		stats["context_used"] = m.usage.ContextUsed
 	}
 	if m.usage.Cost != nil && m.usage.Cost.Amount > 0 {
-		costCopy := *m.usage.Cost
-		stats["cost"] = &costCopy
+		stats["total_cost_usd"] = m.usage.Cost.Amount
 	}
 	m.usageMu.Unlock()
 

--- a/internal/worker/acp/mapper_test.go
+++ b/internal/worker/acp/mapper_test.go
@@ -278,7 +278,8 @@ func TestMapPromptResponse_EndTurn(t *testing.T) {
 
 	done := envs[1].Event.Data.(events.DoneData)
 	require.True(t, done.Success)
-	require.Equal(t, 100, done.Stats["input_tokens"])
+	usage := done.Stats["usage"].(map[string]any)
+	require.Equal(t, 100, usage["input_tokens"])
 	require.Equal(t, "end_turn", done.Stats["stop_reason"])
 }
 

--- a/internal/worker/acp/worker_enhance_test.go
+++ b/internal/worker/acp/worker_enhance_test.go
@@ -262,9 +262,15 @@ func TestBuildStats_IncludesUsageSnapshot(t *testing.T) {
 
 	require.Equal(t, 128000, stats["context_size"])
 	require.Equal(t, 25000, stats["context_used"])
-	cost, ok := stats["cost"].(*CostInfo)
+	// Cost stored as float64 ("total_cost_usd") for gateway compatibility.
+	require.InDelta(t, 0.42, stats["total_cost_usd"], 0.001)
+
+	// Token data nested in "usage" map (Claude Code format).
+	usage, ok := stats["usage"].(map[string]any)
 	require.True(t, ok)
-	require.InDelta(t, 0.42, cost.Amount, 0.001)
+	require.Equal(t, 100, usage["input_tokens"])
+	require.Equal(t, 50, usage["output_tokens"])
+	require.Equal(t, 150, usage["total_tokens"])
 }
 
 func TestBuildStats_NoUsageSnapshot(t *testing.T) {
@@ -278,7 +284,11 @@ func TestBuildStats_NoUsageSnapshot(t *testing.T) {
 
 	require.Nil(t, stats["context_size"])
 	require.Nil(t, stats["context_used"])
-	require.Nil(t, stats["cost"])
+	require.Nil(t, stats["total_cost_usd"])
+	// usage map still present with token data.
+	usage, ok := stats["usage"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, 100, usage["input_tokens"])
 }
 
 // ─── MapNotification routes usage_update ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #609

ACP turn summary 中 token 计数和成本数据全部为 0，根因是 `buildStats()` 输出的扁平格式与 `mergePerTurnStats()` 不兼容。

## Changes

| File | Change |
|------|--------|
| `internal/worker/acp/mapper.go` | Token 数据嵌套为 `usage` map（对齐 Claude Code 格式），key 名改用 Anthropic API 标准；cost 改为 float64 `total_cost_usd` |
| `internal/worker/acp/mapper_test.go` | 验证嵌套 `usage` map |
| `internal/worker/acp/worker_enhance_test.go` | 验证 `usage` map + `total_cost_usd` float64 |

## Before vs After

**Before**: `buildStats()` 输出扁平 key → `mergePerTurnStats()` 完全不认 → token/cost 全为 0
```
stats["input_tokens"] = 100
stats["cached_read_tokens"] = 50
stats["cost"] = &CostInfo{Amount: 0.42}  // struct pointer → ToFloat64 returns 0
```

**After**: 输出嵌套 `usage` map → `mergePerTurnStats()` 走 Claude Code 分支 → 正确累加
```
stats["usage"] = map[string]any{
    "input_tokens": 100,
    "cache_read_input_tokens": 50,
}
stats["total_cost_usd"] = 0.42  // plain float64
```

## Test Plan

- [x] `make check` 通过（fmt + lint + test + build）
- [x] ACP 包测试全部通过（`-race`）
- [ ] CI 绿灯

## Out of Scope

Model name 追踪（需要从 `session_info_update` 中解析 `modelId` 并存入 mapper），单独 issue 跟进。