### PR TITLE
fix(worker/claudecode): resolve self-deadlock in writeTempFile (#606 regression)

### DIFF
--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -13,6 +13,7 @@ import (
 	"runtime/debug"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -116,7 +117,8 @@ type Worker struct {
 	// tempFiles tracks temp files created for --*-file flags (system prompt,
 	// MCP config). Cleaned up in Terminate. Using files avoids Windows cmd.exe
 	// mangling XML/JSON characters (<, >) in inline arguments.
-	tempFiles []string
+	tempFiles   []string
+	tempFilesMu sync.Mutex // protects tempFiles; separate from w.Mu to avoid deadlock in startLocked
 
 	// readLineFn reads the next line from stdout. If nil, readOutput uses
 	// proc.ReadLine. Inject a func for unit testing without a real process.
@@ -954,9 +956,9 @@ func (w *Worker) writeTempFile(prefix, content string) (string, error) {
 		_ = os.Remove(path)
 		return "", fmt.Errorf("close temp file: %w", err)
 	}
-	w.Mu.Lock()
+	w.tempFilesMu.Lock()
 	w.tempFiles = append(w.tempFiles, path)
-	w.Mu.Unlock()
+	w.tempFilesMu.Unlock()
 	return path, nil
 }
 
@@ -967,10 +969,10 @@ func (w *Worker) cleanupTempFiles() {
 	// Snapshot and clear the slice under w.Mu so a concurrent writeTempFile
 	// cannot append to a slice we are iterating, and so the field is left in
 	// a consistent nil state even if a file removal blocks.
-	w.Mu.Lock()
+	w.tempFilesMu.Lock()
 	files := w.tempFiles
 	w.tempFiles = nil
-	w.Mu.Unlock()
+	w.tempFilesMu.Unlock()
 	for _, path := range files {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			// Retry once after a short delay for Windows file-lock stragglers.


### PR DESCRIPTION
## Summary

Fixes #611 — self-deadlock in Claude Code worker that causes complete Feishu bot freeze.

## Root Cause

PR #606 added `w.Mu.Lock()` to `writeTempFile()` and `cleanupTempFiles()` to fix a data race on `tempFiles`. Both functions are called from `startLocked()` which already holds `w.Mu`:

```
Start() → w.Mu.Lock() → startLocked() → buildCLIArgs() → writeTempFile() → w.Mu.Lock() 💀
```

## Fix

Introduce a dedicated `tempFilesMu sync.Mutex` to protect `tempFiles`, decoupled from `w.Mu`:

- Preserves the data-race fix from #606
- No deadlock — `tempFilesMu` and `w.Mu` are independent locks
- No lock ordering concern — `tempFilesMu` is never held alongside `w.Mu`

## Deadlock Paths Fixed

| Path | Before | After |
|------|--------|-------|
| `startLocked → buildCLIArgs → writeTempFile` (L318/324/331) | 💀 Deadlock on `w.Mu` | ✅ `tempFilesMu` |
| `startLocked → cleanupTempFiles` (L200) | 💀 Deadlock on `w.Mu` | ✅ `tempFilesMu` |
| `Terminate → cleanupTempFiles` (L469) | ✅ Safe (no `w.Mu` held) | ✅ `tempFilesMu` |

## Testing

- [x] `go build` passes
- [x] Pre-commit hooks pass (gofmt + golangci-lint)
- [x] Deployed to production — Feishu bot responding normally
- [x] Audited codexcli, acp, ocs workers — no similar deadlock

## Regression

Introduced in #606 (`253f8da`).
