### PR TITLE
fix(gateway): session/bridge/shutdown defects + docs: security.csp (#613)

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -63,6 +63,7 @@ type GatewayDeps struct {
 	Hub             *gateway.Hub
 	SessionMgr      *session.Manager
 	EventStore      eventStoreProvider
+	EventCollector  *eventstore.Collector
 	Auth            *security.Authenticator
 	Handler         *gateway.Handler
 	Bridge          *gateway.Bridge
@@ -412,6 +413,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		Hub:             hub,
 		SessionMgr:      sm,
 		EventStore:      stores.event,
+		EventCollector:  stores.collector,
 		Auth:            auth,
 		Handler:         handler,
 		Bridge:          bridge,
@@ -822,16 +824,34 @@ func shutdownGateway(
 	closeSTTCache(shutdownCtx, log)
 	closeTTSCache(shutdownCtx, log)
 
-	// Terminate all workers BEFORE bridge.Shutdown() so forwardEvents
-	// goroutines (blocked on worker stdout) can exit.
+	// Mark bridge closed FIRST to prevent in-flight message handlers from
+	// creating new sessions/workers during shutdown. Without this, a handler
+	// can pass the b.closed check in StartSession, start a worker, and have
+	// it immediately killed by TerminateAllWorkers below (race #613 defect 2).
+	deps.Bridge.MarkClosed()
+
+	// Terminate all workers so forwardEvents goroutines (blocked on worker
+	// stdout) can exit.
 	deps.SessionMgr.TerminateAllWorkers()
 	opencodeserver.ShutdownSingleton(shutdownCtx)
 	codexcli.ShutdownSingleton(shutdownCtx)
 
-	deps.Bridge.Shutdown(shutdownCtx)
+	// Wait for forwardEvents goroutines to drain.
+	deps.Bridge.WaitForwarders(shutdownCtx)
 
 	cleanupWG.Wait()
 	pidTracker.RemoveAll()
+
+	// Close eventstore collector BEFORE SessionMgr.Close() to prevent
+	// the collector's background writer from writing to a closed DB.
+	// Without this, deferred stores.close() fires after SessionMgr has
+	// already closed the shared SQLite connection (#613 defect 3).
+	if deps.EventCollector != nil {
+		if err := deps.EventCollector.Close(); err != nil {
+			log.Warn("gateway: event collector close", "err", err)
+		}
+		deps.EventCollector = nil // prevent double-close in deferred stores.close()
+	}
 
 	if err := deps.SessionMgr.Close(); err != nil {
 		log.Warn("gateway: session manager close", "err", err)

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -360,6 +360,13 @@ func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, w
 		// fresh. This is safe because the old session key is orphaned: no worker
 		// holds a reference, and startOrResumeOnInUse will create a new session
 		// with the same deterministic key, effectively replacing the deleted one.
+		// TERMINATED sessions cannot be resumed because AttachWorker rejects
+		// non-active sessions (IsActive() returns false). Skip directly to
+		// fresh start to avoid wasting pool quota on doomed resume attempts.
+		if si.State == events.StateTerminated {
+			b.log.Info("bridge: orphan platform session terminated, starting fresh", "session_id", sessionID)
+			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID, injectExclude...)
+		}
 		if si.State == events.StateDeleted {
 			b.log.Info("bridge: orphan platform session already deleted, starting fresh", "session_id", sessionID)
 			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID, injectExclude...)
@@ -582,8 +589,24 @@ func isWorkerInUseError(err error) bool {
 // cancels the shutdown context to abort pending auto-retries,
 // then waits for all forwardEvents goroutines to complete or ctx to expire.
 func (b *Bridge) Shutdown(ctx context.Context) {
+	b.MarkClosed()
+	b.WaitForwarders(ctx)
+}
+
+// MarkClosed sets the closed flag and cancels the shutdown context so that:
+//   - New session creation (StartSession/resumeWithOpts) is rejected immediately.
+//   - handleWorkerExit skips crash recovery during shutdown.
+//   - Pending auto-retry goroutines are cancelled.
+//
+// Must be called BEFORE TerminateAllWorkers to prevent the race where an
+// in-flight message handler creates a worker that is immediately killed.
+func (b *Bridge) MarkClosed() {
 	b.closed.Store(true)
 	b.shutdownCancel()
+}
+
+// WaitForwarders waits for all forwardEvents goroutines to complete or ctx to expire.
+func (b *Bridge) WaitForwarders(ctx context.Context) {
 	done := make(chan struct{})
 	go func() {
 		b.fwdWg.Wait()

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -201,6 +201,13 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 		fc.firstEvent = false
 	}
 
+	// New turn detection: state(running) marks the beginning of a new turn.
+	// Reset doneReceived so crash detection applies to this turn (prevents
+	// stale true from a previous turn masking a crash in the current turn).
+	if env.Event.Type == events.State {
+		fc.doneReceived = false
+	}
+
 	if fc.turnTimer != nil && !fc.turnTimerFired.Load() {
 		fc.turnTimer.Reset(b.turnTimeout)
 	}
@@ -265,7 +272,6 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	if env.Event.Type == events.Done {
 		fc.turnText.Reset()
 		fc.turnStartTime = time.Now()
-		fc.doneReceived = false
 	}
 
 }

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -87,6 +87,10 @@ type Hub struct {
 	mu       sync.RWMutex
 	conns    map[*Conn]struct{}                // all active connections
 	sessions map[string]map[SessionWriter]bool // sessionID → connections
+	// everHadConn tracks sessions that have had at least one connection
+	// registered (WS or platform). Used to suppress "event dropped" debug
+	// log noise for sessions that never had connections (e.g. cron jobs).
+	everHadConn map[string]bool
 
 	// Incoming messages from all connections.
 	broadcast chan *EnvelopeWithConn
@@ -133,6 +137,7 @@ func NewHub(log *slog.Logger, cfgStore *config.ConfigStore) *Hub {
 		cfgStore:       cfgStore,
 		conns:          make(map[*Conn]struct{}),
 		sessions:       make(map[string]map[SessionWriter]bool),
+		everHadConn:    make(map[string]bool),
 		seqGen:         NewSeqGen(),
 		sessionDropped: make(map[string]bool),
 		broadcast:      make(chan *EnvelopeWithConn, broadcastQueueSize(cfg)),
@@ -211,6 +216,7 @@ func (h *Hub) JoinSession(sessionID string, conn *Conn) {
 		h.sessions[sessionID] = make(map[SessionWriter]bool)
 	}
 	h.sessions[sessionID][conn] = true
+	h.everHadConn[sessionID] = true
 }
 
 // LeaveSession unsubscribes conn from a session.
@@ -274,6 +280,7 @@ func (h *Hub) JoinPlatformSession(sessionID string, pc messaging.PlatformConn) {
 	}
 
 	h.sessions[sessionID][newPCEntry(pc, defaultPCEntryConfig(h.cfgStore.Load()), h.log)] = true
+	h.everHadConn[sessionID] = true
 }
 
 // sendBroadcast sends to the broadcast channel. Returns false if the hub is
@@ -467,8 +474,13 @@ func (h *Hub) routeMessage(msg *EnvelopeWithConn) {
 
 	if len(conns) == 0 {
 		metrics.GatewayEventsNoSubscribersDropped.WithLabelValues(string(msg.Env.Event.Type)).Inc()
-		h.log.Debug("gateway: event dropped, no connections",
-			"session_id", msg.Env.SessionID, "event_type", msg.Env.Event.Type)
+		// Suppress debug log for sessions that never had any connection
+		// registered (e.g. cron/internal sessions). These events are expected
+		// to have no subscribers — logging every one is just noise.
+		if h.everHadConn[msg.Env.SessionID] {
+			h.log.Debug("gateway: event dropped, no connections",
+				"session_id", msg.Env.SessionID, "event_type", msg.Env.Event.Type)
+		}
 		return
 	}
 

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -477,7 +477,10 @@ func (h *Hub) routeMessage(msg *EnvelopeWithConn) {
 		// Suppress debug log for sessions that never had any connection
 		// registered (e.g. cron/internal sessions). These events are expected
 		// to have no subscribers — logging every one is just noise.
-		if h.everHadConn[msg.Env.SessionID] {
+		h.mu.RLock()
+		hadConn := h.everHadConn[msg.Env.SessionID]
+		h.mu.RUnlock()
+		if hadConn {
 			h.log.Debug("gateway: event dropped, no connections",
 				"session_id", msg.Env.SessionID, "event_type", msg.Env.Event.Type)
 		}


### PR DESCRIPTION
## Changes

### Gateway Fixes (#613)
- **everHadConn data race** — `routeMessage` 读取 `everHadConn` 前加 `RLock`
- **Shutdown 序列拆分** — `MarkClosed` + `TerminateAllWorkers` + `WaitForwarders` 三阶段
- **TERMINATED fast-path** — 跳过 resume 直接 start fresh
- **Session state 竞态** — 5 状态机原子迁移修复

### Docs (#615 → merged)
- `docs/reference/configuration.md` — 记录 `security.csp` 配置项 + `HOTPLEX_SECURITY_CSP` 环境变量
- `configs/config.yaml` — CSP 示例注释
- `internal/security/csp.go` / `internal/webchat/server.go` — 注释中示例 IP
- `internal/security/headers_test.go` — 测试用例中示例 IP
- 所有示例 IP 已替换为 LAN 保留地址 `192.168.1.100`

Closes #613