### PR TITLE
docs(patrol): 2026-06-02 — record security.csp config key

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -200,6 +200,7 @@ db:
 | `tls_cert_file` | string | `/etc/hotplex/tls/server.crt` | — | TLS 证书文件路径 |
 | `tls_key_file` | string | `/etc/hotplex/tls/server.key` | — | TLS 私钥文件路径 |
 | `allowed_origins` | []string | `["*"]` | — | WebSocket CORS 允许的 Origin 列表 |
+| `csp` | string | `""` | `HOTPLEX_SECURITY_CSP` | 嵌入式 webchat SPA 与文档门户的 `Content-Security-Policy` 响应头。空值使用包级默认（**故意宽松**）：`connect-src` 使用 CSP scheme 关键字（`http:` / `https:` / `ws:` / `wss:`），允许 SPA 直连任意后端主机，零配置即可用于远程部署。启动时会输出 WARN 日志提示此默认值生效。锁定严格指令示例：`"default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' http://10.102.78.2:9999 ws://10.102.78.2:9999 wss://*; img-src 'self' data: blob:; font-src 'self' data:"` |
 | `work_dir_allowed_base_patterns` | []string | `[]` | — | 额外的工作目录白名单模式。支持 `~` 和 `${VAR}` 展开。程序内建默认值：`~/.hotplex/workspace`、`~/workspace`、`~/projects`、`~/work`、`~/dev`、`/var/hotplex/projects` |
 | `work_dir_forbidden_dirs` | []string | `[]` | — | 额外的工作目录黑名单。显式禁止的目录列表 |
 
@@ -757,6 +758,7 @@ HOTPLEX_SECURITY_API_KEY_1, HOTPLEX_SECURITY_API_KEY_2, ...
 | `HOTPLEX_ADMIN_TOKEN_1..N` | `admin.tokens` | 编号后缀，支持轮换 |
 | `HOTPLEX_SECURITY_API_KEY_1..N` | `security.api_keys` | 编号后缀，支持轮换 |
 | `HOTPLEX_SECURITY_API_KEY_HEADER` | `security.api_key_header` | 默认 `X-API-Key` |
+| `HOTPLEX_SECURITY_CSP` | `security.csp` | 覆盖 webchat/docs CSP；空值使用宽松默认（远程部署友好，启动 WARN 提示） |
 
 #### Agent Config
 


### PR DESCRIPTION
## 文档巡逻修复

**变更驱动**：PR #608（v1.23.0）新增 `security.csp` / `HOTPLEX_SECURITY_CSP` 配置项，使 webchat/docs 的 CSP 头可配置，但 `reference/configuration.md` 未同步更新。

## 变更内容

- `docs/reference/configuration.md` §3.4 security 表：新增 `csp` 行，说明默认值意图（宽松以支持零配置远程部署）+ 启动 WARN 提示 + 严格指令示例
- `docs/reference/configuration.md` 环境变量速查表：新增 `HOTPLEX_SECURITY_CSP` → `security.csp` 映射

## 影响范围

仅文档。无代码变更，无配置 schema 变更。

## 验证

```
make docs-build  →  Discovered 55 documents and 1 assets  ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)