### PR TITLE
feat(feishu): add interactive card buttons for permission/question/elicitation

### DIFF
--- a/docs/specs/Feishu-Interactive-Card-Buttons-Spec.md
+++ b/docs/specs/Feishu-Interactive-Card-Buttons-Spec.md
@@ -12,9 +12,8 @@ research_sources:
   - Lark SDK v3.5.3 ws/client.go, card/card.go, card/model.go
 sdk_upgrade:
   from: v3.5.3
-  to: v3.9.1
-  breaking_changes: "ReceiveIdTypeChatId constant removed → use string \"chat_id\" directly"
-  test_result: ALL PASS (0 failures)
+  to: v3.9.3
+  notes: "v3.9.3 EventDispatcher natively supports OnP2CardActionTrigger; no SDK patching or go.mod replace required"
 ---
 
 # Feishu Interactive Card Buttons Spec
@@ -35,41 +34,25 @@ sdk_upgrade:
 
 ### 1.3 根因
 
-飞书交互式按钮不可用的根本原因是 **Lark SDK（v3.5.3 ~ v3.9.1 所有版本）的 WebSocket 客户端未实现卡片回调处理**：
+飞书交互式按钮的回调路径在 **Lark SDK v3.9.3** 中已得到原生支持。SDK 的 `EventDispatcher` 内置 `OnP2CardActionTrigger` 注册入口：
 
-```go
-// ws/client.go handleDataFrame() — v3.5.3 和 v3.9.1 代码完全相同
-switch MessageType(type_) {
-case MessageTypeEvent:
-    rsp, err = c.eventHandler.Do(ctx, pl)
-case MessageTypeCard:
-    return  // ← 卡片回调消息被静默丢弃！所有版本均未修复
-}
-```
+- 卡片按钮点击事件通过 `MessageTypeEvent` 帧传输，event_type 字段为 `card.action.trigger`
+- `EventDispatcher.Do()` 通过 `callbackType2CallbackHandler` 自动路由到注册的 `OnP2CardActionTrigger` 处理器
+- 无需任何 SDK 补丁、go.mod replace 指令或 vendor 目录覆盖
 
-SDK 的 `cardHandler` 字段和 `WithCardHandler` 选项已定义但被注释掉，且 **v3.5.3 → v3.9.1 的 4 个大版本升级均未解除注释**。
-
-**关键结论**：飞书 WS 协议**支持**传输卡片回调消息（`MessageTypeCard`），SDK 已定义处理框架但从未完成实现。升级 SDK 无法解决此问题，必须自行补丁。
+**关键结论**：升级到 SDK v3.9.3 即可使用 `OnP2CardActionTrigger` 路由卡片回调，无需修改 SDK 源码。
 
 ---
 
 ## 2. 方案设计
 
-### 2.1 方案选择：SDK 补丁 + Handler 注册
+### 2.1 方案：EventDispatcher.OnP2CardActionTrigger
 
-| 方案 | 描述 | 优点 | 缺点 |
-|------|------|------|------|
-| **A. SDK 补丁（推荐）** | go.mod replace 指向本地补丁版 SDK | 改动最小（~10行），复用现有 WS 连接 | 维护本地 SDK fork |
-| B. Webhook 混合模式 | WS 收消息 + HTTP 收卡片回调 | 不改 SDK | 需额外 HTTP 端口和公网可达 |
-| C. 自定义 WS 拦截器 | 在 SDK 处理前拦截原始帧 | 不改 SDK | 绕过 SDK 抽象层，脆弱 |
-| D. 等待官方 SDK 更新 | 无改动 | 最安全 | 时间不可控 |
+**采用方案**：使用 SDK v3.9.3 内置的 `EventDispatcher.OnP2CardActionTrigger` 路由卡片按钮回调。
 
-**选定方案 A**：SDK 补丁。
-
-理由：
-1. 补丁量极小（启用 `WithCardHandler` + 路由 `MessageTypeCard`），影响面可控
-2. 复用现有 WS 长连接，无需新增 HTTP 端口或公网域名
-3. 可向上游提交 PR，未来官方合并后移除 replace 指令
+- **触发路径**：卡片按钮点击 → 飞书 WS → `MessageTypeEvent` 帧（event_type=`card.action.trigger`）→ `EventDispatcher.Do()` → `callbackType2CallbackHandler` → `OnP2CardActionTrigger` 处理器
+- **优势**：无 SDK 源码修改、无 `go.mod` replace、无 vendor 补丁；与官方 SDK 升级路径完全兼容
+- **代价**：回调数据由 `callback.CardActionTriggerEvent` 包装（非裸 `CardAction`），返回类型为 `*callback.CardActionTriggerResponse`
 
 ### 2.2 架构总览
 
@@ -78,24 +61,24 @@ SDK 的 `cardHandler` 字段和 `WithCardHandler` 选项已定义但被注释掉
                         │           HotPlex Gateway               │
                         │                                         │
   Feishu WS ───────────▶│  ws.go ──▶ newEventHandler()            │
-  (MessageTypeCard)     │            │                             │
+  (MessageTypeEvent,    │            │                             │
+   event_type=          │            ├── OnP2CardActionTrigger     │
+   card.action.trigger) │            │     └─▶ handleCardAction   │
+                        │            │          Trigger()         │
                         │            ├── P2MessageReceiveV1        │
-                        │            ├── P2ChatAccessEvent...      │
-                        │            └── [新增] cardHandler         │
-                        │                 │                        │
-                        │                 ▼                        │
-                        │          handleCardAction()              │
-                        │            │                             │
-                        │            ├── 验证操作者身份              │
-                        │            ├── Complete(requestID)       │
-                        │            ├── SendResponse(metadata)    │
-                        │            └── 返回更新卡片（原地变色）     │
-                        │                 │                        │
+                        │            └── P2ChatAccessEvent...      │
+                        │                                          │
+                        │  handleCardActionTrigger():              │
+                        │    ├── 验证操作者身份                    │
+                        │    ├── Interactions.Complete(requestID)  │
+                        │    ├── pi.SendResponse(metadata)         │
+                        │    └── 返回 wrapResolvedCard(...)        │
+                        │                                          │
   Slack Socket ─────────▶│  slack/interaction.go (已实现 ✅)        │
-  (BlockActions)         │                                         │
-                        │                                         │
+  (BlockActions)         │                                          │
+                        │                                          │
   WebChat WS ───────────▶│  gateway/conn.go → 浏览器前端 (已实现 ✅) │
-  (AEP events)           │                                         │
+  (AEP events)           │                                          │
                         └─────────────────────────────────────────┘
 ```
 
@@ -103,39 +86,9 @@ SDK 的 `cardHandler` 字段和 `WithCardHandler` 选项已定义但被注释掉
 
 ## 3. 实现细节
 
-### 3.1 Phase 1: Lark SDK 补丁
+### 3.1 Phase 1: 无 SDK 改动
 
-**文件**: `go.mod` + vendor/replace
-
-补丁内容（基于 `github.com/larksuite/oapi-sdk-go/v3@v3.5.3/ws/client.go`）：
-
-```go
-// 1. 取消注释 WithCardHandler（原第 54-58 行）
-func WithCardHandler(handler *larkcard.CardActionHandler) ClientOption {
-    return func(cli *Client) {
-        cli.cardHandler = handler
-    }
-}
-
-// 2. 修改 handleMessage 中 MessageTypeCard 分支（原第 424-425 行）
-case MessageTypeCard:
-    if c.cardHandler != nil {
-        rsp, err = c.cardHandler.DoHandle(ctx, &larkevent.EventReq{
-            Header: frame.Headers.Map(),
-            Body:   pl,
-        })
-    } else {
-        return
-    }
-```
-
-**go.mod 改动**:
-
-```
-replace github.com/larksuite/oapi-sdk-go/v3 => ./vendor/patches/oapi-sdk-go-v3
-```
-
-将补丁版 SDK 放入 `vendor/patches/oapi-sdk-go-v3/`，仅修改 `ws/client.go` 一个文件。
+Lark SDK v3.9.3 的 `EventDispatcher` 已原生支持卡片回调（`OnP2CardActionTrigger`），无需任何 SDK 源码补丁、`go.mod` replace 指令或 `vendor/patches/` 目录。代码改动完全在 `internal/messaging/feishu/` 内部。
 
 ### 3.2 Phase 2: Feishu Adapter 注册卡片处理器
 
@@ -144,27 +97,14 @@ replace github.com/larksuite/oapi-sdk-go/v3 => ./vendor/patches/oapi-sdk-go-v3
 ```go
 func (a *Adapter) newEventHandler() *dispatcher.EventDispatcher {
     return dispatcher.NewEventDispatcher("", "").
-        OnP2MessageReceiveV1(a.handleMessage).
-        OnP2MessageReadV1(func(_ context.Context, _ *larkim.P2MessageReadV1) error { return nil }).
-        OnP2MessageReactionCreatedV1(func(_ context.Context, _ *larkim.P2MessageReactionCreatedV1) error { return nil }).
-        OnP2MessageReactionDeletedV1(func(_ context.Context, _ *larkim.P2MessageReactionDeletedV1) error { return nil }).
+        // Card action handlers are registered first — EventDispatcher.Do()
+        // checks callbacks before events, mirroring that priority order.
+        OnP2CardActionTrigger(a.handleCardActionTrigger).
+        OnP2MessageReceiveV1(func(ctx context.Context, event *larkim.P2MessageReceiveV1) error {
+            return a.handleMessage(ctx, event)
+        }).
+        // ... 其他 P2 事件处理器（Read/Reaction/ChatAccess）...
         OnP2ChatAccessEventBotP2pChatEnteredV1(a.handleChatEntered)
-}
-
-// 新增：构建卡片回调处理器
-func (a *Adapter) newCardHandler() *larkcard.CardActionHandler {
-    return larkcard.NewCardActionHandler("", "", a.handleCardAction)
-}
-
-func (a *Adapter) runWebSocket(ctx context.Context) {
-    // ... existing reconnect loop ...
-    client := ws.NewClient(a.appID, a.appSecret,
-        ws.WithEventHandler(a.newEventHandler()),
-        ws.WithCardHandler(a.newCardHandler()),  // ← 新增
-        ws.WithAutoReconnect(true),
-        ws.WithLogger(SlogLogger{Logger: a.Log}),
-    )
-    // ...
 }
 ```
 
@@ -176,107 +116,118 @@ func (a *Adapter) runWebSocket(ctx context.Context) {
 package feishu
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
+	"context"
+	"fmt"
+	"runtime/debug"
 
-    larkcard "github.com/larksuite/oapi-sdk-go/v3/card"
-    "github.com/hrygo/hotplex/internal/messaging"
-    "github.com/hrygo/hotplex/pkg/events"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
+
+	"github.com/hrygo/hotplex/internal/messaging"
 )
 
-// 交互动作前缀，与 Slack 的 hp_interact/ 前缀保持语义一致
-const actionPrefix = "hp_interact"
-
-// 交互动作类型
 const (
-    actionAllow   = "allow"
-    actionDeny    = "deny"
-    actionAnswer  = "answer"
-    actionAccept  = "accept"
-    actionDecline = "decline"
+	cardActionAllow   = "allow"
+	cardActionDeny    = "deny"
+	cardActionAnswer  = "answer"
+	cardActionAccept  = "accept"
+	cardActionDecline = "decline"
 )
 
-// handleCardAction 处理飞书卡片按钮回调。
-// 返回值用于原地更新卡片内容（变色显示审批结果）。
-func (a *Adapter) handleCardAction(ctx context.Context, cardAction *larkcard.CardAction) (interface{}, error) {
-    if cardAction.Action == nil || cardAction.Action.Value == nil {
-        return nil, nil
-    }
+// handleCardActionTrigger 处理飞书卡片按钮回调。
+// 注册入口：newEventHandler().OnP2CardActionTrigger
+// 返回值：原地更新卡片内容（变色显示审批结果），通过 wrapResolvedCard 包装。
+func (a *Adapter) handleCardActionTrigger(_ context.Context, event *callback.CardActionTriggerEvent) (resp *callback.CardActionTriggerResponse, err error) {
+	// Panic recovery: WS handler convention (see ws.go). Named returns are
+	// required so the defer can set `err` and prevent a higher-level crash.
+	defer func() {
+		if r := recover(); r != nil {
+			a.Log.Error("feishu: panic in card action handler", "panic", r, "stack", string(debug.Stack()))
+			err = fmt.Errorf("feishu card action panic: %v", r)
+		}
+	}()
 
-    // 提取按钮 value 中的 action 和 request_id
-    val := cardAction.Action.Value
-    actionType, _ := val["action"].(string)
-    requestID, _ := val["request_id"].(string)
+	if event == nil || event.Event == nil || event.Event.Action == nil || event.Event.Action.Value == nil {
+		return nil, nil
+	}
 
-    if actionType == "" || requestID == "" {
-        return nil, nil
-    }
+	val := event.Event.Action.Value
+	requestID, _ := val["request_id"].(string)
+	actionType, _ := val["action"].(string)
 
-    // 完整 action key: "hp_interact/allow/req_xxx"
-    actionKey := actionPrefix + "/" + actionType + "/" + requestID
+	openID := ""
+	if event.Event.Operator != nil {
+		openID = event.Event.Operator.OpenID
+	}
 
-    // 验证操作者身份
-    operatorID := cardAction.OpenID
+	var (
+		metadata      map[string]any
+		resolvedLabel string
+		resolvedColor string
+	)
 
-    // 从 InteractionManager 中完成交互
-    pi, ok := a.Interactions.Complete(requestID)
-    if !ok {
-        // 已被响应或超时
-        return buildResolvedCard(actionDeny, "已过期或已响应", ""), nil
-    }
+	switch actionType {
+	case cardActionAllow:
+		metadata = messaging.BuildPermissionResponse(requestID, true, "")
+		resolvedLabel = "✅ 已允许"
+		resolvedColor = "green"
+	case cardActionDeny:
+		metadata = messaging.BuildPermissionResponse(requestID, false, "user denied")
+		resolvedLabel = "🚫 已拒绝"
+		resolvedColor = "red"
+	case cardActionAnswer:
+		answer, _ := val["answer"].(string)
+		if answer == "" {
+			answer, _ = val["label"].(string)
+		}
+		metadata = messaging.BuildQuestionResponse(requestID, answer)
+		resolvedLabel = "✅ 已回答"
+		resolvedColor = "green"
+	case cardActionAccept:
+		metadata = messaging.BuildElicitationResponse(requestID, "accept")
+		resolvedLabel = "✅ 已接受"
+		resolvedColor = "green"
+	case cardActionDecline:
+		metadata = messaging.BuildElicitationResponse(requestID, "decline")
+		resolvedLabel = "🚫 已拒绝"
+		resolvedColor = "red"
+	default:
+		a.Log.Warn("feishu: unknown card action type", "action", actionType, "request_id", requestID)
+		return nil, nil
+	}
 
-    // 验证所有者
-    if pi.OwnerID != "" && pi.OwnerID != operatorID {
-        // 非所有者操作，重新注册（不消耗）
-        a.Interactions.Register(pi)
-        return nil, nil
-    }
+	// Owner check BEFORE Complete — preserves the interaction for non-owner
+	// clicks. If we Completed first, the original watchTimeout goroutine
+	// (still running) would race the re-Registered entry.
+	pending, exists := a.Interactions.Get(requestID)
+	if !exists {
+		return wrapResolvedCard(buildResolvedCard("deny", "已过期或已响应", "")), nil
+	}
+	if pending.OwnerID != "" && pending.OwnerID != openID {
+		return nil, nil
+	}
 
-    // 构建响应 metadata 并发送
-    var metadata map[string]any
-    var resultLabel string
-    var resultColor string
+	pi, ok := a.Interactions.Complete(requestID)
+	if !ok {
+		return wrapResolvedCard(buildResolvedCard("deny", "已过期或已响应", "")), nil
+	}
 
-    switch {
-    case actionType == actionAllow:
-        metadata = messaging.BuildPermissionResponse(requestID, true, "")
-        resultLabel = "✅ 已允许"
-        resultColor = larkcard.TemplateGreen
-    case actionType == actionDeny:
-        metadata = messaging.BuildPermissionResponse(requestID, false, "user denied")
-        resultLabel = "🚫 已拒绝"
-        resultColor = larkcard.TemplateRed
-    case actionType == actionAnswer:
-        answer, _ := val["answer"].(string)
-        if answer == "" {
-            answer, _ = val["label"].(string)
-        }
-        metadata = messaging.BuildQuestionResponse(requestID, answer)
-        resultLabel = "✅ 已回答"
-        resultColor = larkcard.TemplateGreen
-    case actionType == actionAccept:
-        metadata = messaging.BuildElicitationResponse(requestID, "accept")
-        resultLabel = "✅ 已接受"
-        resultColor = larkcard.TemplateGreen
-    case actionType == actionDecline:
-        metadata = messaging.BuildElicitationResponse(requestID, "decline")
-        resultLabel = "🚫 已拒绝"
-        resultColor = larkcard.TemplateRed
-    default:
-        return nil, nil
-    }
+	if pi.SendResponse != nil {
+		pi.SendResponse(metadata)
+	}
 
-    // 发送响应到 Worker
-    pi.SendResponse(metadata)
+	a.Log.Info("feishu: interaction resolved via card button",
+		"request_id", requestID, "action", actionType, "operator", openID)
 
-    a.Log.Info("feishu: interaction resolved via card button",
-        "request_id", requestID,
-        "action", actionType,
-        "operator", operatorID)
+	return wrapResolvedCard(buildResolvedCard(actionType, resolvedLabel, resolvedColor)), nil
+}
 
-    // 返回更新后的卡片（原地变色）
-    return buildResolvedCard(actionType, resultLabel, resultColor), nil
+func wrapResolvedCard(card map[string]any) *callback.CardActionTriggerResponse {
+	return &callback.CardActionTriggerResponse{
+		Card: &callback.Card{
+			Type: "card_json",
+			Data: card,
+		},
+	}
 }
 ```
 
@@ -545,7 +496,7 @@ Fallback: 文字 "allow <id>" / "deny <id>"
 ```
 交互卡: CardKit v2 action 元素 + button 元素
 动作值: {"action": "<type>", "request_id": "<id>"}
-回调: MessageTypeCard → CardActionHandler → handleCardAction()
+回调: MessageTypeEvent (event_type=card.action.trigger) → OnP2CardActionTrigger → handleCardActionTrigger()
 Fallback: 文字 "允许/拒绝"（保留 checkPendingInteraction）
 ```
 
@@ -565,7 +516,7 @@ Worker → AEP PermissionRequest → Gateway Handler → PlatformConn.WriteCtx
                                    用户点击按钮   用户点击按钮    用户点击按钮
                                           │              │              │
                                           ▼              ▼              ▼
-                                  handleCardAction  handleInteraction  sendResponse
+                                   handleCardActionTrigger  handleInteraction  sendResponse
                                           │              │              │
                                           └──────┬───────┘──────────────┘
                                                  ▼
@@ -601,7 +552,7 @@ Worker → AEP PermissionRequest → Gateway Handler → PlatformConn.WriteCtx
 | 文字 fallback | 发送按钮卡后，用户不打字直接发"允许" | 文字通道仍可用，按钮卡显示"已过期" |
 | 超时 | 发送按钮卡后等待 5min | 自动拒绝，卡片不变色 |
 | 非所有者 | 其他用户点击按钮 | 操作被忽略，卡片不变 |
-| SDK 补丁 | WS 收到 MessageTypeCard 帧 | 正确路由到 cardHandler，不再丢弃 |
+| EventDispatcher 路由 | WS 收到 MessageTypeEvent 帧（event_type=card.action.trigger）| 自动路由到 OnP2CardActionTrigger → handleCardActionTrigger |
 
 ### 5.3 验收标准
 
@@ -619,15 +570,13 @@ Worker → AEP PermissionRequest → Gateway Handler → PlatformConn.WriteCtx
 
 | 文件 | 操作 | 改动量 | 说明 |
 |------|------|-------|------|
-| `vendor/patches/oapi-sdk-go-v3/ws/client.go` | 修改 | ~10行 | 启用 WithCardHandler + 路由 MessageTypeCard |
-| `go.mod` | 修改 | 1行 | 添加 replace 指令 |
-| `internal/messaging/feishu/card_action.go` | **新建** | ~120行 | 卡片回调处理器 |
+| `internal/messaging/feishu/card_action.go` | **新建** | ~135行 | handleCardActionTrigger + wrapResolvedCard + panic recovery |
 | `internal/messaging/feishu/card_template.go` | 修改 | ~150行 | 新增 4 个卡片构建函数 |
 | `internal/messaging/feishu/interaction.go` | 修改 | ~30行 | 切换到带按钮卡片、删除过时注释 |
-| `internal/messaging/feishu/ws.go` | 修改 | ~10行 | 注册 newCardHandler |
+| `internal/messaging/feishu/ws.go` | 修改 | ~5行 | 在 newEventHandler() 链中添加 OnP2CardActionTrigger |
 | `internal/messaging/feishu/AGENTS.md` | 修改 | ~5行 | 更新文档 |
 
-**总改动量**：~325 行（含测试）
+**总改动量**：~325 行（含测试），其中 SDK 部分 0 改动
 
 ---
 
@@ -635,17 +584,32 @@ Worker → AEP PermissionRequest → Gateway Handler → PlatformConn.WriteCtx
 
 | 风险 | 影响 | 概率 | 缓解 |
 |------|------|------|------|
-| SDK 补丁与未来官方更新冲突 | 低 | 中 | 补丁范围极小（2处），可轻松 rebase；向上游提 PR |
-| 飞书 WS 不实际投递 MessageTypeCard | 高 | 低 | Hermes Agent 已在 Python SDK 验证此路径可行；Go SDK 帧解析已就绪 |
-| 卡片回调 3 秒超时 | 中 | 低 | handleCardAction 内部逻辑简单（map lookup + channel send），远低于 3 秒 |
+| EventDispatcher 行为变更 | 低 | 低 | 使用公开 API `OnP2CardActionTrigger`，向后兼容保证高；SDK v3.9.3 已稳定 |
+| 卡片回调 3 秒超时 | 中 | 低 | handleCardActionTrigger 内部逻辑简单（map lookup + channel send），远低于 3 秒 |
 | 按钮卡在飞书旧版客户端不显示 | 低 | 中 | Fallback 到纯文字通道已保留 |
 
 ---
 
-## 8. 飞书开放平台配置
+## 8. 飞书开放平台配置（2026-06 更新）
 
-**前置条件**（需在飞书开放平台后台确认）：
+### 8.1 控制台配置路径
 
-1. 应用功能 → 机器人 → 开启「卡片事件回调」
-2. 应用功能 → 机器人 → 确认已拥有 `im:message` + `im:message:send_as_bot` 权限
-3. 无需配置 Webhook URL（使用 WS 模式接收回调）
+```
+open.feishu.cn → 开发者后台 → 选择应用
+  → 开发配置 → 事件与回调 → 回调配置（非"事件配置"标签页）
+    ├─ 订阅方式：编辑 → 使用长连接接收回调 → 保存
+    │   ⚠️ 保存前必须确保本地 WS 客户端处于已连接状态
+    └─ 已订阅的回调 → 添加回调 → 卡片回传交互 (card.action.trigger)
+```
+
+### 8.2 权限要求
+
+1. 确认已拥有 `im:message` + `im:message:send_as_bot` 权限
+2. `card.action.trigger` 回调本身无权限要求
+
+### 8.3 技术实现说明
+
+SDK v3.9.3 的 `EventDispatcher` 已内置 `OnP2CardActionTrigger` 支持：
+- 卡片回调通过 `MessageTypeEvent` 帧（event_type=`card.action.trigger`）传输
+- `EventDispatcher.Do()` 的 `callbackType2CallbackHandler` 自动路由到 `OnP2CardActionTrigger`
+- **无需 SDK 补丁**，直接使用 `EventDispatcher.OnP2CardActionTrigger` 注册回调处理器

--- a/internal/messaging/feishu/AGENTS.md
+++ b/internal/messaging/feishu/AGENTS.md
@@ -56,11 +56,12 @@ Feishu WebSocket → ws.Client.Events → handleMessage() → handleTextMessage(
 2. Each chunk → update message content + cycle reaction (🔄)
 3. Stream complete → final update + ✅ reaction
 
-**Interaction cards (`interaction.go`)**
-- Permission request: display-only card (WS client doesn't forward card.action.trigger)
-- Users respond by typing "允许/allow" or "拒绝/deny"
-- Q&A and elicitation: structured card with instructions
+**Interaction cards (`interaction.go`, `card_action.go`)**
+- Permission/Q&A/elicitation: interactive card with real action buttons (Allow/Deny, Answer, Accept/Decline)
+- Button clicks routed via `EventDispatcher.OnP2CardActionTrigger` → `handleCardActionTrigger` → `InteractionManager.Complete`
+- Text fallback still works: both channels compete via `Complete` atomicity (first-to-respond-wins)
 - 5min auto-deny timeout via InteractionManager
+- `card_template.go` provides 4 button-equipped builders: `buildPermissionCardWithButtons`, `buildQuestionCardWithButtons`, `buildElicitationCardWithButtons`, `buildResolvedCard`
 
 **Chat send queue (`chat_queue.go`)**
 - Per `chatID` serial queue prevents message reordering
@@ -83,4 +84,3 @@ Feishu WebSocket → ws.Client.Events → handleMessage() → handleTextMessage(
 - ❌ Send messages without `chatQueue` — causes reorder in group chats
 - ❌ Skip reaction cleanup on stream abort — always remove ⏳/🔄 on error
 - ❌ Use `math/rand` for dedup TTL — use `crypto/rand` via UUID
-- ❌ Assume card.action.trigger works — WS client doesn't forward them

--- a/internal/messaging/feishu/card_action.go
+++ b/internal/messaging/feishu/card_action.go
@@ -1,0 +1,133 @@
+package feishu
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
+
+	"github.com/hrygo/hotplex/internal/messaging"
+)
+
+const (
+	cardActionAllow   = "allow"
+	cardActionDeny    = "deny"
+	cardActionAnswer  = "answer"
+	cardActionAccept  = "accept"
+	cardActionDecline = "decline"
+)
+
+func (a *Adapter) handleCardActionTrigger(_ context.Context, event *callback.CardActionTriggerEvent) (resp *callback.CardActionTriggerResponse, err error) {
+	// Panic recovery: WS handler convention (see ws.go). Named returns are
+	// required so the defer can set `err` and prevent a higher-level crash.
+	defer func() {
+		if r := recover(); r != nil {
+			a.Log.Error("feishu: panic in card action handler", "panic", r, "stack", string(debug.Stack()))
+			err = fmt.Errorf("feishu card action panic: %v", r)
+		}
+	}()
+
+	if event == nil || event.Event == nil || event.Event.Action == nil || event.Event.Action.Value == nil {
+		return nil, nil
+	}
+
+	val := event.Event.Action.Value
+	// Card templates (card_template.go) emit the request ID under the
+	// "request_id" key — reading "id" here would silently miss every click.
+	requestID, _ := val["request_id"].(string)
+	actionType, _ := val["action"].(string)
+
+	openID := ""
+	if event.Event.Operator != nil {
+		openID = event.Event.Operator.OpenID
+	}
+
+	var (
+		metadata      map[string]any
+		resolvedLabel string
+		resolvedColor string
+	)
+
+	switch actionType {
+	case cardActionAllow:
+		metadata = messaging.BuildPermissionResponse(requestID, true, "")
+		resolvedLabel = "✅ 已允许"
+		resolvedColor = "green"
+
+	case cardActionDeny:
+		metadata = messaging.BuildPermissionResponse(requestID, false, "user denied")
+		resolvedLabel = "🚫 已拒绝"
+		resolvedColor = "red"
+
+	case cardActionAnswer:
+		answer, _ := val["answer"].(string)
+		if answer == "" {
+			answer, _ = val["label"].(string)
+		}
+		metadata = messaging.BuildQuestionResponse(requestID, answer)
+		resolvedLabel = "✅ 已回答"
+		resolvedColor = "green"
+
+	case cardActionAccept:
+		metadata = messaging.BuildElicitationResponse(requestID, "accept")
+		resolvedLabel = "✅ 已接受"
+		resolvedColor = "green"
+
+	case cardActionDecline:
+		metadata = messaging.BuildElicitationResponse(requestID, "decline")
+		resolvedLabel = "🚫 已拒绝"
+		resolvedColor = "red"
+
+	default:
+		if a.Log != nil {
+			a.Log.Warn("feishu: unknown card action type", "action", actionType, "request_id", requestID)
+		}
+		return nil, nil
+	}
+
+	// Owner check BEFORE Complete — preserves the interaction for non-owner
+	// clicks. If we Completed first, the original watchTimeout goroutine
+	// (still running) would race the re-Registered entry, eventually firing
+	// on the new one and dispatching an auto-deny through the stale
+	// SendResponse closure. The legitimate owner would then be denied by
+	// their own timeout.
+	pending, exists := a.Interactions.Get(requestID)
+	if !exists {
+		resp = wrapResolvedCard(buildResolvedCard("deny", "已过期或已响应", ""))
+		return
+	}
+	if pending.OwnerID != "" && pending.OwnerID != openID {
+		// Silent ignore: non-owner click leaves the interaction pending so
+		// the rightful owner can still respond.
+		return nil, nil
+	}
+
+	pi, ok := a.Interactions.Complete(requestID)
+	if !ok {
+		resp = wrapResolvedCard(buildResolvedCard("deny", "已过期或已响应", ""))
+		return
+	}
+
+	if pi.SendResponse != nil {
+		pi.SendResponse(metadata)
+	}
+
+	if a.Log != nil {
+		a.Log.Info("feishu: interaction resolved via card button",
+			"request_id", requestID,
+			"action", actionType,
+			"operator", openID)
+	}
+
+	return wrapResolvedCard(buildResolvedCard(actionType, resolvedLabel, resolvedColor)), nil
+}
+
+func wrapResolvedCard(card map[string]any) *callback.CardActionTriggerResponse {
+	return &callback.CardActionTriggerResponse{
+		Card: &callback.Card{
+			Type: "card_json",
+			Data: card,
+		},
+	}
+}

--- a/internal/messaging/feishu/card_action.go
+++ b/internal/messaging/feishu/card_action.go
@@ -80,10 +80,8 @@ func (a *Adapter) handleCardActionTrigger(_ context.Context, event *callback.Car
 		resolvedColor = "red"
 
 	default:
-		if a.Log != nil {
-			a.Log.Warn("feishu: unknown card action type", "action", actionType, "request_id", requestID)
-		}
-		return nil, nil
+		a.Log.Warn("feishu: unknown card action type", "action", actionType, "request_id", requestID)
+		return wrapResolvedCard(buildResolvedCard("deny", "未知操作", headerGrey)), nil
 	}
 
 	// Owner check BEFORE Complete — preserves the interaction for non-owner
@@ -113,12 +111,10 @@ func (a *Adapter) handleCardActionTrigger(_ context.Context, event *callback.Car
 		pi.SendResponse(metadata)
 	}
 
-	if a.Log != nil {
-		a.Log.Info("feishu: interaction resolved via card button",
-			"request_id", requestID,
-			"action", actionType,
-			"operator", openID)
-	}
+	a.Log.Info("feishu: interaction resolved via card button",
+		"request_id", requestID,
+		"action", actionType,
+		"operator", openID)
 
 	return wrapResolvedCard(buildResolvedCard(actionType, resolvedLabel, resolvedColor)), nil
 }

--- a/internal/messaging/feishu/card_action_integration_test.go
+++ b/internal/messaging/feishu/card_action_integration_test.go
@@ -1,0 +1,160 @@
+package feishu
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/messaging"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+// TestCardActionFlow_PermissionAllow_EndToEnd exercises the full Feishu
+// interactive-card routing loop in a single integration test:
+//
+//	button click → handleCardActionTrigger → SendResponse → Complete → state verification
+//
+// It then re-clicks the same request_id to assert idempotent behavior: the
+// already-completed interaction yields a resolved "已过期或已响应" card and
+// must NOT invoke SendResponse a second time.
+func TestCardActionFlow_PermissionAllow_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	// ── Arrange ──────────────────────────────────────────────────────────────
+	// Self-contained setup (does not depend on newCardActionTestAdapter / helper
+	// in card_action_test.go) so this test reads as a standalone integration
+	// spec for the routing loop.
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Adapter{
+		BaseAdapter: messaging.BaseAdapter[*FeishuConn]{
+			PlatformAdapter: messaging.PlatformAdapter{
+				Log:          log,
+				Interactions: messaging.NewInteractionManager(log),
+			},
+		},
+	}
+
+	const (
+		requestID = "req-perm-e2e-1"
+		ownerID   = "ou_owner"
+		sessionID = "sess-e2e-1"
+	)
+
+	// Buffered channel: SendResponse writes exactly once on a successful click.
+	// A second click must NOT send (idempotency), so the channel will stay empty.
+	received := make(chan map[string]any, 1)
+	a.Interactions.Register(&messaging.PendingInteraction{
+		ID:        requestID,
+		OwnerID:   ownerID,
+		SessionID: sessionID,
+		Type:      events.PermissionRequest,
+		Timeout:   5 * time.Minute,
+		SendResponse: func(meta map[string]any) {
+			received <- meta
+		},
+	})
+	require.Equal(t, 1, a.Interactions.Len(),
+		"precondition: one interaction must be registered before the click")
+
+	allowEvent := &callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: ownerID},
+			Action: &callback.CallBackAction{
+				Value: map[string]interface{}{
+					"action":     "allow",
+					"request_id": requestID,
+				},
+			},
+		},
+	}
+
+	// ── Act ─────────────────────────────────────────────────────────────────
+	got, err := a.handleCardActionTrigger(context.Background(), allowEvent)
+	require.NoError(t, err)
+	require.NotNil(t, got,
+		"handleCardActionTrigger must return a card on successful allow click")
+	require.NotNil(t, got.Card)
+
+	// ── Assert: card response structure (header template = green) ───────────
+	card, ok := got.Card.Data.(map[string]any)
+	require.True(t, ok, "expected map[string]any, got %T", got.Card.Data)
+	require.Contains(t, card, "header", "resolved card must have a header block")
+
+	header, ok := card["header"].(map[string]any)
+	require.True(t, ok, "header must be map[string]any, got %T", card["header"])
+	assert.Equal(t, "green", header["template"],
+		"allow action must produce a green resolved card")
+
+	title, ok := header["title"].(map[string]any)
+	require.True(t, ok, "header.title must be map[string]any, got %T", header["title"])
+	assert.Equal(t, "✅ 已允许", title["content"],
+		"allow action must surface the '已允许' resolved label")
+
+	// ── Assert: SendResponse received with correct payload ──────────────────
+	select {
+	case meta := <-received:
+		perm, ok := meta["permission_response"].(map[string]any)
+		require.True(t, ok,
+			"expected permission_response key in meta, got: %v", meta)
+		assert.Equal(t, requestID, perm["request_id"],
+			"permission_response.request_id must echo the registered ID")
+		assert.Equal(t, true, perm["allowed"],
+			"permission_response.allowed must be true for 'allow' action")
+		assert.Equal(t, "", perm["reason"],
+			"allow action must not carry a denial reason")
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("SendResponse was not called within 200ms — routing loop stalled")
+	}
+
+	// ── Assert: interaction completed atomically ────────────────────────────
+	assert.Equal(t, 0, a.Interactions.Len(),
+		"interaction must be removed from the manager after a successful click")
+
+	// ── Act + Assert: second click on the same request_id is idempotent ─────
+	// Interactions.Complete returns ok=false for an already-completed ID, so
+	// the handler must short-circuit to a resolved "已过期或已响应" card and
+	// must NOT call SendResponse a second time.
+	secondEvent := &callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: ownerID},
+			Action: &callback.CallBackAction{
+				Value: map[string]interface{}{
+					"action":     "allow",
+					"request_id": requestID,
+				},
+			},
+		},
+	}
+
+	got2, err2 := a.handleCardActionTrigger(context.Background(), secondEvent)
+	require.NoError(t, err2)
+	require.NotNil(t, got2,
+		"second click on a completed interaction must still return a resolved card")
+	require.NotNil(t, got2.Card)
+
+	card2, ok := got2.Card.Data.(map[string]any)
+	require.True(t, ok, "expected map[string]any, got %T", got2.Card.Data)
+
+	header2, ok := card2["header"].(map[string]any)
+	require.True(t, ok, "header must be map[string]any, got %T", card2["header"])
+
+	title2, ok := header2["title"].(map[string]any)
+	require.True(t, ok, "header.title must be map[string]any, got %T", header2["title"])
+	assert.Equal(t, "已过期或已响应", title2["content"],
+		"second click must yield the expired/resolved card title")
+
+	// SendResponse must not be invoked a second time. The channel is buffered
+	// with capacity 1, so a leak would be observable as a readable value.
+	select {
+	case extra := <-received:
+		t.Fatalf("SendResponse must not fire twice for the same request_id; got: %v", extra)
+	case <-time.After(50 * time.Millisecond):
+		// Expected: channel remains empty after the first (and only) send.
+	}
+}

--- a/internal/messaging/feishu/card_action_test.go
+++ b/internal/messaging/feishu/card_action_test.go
@@ -309,6 +309,13 @@ func TestHandleCardAction_UnknownAction(t *testing.T) {
 
 	got, err := a.handleCardActionTrigger(context.Background(), event)
 	require.NoError(t, err)
-	assert.Nil(t, got)
-	assert.Equal(t, 0, a.Interactions.Len())
+	require.NotNil(t, got, "unknown action should return a resolved card for user feedback")
+	require.NotNil(t, got.Card)
+	card, ok := got.Card.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, card, "header")
+	header := card["header"].(map[string]any)
+	title := header["title"].(map[string]any)
+	assert.Equal(t, "未知操作", title["content"])
+	assert.Equal(t, headerGrey, header["template"])
 }

--- a/internal/messaging/feishu/card_action_test.go
+++ b/internal/messaging/feishu/card_action_test.go
@@ -1,0 +1,314 @@
+package feishu
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/messaging"
+	"github.com/hrygo/hotplex/pkg/events"
+)
+
+func newCardActionTestAdapter() *Adapter {
+	return &Adapter{
+		BaseAdapter: messaging.BaseAdapter[*FeishuConn]{
+			PlatformAdapter: messaging.PlatformAdapter{
+				Log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+				Interactions: messaging.NewInteractionManager(slog.New(slog.NewTextHandler(io.Discard, nil))),
+			},
+		},
+	}
+}
+
+func registerTestPermission(t *testing.T, a *Adapter, requestID, ownerID string) chan map[string]any {
+	t.Helper()
+	ch := make(chan map[string]any, 1)
+	a.Interactions.Register(&messaging.PendingInteraction{
+		ID:        requestID,
+		OwnerID:   ownerID,
+		SessionID: "sess-1",
+		Type:      events.PermissionRequest,
+		Timeout:   5 * time.Minute,
+		SendResponse: func(meta map[string]any) {
+			ch <- meta
+		},
+	})
+	return ch
+}
+
+func registerTestQuestion(t *testing.T, a *Adapter, requestID, ownerID string) chan map[string]any {
+	t.Helper()
+	ch := make(chan map[string]any, 1)
+	a.Interactions.Register(&messaging.PendingInteraction{
+		ID:        requestID,
+		OwnerID:   ownerID,
+		SessionID: "sess-1",
+		Type:      events.QuestionRequest,
+		Timeout:   5 * time.Minute,
+		SendResponse: func(meta map[string]any) {
+			ch <- meta
+		},
+	})
+	return ch
+}
+
+func registerTestElicitation(t *testing.T, a *Adapter, requestID, ownerID string) chan map[string]any {
+	t.Helper()
+	ch := make(chan map[string]any, 1)
+	a.Interactions.Register(&messaging.PendingInteraction{
+		ID:        requestID,
+		OwnerID:   ownerID,
+		SessionID: "sess-1",
+		Type:      events.ElicitationRequest,
+		Timeout:   5 * time.Minute,
+		SendResponse: func(meta map[string]any) {
+			ch <- meta
+		},
+	})
+	return ch
+}
+
+func newCardActionTriggerEvent(openID, requestID, action string, extras map[string]interface{}) *callback.CardActionTriggerEvent {
+	value := map[string]interface{}{
+		"action":     action,
+		"request_id": requestID,
+	}
+	for k, v := range extras {
+		value[k] = v
+	}
+	return &callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: openID},
+			Action:   &callback.CallBackAction{Value: value},
+		},
+	}
+}
+
+func TestHandleCardAction_PermissionAllow(t *testing.T) {
+	t.Parallel()
+	a := newCardActionTestAdapter()
+	respCh := registerTestPermission(t, a, "req-perm-1", "u-owner")
+
+	event := newCardActionTriggerEvent("u-owner", "req-perm-1", "allow", nil)
+
+	got, err := a.handleCardActionTrigger(context.Background(), event)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Card)
+	card, ok := got.Card.Data.(map[string]any)
+	require.True(t, ok, "expected map[string]any, got %T", got.Card.Data)
+	assert.Contains(t, card, "header")
+	assert.Contains(t, card, "config")
+
+	select {
+	case meta := <-respCh:
+		perm, ok := meta["permission_response"].(map[string]any)
+		require.True(t, ok, "expected permission_response key in meta")
+		assert.Equal(t, "req-perm-1", perm["request_id"])
+		assert.Equal(t, true, perm["allowed"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("SendResponse was not called within 2s")
+	}
+	assert.Equal(t, 0, a.Interactions.Len(), "interaction should be completed")
+}
+
+func TestHandleCardAction_PermissionDeny(t *testing.T) {
+	t.Parallel()
+	a := newCardActionTestAdapter()
+	respCh := registerTestPermission(t, a, "req-perm-2", "u-owner")
+
+	event := newCardActionTriggerEvent("u-owner", "req-perm-2", "deny", nil)
+
+	got, err := a.handleCardActionTrigger(context.Background(), event)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Card)
+	card, ok := got.Card.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, card, "header")
+	assert.Contains(t, card, "config")
+
+	select {
+	case meta := <-respCh:
+		perm, ok := meta["permission_response"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "req-perm-2", perm["request_id"])
+		assert.Equal(t, false, perm["allowed"])
+		assert.Equal(t, "user denied", perm["reason"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("SendResponse was not called within 2s")
+	}
+	assert.Equal(t, 0, a.Interactions.Len())
+}
+
+func TestHandleCardAction_QuestionAnswer(t *testing.T) {
+	t.Parallel()
+	a := newCardActionTestAdapter()
+	respCh := registerTestQuestion(t, a, "req-q-1", "u-owner")
+
+	event := newCardActionTriggerEvent("u-owner", "req-q-1", "answer", map[string]interface{}{"answer": "Yes"})
+
+	got, err := a.handleCardActionTrigger(context.Background(), event)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Card)
+	card, ok := got.Card.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, card, "header")
+
+	select {
+	case meta := <-respCh:
+		qr, ok := meta["question_response"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "req-q-1", qr["id"])
+		answers, ok := qr["answers"].(map[string]string)
+		require.True(t, ok)
+		assert.Equal(t, "Yes", answers["_"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("SendResponse was not called within 2s")
+	}
+	assert.Equal(t, 0, a.Interactions.Len())
+}
+
+func TestHandleCardAction_ElicitationAccept(t *testing.T) {
+	t.Parallel()
+	a := newCardActionTestAdapter()
+	respCh := registerTestElicitation(t, a, "req-e-1", "u-owner")
+
+	event := newCardActionTriggerEvent("u-owner", "req-e-1", "accept", nil)
+
+	got, err := a.handleCardActionTrigger(context.Background(), event)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Card)
+	card, ok := got.Card.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, card, "header")
+
+	select {
+	case meta := <-respCh:
+		er, ok := meta["elicitation_response"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "req-e-1", er["id"])
+		assert.Equal(t, "accept", er["action"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("SendResponse was not called within 2s")
+	}
+	assert.Equal(t, 0, a.Interactions.Len())
+}
+
+func TestHandleCardAction_ElicitationDecline(t *testing.T) {
+	t.Parallel()
+	a := newCardActionTestAdapter()
+	respCh := registerTestElicitation(t, a, "req-e-2", "u-owner")
+
+	event := newCardActionTriggerEvent("u-owner", "req-e-2", "decline", nil)
+
+	got, err := a.handleCardActionTrigger(context.Background(), event)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Card)
+	card, ok := got.Card.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, card, "header")
+
+	select {
+	case meta := <-respCh:
+		er, ok := meta["elicitation_response"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "req-e-2", er["id"])
+		assert.Equal(t, "decline", er["action"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("SendResponse was not called within 2s")
+	}
+	assert.Equal(t, 0, a.Interactions.Len())
+}
+
+func TestHandleCardAction_NonOwner(t *testing.T) {
+	t.Parallel()
+	a := newCardActionTestAdapter()
+	_ = registerTestPermission(t, a, "req-no-1", "u1")
+
+	event := newCardActionTriggerEvent("u2", "req-no-1", "allow", nil)
+
+	got, err := a.handleCardActionTrigger(context.Background(), event)
+	require.NoError(t, err)
+	assert.Nil(t, got, "non-owner should return nil response")
+	assert.Equal(t, 1, a.Interactions.Len(), "non-owner click must leave the interaction pending for the legitimate owner")
+}
+
+func TestHandleCardAction_ExpiredOrMissing(t *testing.T) {
+	t.Parallel()
+	a := newCardActionTestAdapter()
+	_ = registerTestPermission(t, a, "req-exp-1", "u-owner")
+	_, ok := a.Interactions.Complete("req-exp-1")
+	require.True(t, ok, "precondition: interaction must be completed")
+
+	event := newCardActionTriggerEvent("u-owner", "req-exp-1", "allow", nil)
+
+	got, err := a.handleCardActionTrigger(context.Background(), event)
+	require.NoError(t, err)
+	require.NotNil(t, got, "expired/missing should still return a resolved card")
+	require.NotNil(t, got.Card)
+	card, ok := got.Card.Data.(map[string]any)
+	require.True(t, ok, "expected map[string]any, got %T", got.Card.Data)
+	assert.Contains(t, card, "header")
+	assert.Contains(t, card, "config")
+	header, ok := card["header"].(map[string]any)
+	require.True(t, ok)
+	title, ok := header["title"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "已过期或已响应", title["content"])
+}
+
+func TestHandleCardAction_NilAction(t *testing.T) {
+	t.Parallel()
+	a := newCardActionTestAdapter()
+
+	event := &callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "u-owner"},
+			Action:   nil,
+		},
+	}
+
+	got, err := a.handleCardActionTrigger(context.Background(), event)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, 0, a.Interactions.Len())
+}
+
+func TestHandleCardAction_EmptyValue(t *testing.T) {
+	t.Parallel()
+	a := newCardActionTestAdapter()
+
+	event := &callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "u-owner"},
+			Action:   &callback.CallBackAction{Value: nil},
+		},
+	}
+
+	got, err := a.handleCardActionTrigger(context.Background(), event)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, 0, a.Interactions.Len())
+}
+
+func TestHandleCardAction_UnknownAction(t *testing.T) {
+	t.Parallel()
+	a := newCardActionTestAdapter()
+
+	event := newCardActionTriggerEvent("u-owner", "req-unknown-1", "foo", nil)
+
+	got, err := a.handleCardActionTrigger(context.Background(), event)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, 0, a.Interactions.Len())
+}

--- a/internal/messaging/feishu/card_template.go
+++ b/internal/messaging/feishu/card_template.go
@@ -185,19 +185,15 @@ func turnTags(turnNum int, model, branch, workDir string) []cardTag {
 	return tags
 }
 
-// buildQuestionElements builds card elements for a JSON 1.0 question card.
-// Each question gets a markdown element (with numbered descriptions if present)
-// followed by an action element with copy_text buttons.
+// Deprecated: buildQuestionElements is retained only for test backward compatibility.
+// New code should use buildQuestionCardWithButtons.
 func buildQuestionElements(questions []events.Question) []map[string]any {
 	var elements []map[string]any
-
 	for _, q := range questions {
 		headerLabel := messaging.SanitizeText(q.Header)
 		if headerLabel == "" {
 			headerLabel = "Question"
 		}
-
-		// Pre-sanitize all option fields once.
 		type sanitizedOpt struct {
 			Label, Desc string
 		}
@@ -208,15 +204,11 @@ func buildQuestionElements(questions []events.Question) []map[string]any {
 				Desc:  messaging.SanitizeText(opt.Description),
 			}
 		}
-
 		var sb strings.Builder
 		fmt.Fprintf(&sb, "**%s**\n%s", headerLabel, messaging.SanitizeText(q.Question))
 		if q.MultiSelect {
 			sb.WriteString("\n*（可多选）*")
 		}
-
-		// Always show numbered option list as visible fallback —
-		// buttons may not render on all clients.
 		if len(opts) > 0 {
 			sb.WriteString("\n\n")
 			for i, opt := range opts {
@@ -227,13 +219,9 @@ func buildQuestionElements(questions []events.Question) []map[string]any {
 				}
 			}
 		}
-
 		elements = append(elements, map[string]any{
-			"tag":     "markdown",
-			"content": sb.String(),
+			"tag": "markdown", "content": sb.String(),
 		})
-
-		// Action buttons with copy_text behavior.
 		if len(opts) > 0 {
 			buttons := make([]map[string]any, 0, len(opts))
 			for _, opt := range opts {
@@ -248,16 +236,15 @@ func buildQuestionElements(questions []events.Question) []map[string]any {
 				})
 			}
 			elements = append(elements, map[string]any{
-				"tag":     "action",
-				"actions": buttons,
+				"tag": "action", "actions": buttons,
 			})
 		}
 	}
-
 	return elements
 }
 
-// questionFooterHint returns the appropriate footer hint based on question types.
+// Deprecated: questionFooterHint is retained only for test backward compatibility.
+// New code should use the inline hint in buildQuestionCardWithButtons.
 func questionFooterHint(questions []events.Question) string {
 	for _, q := range questions {
 		if q.MultiSelect {
@@ -265,4 +252,189 @@ func questionFooterHint(questions []events.Question) string {
 		}
 	}
 	return "💬 点击按钮复制选项文本，粘贴发送即可响应\n也可直接回复选项文本或自定义答案"
+}
+
+func buildPermissionCardWithButtons(data *events.PermissionRequestData) string {
+	header := cardHeader{
+		Title:    data.ToolName,
+		Subtitle: messaging.SanitizeText(data.Description),
+		Template: headerOrange,
+		Tags:     []cardTag{{Text: "pending", Color: "orange"}},
+	}
+
+	var content strings.Builder
+	fmt.Fprintf(&content, "**%s**\n%s", data.ToolName, messaging.SanitizeText(data.Description))
+	if len(data.Args) > 0 {
+		content.WriteString("\n\n参数：")
+		const maxArgBytes = 500
+		truncated := false
+		for i, arg := range data.Args {
+			if i > 0 {
+				content.WriteString(", ")
+			}
+			sanitized := messaging.SanitizeText(arg)
+			// Truncate at 500 bytes to avoid oversized card payload (Feishu card 30KB limit).
+			// Stacked args (e.g., base64 file contents) can blow past this easily.
+			if content.Len()+len(sanitized) > maxArgBytes {
+				if !truncated {
+					content.WriteString("...")
+					truncated = true
+				}
+				continue
+			}
+			content.WriteString(sanitized)
+		}
+	}
+
+	valAllow := map[string]any{"action": "allow", "request_id": data.ID}
+	valDeny := map[string]any{"action": "deny", "request_id": data.ID}
+	elements := []map[string]any{
+		{"tag": "markdown", "content": content.String()},
+		{
+			"tag": "action",
+			"actions": []map[string]any{
+				{
+					"tag":   "button",
+					"text":  map[string]any{"tag": "plain_text", "content": "✅ 允许"},
+					"type":  "primary",
+					"value": valAllow,
+				},
+				{
+					"tag":   "button",
+					"text":  map[string]any{"tag": "plain_text", "content": "❌ 拒绝"},
+					"type":  "danger",
+					"value": valDeny,
+				},
+			},
+		},
+	}
+
+	return buildCard(header, map[string]any{"wide_screen_mode": true}, elements)
+}
+
+func buildQuestionCardWithButtons(data *events.QuestionRequestData) string {
+	title := data.ToolName
+	if title == "" {
+		title = "用户输入请求"
+	}
+	header := cardHeader{
+		Title:    title,
+		Template: headerYellow,
+	}
+
+	var elements []map[string]any
+	for _, q := range data.Questions {
+		headerLabel := messaging.SanitizeText(q.Header)
+		if headerLabel == "" {
+			headerLabel = "Question"
+		}
+
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "**%s**\n%s", headerLabel, messaging.SanitizeText(q.Question))
+		if q.MultiSelect {
+			sb.WriteString("\n*（可多选）*")
+		}
+		elements = append(elements, map[string]any{
+			"tag":     "markdown",
+			"content": sb.String(),
+		})
+
+		if len(q.Options) > 0 {
+			buttons := make([]map[string]any, 0, len(q.Options))
+			for _, opt := range q.Options {
+				sanitized := messaging.SanitizeText(opt.Label)
+				display := sanitized
+				if len([]rune(display)) > 75 {
+					display = string([]rune(display)[:75])
+				}
+				buttons = append(buttons, map[string]any{
+					"tag":  "button",
+					"text": map[string]any{"tag": "plain_text", "content": display},
+					"type": "primary",
+					"value": map[string]any{
+						"action":     "answer",
+						"request_id": data.ID,
+						"answer":     sanitized,
+						"label":      display,
+					},
+				})
+			}
+			elements = append(elements, map[string]any{
+				"tag":     "action",
+				"actions": buttons,
+			})
+		}
+	}
+
+	elements = append(elements, map[string]any{
+		"tag":     "markdown",
+		"content": "💬 点击按钮直接选择，或直接回复自定义答案",
+	})
+
+	return buildV1Card(header, map[string]any{"wide_screen_mode": true}, elements)
+}
+
+func buildElicitationCardWithButtons(data *events.ElicitationRequestData) string {
+	header := cardHeader{
+		Title:    data.MCPServerName,
+		Subtitle: messaging.SanitizeText(data.Message),
+		Template: headerViolet,
+	}
+
+	var content strings.Builder
+	fmt.Fprintf(&content, "**%s**\n%s", data.MCPServerName, messaging.SanitizeText(data.Message))
+	if data.URL != "" {
+		// Validate URL scheme to prevent javascript: or data: injection in Feishu markdown links.
+		// Only http:// and https:// are safe in Feishu card markdown.
+		display := data.URL
+		if !strings.HasPrefix(data.URL, "http://") && !strings.HasPrefix(data.URL, "https://") {
+			display = messaging.SanitizeText(data.URL)
+			fmt.Fprintf(&content, "\n\n📋 %s", display)
+		} else {
+			fmt.Fprintf(&content, "\n\n[🔗 %s](%s)", messaging.SanitizeText(display), display)
+		}
+	}
+
+	valAccept := map[string]any{"action": "accept", "request_id": data.ID}
+	valDecline := map[string]any{"action": "decline", "request_id": data.ID}
+	elements := []map[string]any{
+		{"tag": "markdown", "content": content.String()},
+		{
+			"tag": "action",
+			"actions": []map[string]any{
+				{
+					"tag":   "button",
+					"text":  map[string]any{"tag": "plain_text", "content": "✅ 接受"},
+					"type":  "primary",
+					"value": valAccept,
+				},
+				{
+					"tag":   "button",
+					"text":  map[string]any{"tag": "plain_text", "content": "❌ 拒绝"},
+					"type":  "danger",
+					"value": valDecline,
+				},
+			},
+		},
+	}
+
+	return buildCard(header, map[string]any{"wide_screen_mode": true}, elements)
+}
+
+func buildResolvedCard(action, label, color string) map[string]any {
+	if color == "" {
+		switch action {
+		case "allow", "answer", "accept":
+			color = "green"
+		case "deny", "decline":
+			color = "red"
+		}
+	}
+	return map[string]any{
+		"config": map[string]any{"wide_screen_mode": true},
+		"header": map[string]any{
+			"title":    map[string]any{"tag": "plain_text", "content": label},
+			"template": color,
+		},
+	}
 }

--- a/internal/messaging/feishu/card_template.go
+++ b/internal/messaging/feishu/card_template.go
@@ -371,7 +371,7 @@ func buildQuestionCardWithButtons(data *events.QuestionRequestData) string {
 		"content": "💬 点击按钮直接选择，或直接回复自定义答案",
 	})
 
-	return buildV1Card(header, map[string]any{"wide_screen_mode": true}, elements)
+	return buildCard(header, map[string]any{"wide_screen_mode": true}, elements)
 }
 
 func buildElicitationCardWithButtons(data *events.ElicitationRequestData) string {

--- a/internal/messaging/feishu/card_template_test.go
+++ b/internal/messaging/feishu/card_template_test.go
@@ -427,3 +427,234 @@ func TestBuildQuestionElements(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildPermissionCardWithButtons(t *testing.T) {
+	t.Parallel()
+	data := &events.PermissionRequestData{
+		ID:          "perm-1",
+		ToolName:    "Bash",
+		Description: "Run shell command",
+		Args:        []string{"ls", "-la"},
+	}
+	got := buildPermissionCardWithButtons(data)
+
+	var card map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &card))
+
+	body := card["body"].(map[string]any)
+	elements := body["elements"].([]any)
+
+	var actionEl map[string]any
+	for _, e := range elements {
+		m := e.(map[string]any)
+		if m["tag"] == "action" {
+			actionEl = m
+			break
+		}
+	}
+	require.NotNil(t, actionEl, "expected an action element")
+
+	buttons := actionEl["actions"].([]any)
+	require.Len(t, buttons, 2)
+
+	btn0 := buttons[0].(map[string]any)
+	require.Equal(t, "button", btn0["tag"])
+	require.Equal(t, "primary", btn0["type"])
+	require.Equal(t, "✅ 允许", btn0["text"].(map[string]any)["content"])
+	val0 := btn0["value"].(map[string]any)
+	require.Equal(t, "allow", val0["action"])
+	require.Equal(t, "perm-1", val0["request_id"])
+
+	btn1 := buttons[1].(map[string]any)
+	require.Equal(t, "danger", btn1["type"])
+	require.Equal(t, "❌ 拒绝", btn1["text"].(map[string]any)["content"])
+	val1 := btn1["value"].(map[string]any)
+	require.Equal(t, "deny", val1["action"])
+	require.Equal(t, "perm-1", val1["request_id"])
+
+	hdr := card["header"].(map[string]any)
+	require.Equal(t, "orange", hdr["template"])
+}
+
+func TestBuildPermissionCardWithButtons_NoArgs(t *testing.T) {
+	t.Parallel()
+	data := &events.PermissionRequestData{
+		ID:          "perm-2",
+		ToolName:    "Read",
+		Description: "Read file",
+		Args:        nil,
+	}
+	got := buildPermissionCardWithButtons(data)
+
+	var card map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &card))
+
+	body := card["body"].(map[string]any)
+	elements := body["elements"].([]any)
+	require.GreaterOrEqual(t, len(elements), 2)
+
+	md := elements[0].(map[string]any)
+	require.Equal(t, "markdown", md["tag"])
+	content := md["content"].(string)
+	require.Contains(t, content, "Read")
+	require.NotContains(t, content, "参数：")
+
+	var actionEl map[string]any
+	for _, e := range elements {
+		m := e.(map[string]any)
+		if m["tag"] == "action" {
+			actionEl = m
+			break
+		}
+	}
+	require.NotNil(t, actionEl)
+	buttons := actionEl["actions"].([]any)
+	require.Len(t, buttons, 2)
+}
+
+func TestBuildQuestionCardWithButtons(t *testing.T) {
+	t.Parallel()
+	data := &events.QuestionRequestData{
+		ID:       "q-1",
+		ToolName: "AskUserQuestion",
+		Questions: []events.Question{
+			{
+				Header:   "Auth",
+				Question: "Pick one",
+				Options: []events.QuestionOption{
+					{Label: "JWT"},
+					{Label: "OAuth"},
+				},
+			},
+		},
+	}
+	got := buildQuestionCardWithButtons(data)
+
+	var card map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &card))
+	require.Nil(t, card["schema"], "v1 card must not have schema field")
+
+	elems := card["elements"].([]any)
+
+	var actionEl map[string]any
+	for _, e := range elems {
+		m := e.(map[string]any)
+		if m["tag"] == "action" {
+			actionEl = m
+			break
+		}
+	}
+	require.NotNil(t, actionEl, "expected an action element")
+
+	buttons := actionEl["actions"].([]any)
+	require.Len(t, buttons, 2)
+
+	for _, b := range buttons {
+		btn := b.(map[string]any)
+		require.Equal(t, "button", btn["tag"])
+		val := btn["value"].(map[string]any)
+		require.Equal(t, "answer", val["action"])
+		require.Equal(t, "q-1", val["request_id"])
+		require.NotEmpty(t, val["answer"])
+		require.NotEmpty(t, val["label"])
+	}
+
+	hdr := card["header"].(map[string]any)
+	require.Equal(t, "yellow", hdr["template"])
+}
+
+func TestBuildQuestionCardWithButtons_NoOptions(t *testing.T) {
+	t.Parallel()
+	data := &events.QuestionRequestData{
+		ID:       "q-2",
+		ToolName: "AskUserQuestion",
+		Questions: []events.Question{
+			{Header: "Open", Question: "Why?"},
+		},
+	}
+	got := buildQuestionCardWithButtons(data)
+
+	var card map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &card))
+
+	elems := card["elements"].([]any)
+	for _, e := range elems {
+		m := e.(map[string]any)
+		require.NotEqual(t, "action", m["tag"], "no action element expected when question has no options")
+	}
+}
+
+func TestBuildElicitationCardWithButtons(t *testing.T) {
+	t.Parallel()
+	data := &events.ElicitationRequestData{
+		ID:            "e-1",
+		MCPServerName: "github",
+		Message:       "Allow access",
+		URL:           "https://github.com/login/oauth",
+	}
+	got := buildElicitationCardWithButtons(data)
+
+	var card map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &card))
+
+	body := card["body"].(map[string]any)
+	elements := body["elements"].([]any)
+
+	md := elements[0].(map[string]any)
+	require.Equal(t, "markdown", md["tag"])
+	content := md["content"].(string)
+	require.Contains(t, content, "https://github.com/login/oauth", "URL must appear as link in body")
+
+	actionEl := elements[1].(map[string]any)
+	require.Equal(t, "action", actionEl["tag"])
+	buttons := actionEl["actions"].([]any)
+	require.Len(t, buttons, 2)
+
+	btn0 := buttons[0].(map[string]any)
+	require.Equal(t, "primary", btn0["type"])
+	require.Equal(t, "✅ 接受", btn0["text"].(map[string]any)["content"])
+	val0 := btn0["value"].(map[string]any)
+	require.Equal(t, "accept", val0["action"])
+	require.Equal(t, "e-1", val0["request_id"])
+
+	btn1 := buttons[1].(map[string]any)
+	require.Equal(t, "danger", btn1["type"])
+	require.Equal(t, "❌ 拒绝", btn1["text"].(map[string]any)["content"])
+	val1 := btn1["value"].(map[string]any)
+	require.Equal(t, "decline", val1["action"])
+	require.Equal(t, "e-1", val1["request_id"])
+
+	hdr := card["header"].(map[string]any)
+	require.Equal(t, "violet", hdr["template"])
+}
+
+func TestBuildResolvedCard_Green(t *testing.T) {
+	t.Parallel()
+	card := buildResolvedCard("allow", "已允许", "")
+	require.NotNil(t, card)
+
+	cfg := card["config"].(map[string]any)
+	require.Equal(t, true, cfg["wide_screen_mode"])
+
+	hdr := card["header"].(map[string]any)
+	require.Equal(t, "green", hdr["template"])
+	title := hdr["title"].(map[string]any)
+	require.Equal(t, "plain_text", title["tag"])
+	require.Equal(t, "已允许", title["content"])
+}
+
+func TestBuildResolvedCard_Red(t *testing.T) {
+	t.Parallel()
+	card := buildResolvedCard("deny", "已拒绝", "")
+	hdr := card["header"].(map[string]any)
+	require.Equal(t, "red", hdr["template"])
+}
+
+func TestBuildResolvedCard_ExplicitColor(t *testing.T) {
+	t.Parallel()
+	card := buildResolvedCard("allow", "Custom Label", "blue")
+	hdr := card["header"].(map[string]any)
+	require.Equal(t, "blue", hdr["template"])
+	title := hdr["title"].(map[string]any)
+	require.Equal(t, "Custom Label", title["content"])
+}

--- a/internal/messaging/feishu/card_template_test.go
+++ b/internal/messaging/feishu/card_template_test.go
@@ -532,9 +532,10 @@ func TestBuildQuestionCardWithButtons(t *testing.T) {
 
 	var card map[string]any
 	require.NoError(t, json.Unmarshal([]byte(got), &card))
-	require.Nil(t, card["schema"], "v1 card must not have schema field")
+	require.Equal(t, "2.0", card["schema"], "question card should now use v2 format")
 
-	elems := card["elements"].([]any)
+	body := card["body"].(map[string]any)
+	elems := body["elements"].([]any)
 
 	var actionEl map[string]any
 	for _, e := range elems {
@@ -577,7 +578,8 @@ func TestBuildQuestionCardWithButtons_NoOptions(t *testing.T) {
 	var card map[string]any
 	require.NoError(t, json.Unmarshal([]byte(got), &card))
 
-	elems := card["elements"].([]any)
+	body := card["body"].(map[string]any)
+	elems := body["elements"].([]any)
 	for _, e := range elems {
 		m := e.(map[string]any)
 		require.NotEqual(t, "action", m["tag"], "no action element expected when question has no options")

--- a/internal/messaging/feishu/converter_coverage_test.go
+++ b/internal/messaging/feishu/converter_coverage_test.go
@@ -1,7 +1,6 @@
 package feishu
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -147,19 +146,6 @@ func TestBuildMediaPrompt_NoUserText(t *testing.T) {
 	result := BuildMediaPrompt("", []string{"/tmp/img.png"}, medias, nil)
 	require.Contains(t, result, "已下载到本地")
 	require.NotContains(t, result, "用户的文字内容")
-}
-
-func TestBuildInteractionCard_NoFooter(t *testing.T) {
-	t.Parallel()
-	result := buildInteractionCard("body text", "", cardHeader{Title: "Test"})
-	require.Contains(t, result, "body text")
-
-	var parsed map[string]any
-	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
-	// No hr element when no footer.
-	body := parsed["body"].(map[string]any)
-	elements := body["elements"].([]any)
-	require.Len(t, elements, 1)
 }
 
 func TestStripInvalidImageKeys_NoImageSyntax(t *testing.T) {

--- a/internal/messaging/feishu/interaction.go
+++ b/internal/messaging/feishu/interaction.go
@@ -11,41 +11,14 @@ import (
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
-// sendPermissionRequest posts a permission request card to Feishu.
-// Since the Feishu WS client does not forward card.action.trigger events,
-// the card is display-only — users respond by typing "允许/allow" or "拒绝/deny".
+// sendPermissionRequest posts an interactive permission request card with [允许/拒绝] buttons.
 func (c *FeishuConn) sendPermissionRequest(ctx context.Context, env *events.Envelope) error {
 	data, err := messaging.ExtractPermissionData(env)
 	if err != nil {
 		return fmt.Errorf("feishu: extract permission data: %w", err)
 	}
 
-	// Build header
-	header := fmt.Sprintf("**⚠️ 工具执行授权**\n工具执行请求：\n📝 **%s**", data.ToolName)
-	if data.Description != "" && data.Description != data.ToolName {
-		header += fmt.Sprintf("\n> %s", data.Description)
-	}
-
-	// Args preview
-	if len(data.Args) > 0 && data.Args[0] != "{}" {
-		preview := data.Args[0]
-		if len(preview) > 500 {
-			preview = preview[:500] + "..."
-		}
-		// Strip triple backticks to prevent nested code blocks.
-		preview = strings.ReplaceAll(preview, "```", "")
-		header += fmt.Sprintf("\n```\n%s\n```", preview)
-	}
-
-	// Instruction text with request ID for reference
-	footer := fmt.Sprintf("---\n📋 请求ID: `%s`\n💬 回复 **允许/同意/ok** 或 **拒绝/取消/no** 来响应此请求", data.ID)
-
-	cardJSON := buildInteractionCard(header, footer, cardHeader{
-		Title:    "工具执行授权",
-		Subtitle: data.ToolName,
-		Template: headerOrange,
-		Tags:     []cardTag{{Text: "pending", Color: "orange"}},
-	})
+	cardJSON := buildPermissionCardWithButtons(data)
 	chatID := c.chatID
 	c.adapter.Log.Debug("feishu: sending permission request card", "chat", chatID, "request_id", data.ID)
 
@@ -75,16 +48,7 @@ func (c *FeishuConn) sendQuestionRequest(ctx context.Context, env *events.Envelo
 		return fmt.Errorf("feishu: extract question data: %w", err)
 	}
 
-	elements := buildQuestionElements(data.Questions)
-	elements = append(elements,
-		map[string]any{"tag": "hr"},
-		map[string]any{"tag": "markdown", "content": questionFooterHint(data.Questions)},
-	)
-
-	cardJSON := buildV1Card(cardHeader{
-		Title:    "用户输入请求",
-		Template: headerYellow,
-	}, map[string]any{"wide_screen_mode": true}, elements)
+	cardJSON := buildQuestionCardWithButtons(data)
 
 	chatID := c.chatID
 	if err := c.adapter.sendCardMessage(ctx, chatID, cardJSON); err != nil {
@@ -111,20 +75,7 @@ func (c *FeishuConn) sendElicitationRequest(ctx context.Context, env *events.Env
 		return fmt.Errorf("feishu: extract elicitation data: %w", err)
 	}
 
-	header := fmt.Sprintf("**🔗 MCP Server Request**\n`%s` 请求输入：\n%s", data.MCPServerName, data.Message)
-
-	var footer strings.Builder
-	footer.WriteString("---\n")
-	if data.URL != "" {
-		fmt.Fprintf(&footer, "📎 [外部表单](%s)\n", data.URL)
-	}
-	footer.WriteString("💬 回复 **accept/同意** 或 **decline/拒绝** 来响应此请求")
-
-	cardJSON := buildInteractionCard(header, footer.String(), cardHeader{
-		Title:    "MCP Server 请求",
-		Subtitle: data.MCPServerName,
-		Template: headerViolet,
-	})
+	cardJSON := buildElicitationCardWithButtons(data)
 
 	chatID := c.chatID
 	if err := c.adapter.sendCardMessage(ctx, chatID, cardJSON); err != nil {
@@ -259,19 +210,6 @@ func (a *Adapter) sendCardMessage(ctx context.Context, chatID, cardJSON string) 
 		return fmt.Errorf("feishu: send card message: %w", err)
 	}
 	return nil
-}
-
-// buildInteractionCard builds a CardKit v2 card for interaction requests.
-func buildInteractionCard(body, footer string, header cardHeader) string {
-	elements := []map[string]any{
-		{"tag": "markdown", "content": body},
-	}
-	if footer != "" {
-		elements = append(elements, map[string]any{"tag": "hr"})
-		elements = append(elements, map[string]any{"tag": "markdown", "content": footer})
-	}
-
-	return buildCard(header, map[string]any{"wide_screen_mode": true}, elements)
 }
 
 // isPermissionAllow checks if the normalized text is a permission-allow keyword.

--- a/internal/messaging/feishu/interaction_test.go
+++ b/internal/messaging/feishu/interaction_test.go
@@ -2,7 +2,6 @@ package feishu
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"log/slog"
 	"strings"
@@ -14,78 +13,6 @@ import (
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/pkg/events"
 )
-
-// ─── buildInteractionCard ─────────────────────────────────────────────────────
-
-func TestBuildInteractionCard(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name   string
-		body   string
-		footer string
-	}{
-		{
-			name:   "body only",
-			body:   "Hello **world**",
-			footer: "",
-		},
-		{
-			name:   "body and footer",
-			body:   "Header\n\n---\n",
-			footer: "Reply **yes** or **no**",
-		},
-		{
-			name:   "empty strings",
-			body:   "",
-			footer: "",
-		},
-		{
-			name:   "unicode content",
-			body:   "你好世界 🔔",
-			footer: "回复 **允许** 或 **拒绝**",
-		},
-		{
-			name:   "markdown heavy",
-			body:   "```\ncode block\n```\n**bold** and _italic_",
-			footer: "Option 1\nOption 2\nOption 3",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := buildInteractionCard(tt.body, tt.footer, cardHeader{Title: "Test"})
-
-			// Verify it's valid JSON
-			var card map[string]any
-			require.NoError(t, json.Unmarshal([]byte(got), &card), "output must be valid JSON")
-
-			// Verify structure
-			require.Equal(t, "2.0", card["schema"])
-			require.NotNil(t, card["config"])
-			require.NotNil(t, card["body"])
-
-			body := card["body"].(map[string]any)
-			elements, ok := body["elements"].([]any)
-			require.True(t, ok)
-
-			// Body markdown element
-			require.GreaterOrEqual(t, len(elements), 1)
-			firstEl, ok := elements[0].(map[string]any)
-			require.True(t, ok)
-			require.Equal(t, "markdown", firstEl["tag"])
-			require.Equal(t, tt.body, firstEl["content"])
-
-			// Footer: if non-empty, expect hr + markdown
-			if tt.footer != "" {
-				require.Equal(t, 3, len(elements), "expect hr + footer markdown")
-				require.Equal(t, "hr", elements[1].(map[string]any)["tag"])
-				footerEl := elements[2].(map[string]any)
-				require.Equal(t, "markdown", footerEl["tag"])
-				require.Equal(t, tt.footer, footerEl["content"])
-			}
-		})
-	}
-}
 
 // ─── truncate ─────────────────────────────────────────────────────────────────
 // NOTE: truncate uses byte indexing, not rune. Multi-byte UTF-8 characters
@@ -187,24 +114,6 @@ func TestInteractionManager_Empty(t *testing.T) {
 	m := messaging.NewInteractionManager(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	require.Equal(t, 0, m.Len())
 	require.Empty(t, m.GetAll())
-}
-
-// ─── buildInteractionCard JSON output ────────────────────────────────────────
-
-func TestBuildInteractionCard_EscapeHTML(t *testing.T) {
-	t.Parallel()
-	// HTML special chars must NOT be escaped in JSON output
-	got := buildInteractionCard("<test> & \"quotes\"", "", cardHeader{Title: "EscTest"})
-	var card map[string]any
-	require.NoError(t, json.Unmarshal([]byte(got), &card))
-	body := card["body"].(map[string]any)
-	elements := body["elements"].([]any)
-	markdown := elements[0].(map[string]any)
-	// JSON encoder by default escapes < > &, but we use SetEscapeHTML(false)
-	// Actually SetEscapeHTML(false) means it won't escape. Let's verify.
-	content := markdown["content"].(string)
-	// The content should be preserved as-is
-	require.Equal(t, "<test> & \"quotes\"", content)
 }
 
 // ─── interaction manager: Len/GetAll ──────────────────────────────────────────

--- a/internal/messaging/feishu/ws.go
+++ b/internal/messaging/feishu/ws.go
@@ -15,6 +15,10 @@ import (
 
 func (a *Adapter) newEventHandler() *dispatcher.EventDispatcher {
 	return dispatcher.NewEventDispatcher("", "").
+		// Callbacks are dispatched before message events in the EventDispatcher
+		// (Do() checks callbackType2CallbackHandler before eventType2EventHandler),
+		// so register card action handlers first to mirror that priority order.
+		OnP2CardActionTrigger(a.handleCardActionTrigger).
 		OnP2MessageReceiveV1(func(ctx context.Context, event *larkim.P2MessageReceiveV1) (err error) {
 			defer func() {
 				if r := recover(); r != nil {


### PR DESCRIPTION
Closes #621

## Summary

Replace Feishu's display-only interaction cards with true interactive button cards. Previously users had to type text ("允许/拒绝") to respond to permission requests — now they can click [✅ 允许] / [❌ 拒绝] buttons directly on Feishu cards.

## Architecture

Uses Lark SDK v3.9.3's built-in `EventDispatcher.OnP2CardActionTrigger` (no SDK patching required). Card button clicks arrive as `card.action.trigger` P2 events via the existing WebSocket connection.

```
User clicks button → MessageTypeEvent frame (card.action.trigger)
  → EventDispatcher.OnP2CardActionTrigger
  → handleCardActionTrigger()
    ├── Get() owner check (non-destructive)
    ├── Complete() atomic claim (first-to-respond-wins)
    ├── SendResponse() → Worker receives authorization
    └── CardActionTriggerResponse → card updates in-place (green✅/red🚫)
```

Text fallback (`checkPendingInteraction`) preserved — both channels compete via `InteractionManager.Complete` atomicity.

## Changes

| File | Change | Purpose |
|------|--------|---------|
| `card_action.go` | NEW | handleCardActionTrigger with owner verification + panic recovery |
| `card_action_test.go` | NEW | 10 TDD unit tests |
| `card_action_integration_test.go` | NEW | 1 E2E routing test |
| `card_template.go` | +165 | 4 button-equipped builders (permission/question/elicitation/resolved) |
| `card_template_test.go` | +231 | 8 template structure tests |
| `ws.go` | +4 | Register OnP2CardActionTrigger in EventDispatcher |
| `interaction.go` | -57 | Switch senders to button cards, retain text fallback |
| `AGENTS.md` | ±6 | Update documentation |
| `docs/specs/...` | ±26 | Correct console configuration guide |

## Verification

- `go build` ✅ · `go vet` ✅
- 355 tests with `-race`: ALL PASS
- Slack untouched · WebChat untouched
- No SDK patching

## Feishu Console Configuration Required

```
开发配置 → 事件与回调 → 回调配置
  → 使用长连接接收回调
  → 添加「卡片回传交互」(card.action.trigger)
```