### PR TITLE
fix(gateway): PR #614 review findings — P1 double-close + P2 everHadConn + P2 comment

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -844,13 +844,12 @@ func shutdownGateway(
 
 	// Close eventstore collector BEFORE SessionMgr.Close() to prevent
 	// the collector's background writer from writing to a closed DB.
-	// Without this, deferred stores.close() fires after SessionMgr has
-	// already closed the shared SQLite connection (#613 defect 3).
+	// Collector.Close() is idempotent (sync.Once), so the deferred
+	// stores.close() calling Close() again is safe.
 	if deps.EventCollector != nil {
 		if err := deps.EventCollector.Close(); err != nil {
 			log.Warn("gateway: event collector close", "err", err)
 		}
-		deps.EventCollector = nil // prevent double-close in deferred stores.close()
 	}
 
 	if err := deps.SessionMgr.Close(); err != nil {

--- a/internal/eventstore/collector.go
+++ b/internal/eventstore/collector.go
@@ -85,11 +85,12 @@ func kindOf(req *captureRequest) string {
 //   - Timer: accumulator age exceeds deltaFlushInterval (runWriter ticker)
 //   - Event: MessageEnd or next storable event (hot path, synchronous)
 type Collector struct {
-	store    EventStore
-	captureC chan *captureRequest
-	closeC   chan struct{}
-	closeWg  sync.WaitGroup
-	log      *slog.Logger
+	store     EventStore
+	captureC  chan *captureRequest
+	closeC    chan struct{}
+	closeWg   sync.WaitGroup
+	closeOnce sync.Once
+	log       *slog.Logger
 
 	flushInterval time.Duration // ticker interval for batch flush (default: collectorFlushInterval)
 	deltaFlush    time.Duration // max age before flushing accumulated deltas (default: deltaFlushInterval)
@@ -315,39 +316,41 @@ func (c *Collector) Flush() error {
 
 // Close drains the capture channel and flushes remaining events.
 func (c *Collector) Close() error {
-	// Swap accumulator maps under lock, flush outside to avoid deadlock.
-	c.accumMu.Lock()
-	pending := c.accum
-	pendingReasoning := c.reasoningAccum
-	c.accum = nil
-	c.reasoningAccum = nil
-	c.accumMu.Unlock()
+	c.closeOnce.Do(func() {
+		// Swap accumulator maps under lock, flush outside to avoid deadlock.
+		c.accumMu.Lock()
+		pending := c.accum
+		pendingReasoning := c.reasoningAccum
+		c.accum = nil
+		c.reasoningAccum = nil
+		c.accumMu.Unlock()
 
-	for sid, acc := range pending {
-		if acc.count > 0 {
-			req := acc.toRequest(sid)
-			select {
-			case c.captureC <- req:
-			case <-time.After(5 * time.Second):
-				c.log.Error("eventstore: accumulator flush dropped during close",
-					"session_id", sid, "kind", "turn")
+		for sid, acc := range pending {
+			if acc.count > 0 {
+				req := acc.toRequest(sid)
+				select {
+				case c.captureC <- req:
+				case <-time.After(5 * time.Second):
+					c.log.Error("eventstore: accumulator flush dropped during close",
+						"session_id", sid, "kind", "turn")
+				}
 			}
 		}
-	}
-	for sid, acc := range pendingReasoning {
-		if acc.count > 0 {
-			req := acc.toRequest(sid)
-			select {
-			case c.captureC <- req:
-			case <-time.After(5 * time.Second):
-				c.log.Error("eventstore: accumulator flush dropped during close",
-					"session_id", sid, "kind", "reasoning")
+		for sid, acc := range pendingReasoning {
+			if acc.count > 0 {
+				req := acc.toRequest(sid)
+				select {
+				case c.captureC <- req:
+				case <-time.After(5 * time.Second):
+					c.log.Error("eventstore: accumulator flush dropped during close",
+						"session_id", sid, "kind", "reasoning")
+				}
 			}
 		}
-	}
 
-	close(c.closeC)
-	c.closeWg.Wait()
+		close(c.closeC)
+		c.closeWg.Wait()
+	})
 	return nil
 }
 

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -331,7 +331,8 @@ var _ = events.Clone // compile-time check that Clone is accessible
 //  1. No DB record → Create + Start (--session-id)
 //  2. Worker alive → Reuse (forward message)
 //  3. No worker, state=CREATED → Start (--session-id)
-//  4. No worker, state=RUNNING/IDLE/TERMINATED → Resume (--resume)
+//  4. No worker, state=TERMINATED/DELETED → Start fresh (skip resume)
+//  5. No worker, state=RUNNING/IDLE → Resume (--resume)
 //     If Resume fails (files gone/corrupted), fall back to Start (--session-id)
 func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, workerType, workDir, sandbox, platform string, platformKey map[string]string, botID string, injectExclude ...string) error {
 	b.log.Debug("bridge: StartPlatformSession called", "session_id", sessionID, "owner_id", ownerID, "worker_type", workerType, "work_dir", workDir, "sandbox", sandbox, "platform", platform, "platform_key", platformKey, "bot_id", botID)
@@ -355,14 +356,12 @@ func (b *Bridge) StartPlatformSession(ctx context.Context, sessionID, ownerID, w
 			b.log.Info("bridge: orphan platform session unstarted, starting fresh", "session_id", sessionID)
 			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID, injectExclude...)
 		}
-		// RUNNING/IDLE/TERMINATED — try Resume to preserve conversation history.
-		// DELETED sessions cannot be resumed (session state is DELETED), so we start
-		// fresh. This is safe because the old session key is orphaned: no worker
-		// holds a reference, and startOrResumeOnInUse will create a new session
-		// with the same deterministic key, effectively replacing the deleted one.
-		// TERMINATED sessions cannot be resumed because AttachWorker rejects
-		// non-active sessions (IsActive() returns false). Skip directly to
-		// fresh start to avoid wasting pool quota on doomed resume attempts.
+		// TERMINATED/DELETED — start fresh (skip resume).
+		// AttachWorker rejects non-active sessions (IsActive() returns false),
+		// so TERMINATED sessions cannot be resumed. DELETED sessions have no
+		// DB record to resume from. In both cases, startOrResumeOnInUse creates
+		// a new session with the same deterministic key, effectively replacing
+		// the orphaned one.
 		if si.State == events.StateTerminated {
 			b.log.Info("bridge: orphan platform session terminated, starting fresh", "session_id", sessionID)
 			return b.startOrResumeOnInUse(ctx, sessionID, ownerID, worker.WorkerType(workerType), workDir, platform, platformKey, botID, injectExclude...)

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -236,6 +236,7 @@ func (h *Hub) removeSession(sessionID string, conn SessionWriter) {
 		if len(conns) == 0 {
 			delete(h.sessions, sessionID)
 			delete(h.sessionDropped, sessionID)
+			delete(h.everHadConn, sessionID)
 			h.seqGen.Remove(sessionID)
 		}
 	}


### PR DESCRIPTION
## Fixes for PR #614 code review (hotplex-ai)

### P1 — Collector double-close panic on clean shutdown
`Collector.Close()` 用 `sync.Once` 包裹，幂等防止 `close(c.closeC)` 二次 panic。
`gateway_run.go` 移除无效的 `deps.EventCollector = nil`（nil 的是 `GatewayDeps` 的副本，不影响 `gatewayStores.collector`）。

### P2 — everHadConn map 无界增长
`removeSession()` 在 `len(conns) == 0` 分支添加 `delete(h.everHadConn, sessionID)`。

### P2 — bridge.go 注释与代码不同步
函数摘要和内联注释更新为：TERMINATED/DELETED → start fresh；RUNNING/IDLE → try Resume。

### Files
- `internal/eventstore/collector.go` — `closeOnce sync.Once` + `Close()` idempotent
- `cmd/hotplex/gateway_run.go` — 移除无效 nil 赋值，更新注释
- `internal/gateway/hub.go` — `removeSession` 清理 `everHadConn`
- `internal/gateway/bridge.go` — 注释与代码对齐

Refs #614