### PR TITLE
fix(security): replace real IP with LAN example in CSP comments/tests

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -123,7 +123,7 @@ security:
   # A startup WARN log fires when this default is in effect to flag the
   # production exposure. Pin a strict directive to silence the warning and
   # restrict the SPA, e.g.:
-  #   csp: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' http://10.102.78.2:9999 ws://10.102.78.2:9999 wss://*; img-src 'self' data: blob:; font-src 'self' data:"
+  #   csp: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' http://192.168.1.100:9999 ws://192.168.1.100:9999 wss://*; img-src 'self' data: blob:; font-src 'self' data:"
   # Can be overridden at runtime by HOTPLEX_SECURITY_CSP env var.
   csp: ""
 

--- a/internal/security/csp.go
+++ b/internal/security/csp.go
@@ -8,7 +8,7 @@ import "strings"
 // It is intentionally permissive: connect-src uses the CSP scheme keywords
 // (http: / https: / ws: / wss:), which the browser interprets as "any host
 // over the matching scheme". This lets the SPA reach backends on remote IPs
-// (e.g. http://10.102.78.2:9999) without configuration — the explicit
+// (e.g. http://192.168.1.100:9999) without configuration — the explicit
 // trade-off the project chose between "out-of-the-box usability" and
 // "strict-but-needs-config". Production deployments should override this
 // with security.csp / HOTPLEX_SECURITY_CSP pinning the actual host(s).

--- a/internal/security/headers_test.go
+++ b/internal/security/headers_test.go
@@ -52,7 +52,7 @@ func TestIsPermissiveCSP(t *testing.T) {
 		{"data: is not permissive", "img-src 'self' data: blob:", false},
 		{"blob: is not permissive", "img-src 'self' blob:", false},
 		{"default real_example_strict unchanged", "default-src 'self'; script-src 'self' 'unsafe-inline'; " +
-			"style-src 'self' 'unsafe-inline'; connect-src 'self' http://10.102.78.2:9999", false},
+			"style-src 'self' 'unsafe-inline'; connect-src 'self' http://192.168.1.100:9999", false},
 		{"real_example_permissive trips", "default-src 'self'; connect-src 'self' http: wss://*", true},
 	}
 	for _, tt := range cases {

--- a/internal/webchat/server.go
+++ b/internal/webchat/server.go
@@ -16,7 +16,7 @@ var fileServer = http.FileServerFS(spaFS)
 //
 // Pass an empty string for csp to use DefaultWebChatCSP; pass a custom
 // directive when serving from a non-localhost host (e.g. reverse-prod on
-// http://10.102.78.2:9999). Whitespace-only csp is treated as empty.
+// http://192.168.1.100:9999). Whitespace-only csp is treated as empty.
 //
 // Routing strategy:
 //   - /_next/*  → static assets with aggressive cache headers (hashed filenames)


### PR DESCRIPTION
## Changes

将 CSP 相关注释和测试中的真实内网 IP `10.102.78.2` 替换为 RFC 1918 保留地址 `192.168.1.100`。

### 影响文件
- `configs/config.yaml` — CSP 示例注释
- `internal/security/csp.go` — 代码注释
- `internal/security/headers_test.go` — 测试用例
- `internal/webchat/server.go` — 代码注释