### PR TITLE
feat(security): HMAC cookie auth for webchat — eliminate build-time API key exposure

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -415,6 +415,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		cookieAuth = ca
 		auth.SetCookieAuth(ca)
 		log.Info("gateway: webchat cookie auth enabled")
+		log.Warn("gateway: webchat cookie auth uses shared \"webchat_user\" identity; all visitors share the same session ownership — not suitable for multi-user deployments")
 	}
 
 	mux := http.NewServeMux()

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -70,6 +70,7 @@ type GatewayDeps struct {
 	ConfigWatcher   *config.Watcher
 	CronScheduler   *cron.Scheduler
 	WebhookHandler  *gateway.WebhookHandler // non-nil when webhook is enabled
+	CookieAuth      *security.CookieAuth    // non-nil when webchat is enabled
 	ChatAccessStore messaging.ChatAccessStorer
 	DB              *sql.DB
 	DBResolver      *security.DBResolver
@@ -404,6 +405,18 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		}
 	}
 
+	// Cookie auth: created when webchat is enabled for same-origin browser authentication.
+	var cookieAuth *security.CookieAuth
+	if cfg.WebChat.Enabled {
+		ca, err := security.NewCookieAuth()
+		if err != nil {
+			return fmt.Errorf("create cookie auth: %w", err)
+		}
+		cookieAuth = ca
+		auth.SetCookieAuth(ca)
+		log.Info("gateway: webchat cookie auth enabled")
+	}
+
 	mux := http.NewServeMux()
 	deps := &GatewayDeps{
 		Log:             log,
@@ -419,6 +432,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		Bridge:          bridge,
 		ConfigWatcher:   configWatcher,
 		CronScheduler:   cronScheduler,
+		CookieAuth:      cookieAuth,
 		ChatAccessStore: stores.chatAccessOrNew(stores.sqlDB, log),
 		DB:              stores.sqlDB,
 		DBResolver:      dbResolver,
@@ -464,7 +478,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 			log.Warn("csp: webchat policy is permissive (any http/https/ws/wss host allowed); set security.csp to restrict in production",
 				"service", "webchat")
 		}
-		spa := webchat.Handler(cfg.Security.CSP)
+		spa := webchat.Handler(cfg.Security.CSP, cookieAuth)
 		rootHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, pattern := mux.Handler(r)
 			if pattern != "" {

--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -62,7 +62,7 @@ func setupRoutes(
 	mux.HandleFunc("OPTIONS /api/sessions/{id}/history", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
 	mux.HandleFunc("OPTIONS /api/sessions/{id}/events", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
 
-	mux.Handle("GET /ws", hub.HandleHTTP(auth, handler, bridge))
+	mux.Handle("GET /ws", hub.HandleHTTP(auth, handler, bridge, deps.CookieAuth))
 
 	sessionAdapter := &sessionManagerAdapter{sm: sm}
 	hubAdapter := &hubAdapter{hub: hub}

--- a/docs/superpowers/specs/2026-06-02-webchat-cookie-auth-design.md
+++ b/docs/superpowers/specs/2026-06-02-webchat-cookie-auth-design.md
@@ -1,7 +1,7 @@
 # Webchat Cookie 认证设计规格
 
 **日期**: 2026-06-02
-**状态**: Draft
+**状态**: Implemented (PR #625)
 **范围**: 消除构建时 API Key 泄露，改用运行时 HMAC 签名 Cookie 认证
 
 ---

--- a/docs/superpowers/specs/2026-06-02-webchat-cookie-auth-design.md
+++ b/docs/superpowers/specs/2026-06-02-webchat-cookie-auth-design.md
@@ -53,7 +53,7 @@ type CookieAuth struct {
 }
 
 func NewCookieAuth() *CookieAuth
-func (c *CookieAuth) SetCookie(w http.ResponseWriter, userID string) error
+func (c *CookieAuth) SetCookie(w http.ResponseWriter, r *http.Request, userID string) error
 func (c *CookieAuth) Authenticate(r *http.Request) (userID string, ok bool)
 ```
 

--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -346,7 +346,7 @@ func setupTestGateway(t *testing.T) *testGateway {
 	bridge.SetWorkerFactory(testWorkerFactory{})
 
 	mux := http.NewServeMux()
-	mux.Handle("/ws", hub.HandleHTTP(auth, handler, bridge))
+	mux.Handle("/ws", hub.HandleHTTP(auth, handler, bridge, nil))
 
 	server := httptest.NewServer(mux)
 

--- a/internal/gateway/hub.go
+++ b/internal/gateway/hub.go
@@ -371,6 +371,7 @@ func (h *Hub) HandleHTTP(
 	auth *security.Authenticator,
 	handler *Handler,
 	bridge *Bridge,
+	cookieAuth *security.CookieAuth,
 ) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -388,6 +389,14 @@ func (h *Hub) HandleHTTP(
 			}
 			userID = uid
 			botID = security.BotIDFromRequest(r)
+		} else if cookieAuth != nil {
+			// No API key — try cookie auth before deferring to init envelope.
+			if uid, ok := cookieAuth.Authenticate(r); ok {
+				userID = uid
+				botID = security.BotIDFromRequest(r)
+			} else {
+				pendingAuth = true
+			}
 		} else {
 			// No key at HTTP level — defer to init envelope auth (browser WS clients).
 			pendingAuth = true

--- a/internal/gateway/hub_test.go
+++ b/internal/gateway/hub_test.go
@@ -1041,7 +1041,7 @@ func TestHub_HandleHTTP_Success(t *testing.T) {
 	handler := NewHandler(HandlerDeps{Log: slog.Default(), Hub: h})
 	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
 
-	serveHandler := h.HandleHTTP(auth, handler, bridge)
+	serveHandler := h.HandleHTTP(auth, handler, bridge, nil)
 	server := httptest.NewServer(serveHandler)
 	defer server.Close()
 
@@ -1072,7 +1072,7 @@ func TestHub_HandleHTTP_DeferredAuth(t *testing.T) {
 	handler := NewHandler(HandlerDeps{Log: slog.Default(), Hub: h})
 	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
 
-	serveHandler := h.HandleHTTP(auth, handler, bridge)
+	serveHandler := h.HandleHTTP(auth, handler, bridge, nil)
 	server := httptest.NewServer(serveHandler)
 	defer server.Close()
 
@@ -1095,7 +1095,7 @@ func TestHub_HandleHTTP_WithSessionID(t *testing.T) {
 	handler := NewHandler(HandlerDeps{Log: slog.Default(), Hub: h})
 	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
 
-	serveHandler := h.HandleHTTP(auth, handler, bridge)
+	serveHandler := h.HandleHTTP(auth, handler, bridge, nil)
 	server := httptest.NewServer(serveHandler)
 	defer server.Close()
 
@@ -1127,7 +1127,7 @@ func TestHub_HandleHTTP_GeneratesSessionID(t *testing.T) {
 	handler := NewHandler(HandlerDeps{Log: slog.Default(), Hub: h})
 	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
 
-	serveHandler := h.HandleHTTP(auth, handler, bridge)
+	serveHandler := h.HandleHTTP(auth, handler, bridge, nil)
 	server := httptest.NewServer(serveHandler)
 	defer server.Close()
 
@@ -1160,7 +1160,7 @@ func TestHub_HandleHTTP_RejectsInvalidAPIKey(t *testing.T) {
 	handler := NewHandler(HandlerDeps{Log: slog.Default(), Hub: h})
 	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
 
-	serveHandler := h.HandleHTTP(auth, handler, bridge)
+	serveHandler := h.HandleHTTP(auth, handler, bridge, nil)
 	server := httptest.NewServer(serveHandler)
 	defer server.Close()
 

--- a/internal/gateway/hub_test.go
+++ b/internal/gateway/hub_test.go
@@ -1173,6 +1173,79 @@ func TestHub_HandleHTTP_RejectsInvalidAPIKey(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
+// TestHub_HandleHTTP_CookieAuth verifies that a valid HMAC cookie authenticates
+// the WebSocket upgrade without requiring an API key header.
+func TestHub_HandleHTTP_CookieAuth(t *testing.T) {
+	cfg := config.Default()
+	cfg.Security.AllowedOrigins = []string{"*"}
+
+	cookieAuth, err := security.NewCookieAuth()
+	require.NoError(t, err)
+
+	auth := security.NewAuthenticator(&cfg.Security)
+	auth.SetCookieAuth(cookieAuth)
+
+	h := newTestHub(t)
+	handler := NewHandler(HandlerDeps{Log: slog.Default(), Hub: h})
+	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
+
+	serveHandler := h.HandleHTTP(auth, handler, bridge, cookieAuth)
+	server := httptest.NewServer(serveHandler)
+	defer server.Close()
+
+	// Issue a cookie via CookieAuth.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	_ = cookieAuth.SetCookie(w, r, "cookie_user")
+	cookies := w.Result().Cookies()
+	require.Len(t, cookies, 1)
+
+	// Connect with the cookie but no API key header.
+	u := "ws" + server.URL[4:]
+	header := http.Header{}
+	header.Set("Cookie", cookies[0].String())
+
+	conn, resp, err := websocket.DefaultDialer.Dial(u, header)
+	require.NoError(t, err, "WebSocket upgrade should succeed with valid cookie")
+	defer conn.Close()
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+
+	require.Eventually(t, func() bool {
+		return h.ConnectionsOpen() > 0
+	}, 2*time.Second, 10*time.Millisecond, "hub should have registered the cookie-authed connection")
+}
+
+// TestHub_HandleHTTP_CookieAuth_InvalidCookie verifies that an invalid cookie
+// falls back to pendingAuth (deferred to init envelope).
+func TestHub_HandleHTTP_CookieAuth_InvalidCookie(t *testing.T) {
+	cfg := config.Default()
+	cfg.Security.AllowedOrigins = []string{"*"}
+
+	cookieAuth, err := security.NewCookieAuth()
+	require.NoError(t, err)
+
+	auth := security.NewAuthenticator(&cfg.Security)
+	auth.SetCookieAuth(cookieAuth)
+
+	h := newTestHub(t)
+	handler := NewHandler(HandlerDeps{Log: slog.Default(), Hub: h})
+	bridge := NewBridge(BridgeDeps{Log: slog.Default(), Hub: h})
+
+	serveHandler := h.HandleHTTP(auth, handler, bridge, cookieAuth)
+	server := httptest.NewServer(serveHandler)
+	defer server.Close()
+
+	// Connect with a garbage cookie — should still upgrade (pendingAuth).
+	u := "ws" + server.URL[4:]
+	header := http.Header{}
+	header.Set("Cookie", "webchat_session=invalid_garbage_value")
+
+	conn, resp, err := websocket.DefaultDialer.Dial(u, header)
+	require.NoError(t, err, "WebSocket upgrade should succeed with invalid cookie (pendingAuth fallback)")
+	defer conn.Close()
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+}
+
 // TestHub_SendToSession_PlatformConnOwnerID verifies that json:"-" fields
 // (specifically OwnerID) survive the Hub routing pipeline when delivering
 // to platform conns. Regression test: routeMessage's pre-encode path used

--- a/internal/gateway/hub_test.go
+++ b/internal/gateway/hub_test.go
@@ -1176,6 +1176,7 @@ func TestHub_HandleHTTP_RejectsInvalidAPIKey(t *testing.T) {
 // TestHub_HandleHTTP_CookieAuth verifies that a valid HMAC cookie authenticates
 // the WebSocket upgrade without requiring an API key header.
 func TestHub_HandleHTTP_CookieAuth(t *testing.T) {
+	t.Parallel()
 	cfg := config.Default()
 	cfg.Security.AllowedOrigins = []string{"*"}
 
@@ -1218,6 +1219,7 @@ func TestHub_HandleHTTP_CookieAuth(t *testing.T) {
 // TestHub_HandleHTTP_CookieAuth_InvalidCookie verifies that an invalid cookie
 // falls back to pendingAuth (deferred to init envelope).
 func TestHub_HandleHTTP_CookieAuth_InvalidCookie(t *testing.T) {
+	t.Parallel()
 	cfg := config.Default()
 	cfg.Security.AllowedOrigins = []string{"*"}
 

--- a/internal/security/auth.go
+++ b/internal/security/auth.go
@@ -30,6 +30,7 @@ type Authenticator struct {
 	dbKeys        map[string]bool // database-sourced keys (Admin API CRUD)
 	keyResolver   APIKeyResolver  // optional; maps API keys to user identities. nil = "api_user"
 	devModeLocked bool            // true once any key has existed; prevents dev mode re-enable
+	cookieAuth    *CookieAuth     // optional; HMAC cookie auth (3rd priority after header/query)
 }
 
 // NewAuthenticator creates a new authenticator.
@@ -46,6 +47,14 @@ func NewAuthenticator(cfg *config.SecurityConfig) *Authenticator {
 	}
 }
 
+// SetCookieAuth enables cookie-based authentication as a 3rd priority fallback
+// after header and query param. Typically called when webchat is enabled.
+func (a *Authenticator) SetCookieAuth(ca *CookieAuth) {
+	a.mu.Lock()
+	a.cookieAuth = ca
+	a.mu.Unlock()
+}
+
 // ErrUnauthorized is returned when authentication fails.
 var ErrUnauthorized = errors.New("security: unauthorized")
 
@@ -56,6 +65,14 @@ func (a *Authenticator) AuthenticateRequest(r *http.Request) (string, string, er
 
 	key, found := a.extractAPIKey(r)
 	if !found {
+		// 3rd priority: cookie auth fallback (webchat same-origin).
+		if a.cookieAuth != nil {
+			if uid, ok := a.cookieAuth.Authenticate(r); ok {
+				a.mu.RUnlock()
+				botID := BotIDFromRequest(r)
+				return uid, botID, nil
+			}
+		}
 		a.mu.RUnlock()
 		return "", "", ErrUnauthorized
 	}

--- a/internal/security/cookie.go
+++ b/internal/security/cookie.go
@@ -1,7 +1,3 @@
-// Package security provides HMAC-SHA256 signed cookie authentication for webchat.
-//
-// Cookie format: Base64(timestamp|userID|HMAC(timestamp|userID, secret))
-// Cookie attributes: HttpOnly, SameSite=Strict, Path=/, conditional Secure, 24h Max-Age
 package security
 
 import (
@@ -9,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -27,9 +24,16 @@ const (
 	hmacKeyLen = 32
 )
 
-// CookieAuth provides HMAC-SHA256 signed cookie issuance and verification.
-// The HMAC key is generated at startup via crypto/rand — it is never stored
-// on disk or embedded in the binary.
+// CookieAuth provides HMAC-SHA256 signed cookie issuance and verification for
+// same-origin webchat deployments. The HMAC key is generated at startup via
+// crypto/rand and is never stored on disk or embedded in the binary.
+//
+// Cookie format: Base64(timestamp|userID|hex(HMAC-SHA256(timestamp|userID, secret)))
+// Cookie attributes: HttpOnly, SameSite=Strict, Path=/, conditional Secure, 24h Max-Age.
+//
+// Immutability: the secret and maxAge fields are set once at construction and never
+// modified. This allows safe concurrent access from both Hub.HandleHTTP (WS upgrade)
+// and Authenticator.AuthenticateRequest (REST API) without additional locking.
 type CookieAuth struct {
 	secret []byte
 	maxAge time.Duration
@@ -80,16 +84,18 @@ func (c *CookieAuth) Authenticate(r *http.Request) (string, bool) {
 	return c.verify(cookie.Value)
 }
 
-// sign creates a signed cookie value: Base64(timestamp|userID|hmac).
+// sign creates a signed cookie value: Base64(timestamp|userID|hexHMAC).
+// The HMAC signature is hex-encoded to avoid binary bytes in the delimited format,
+// making the cookie value safe for debugging and unambiguous to parse.
 func (c *CookieAuth) sign(userID string) string {
 	ts := time.Now().Unix()
 	payload := fmt.Sprintf("%d|%s", ts, userID)
 
 	mac := hmac.New(sha256.New, c.secret)
 	mac.Write([]byte(payload))
-	sig := mac.Sum(nil)
+	sig := hex.EncodeToString(mac.Sum(nil))
 
-	return base64.RawURLEncoding.EncodeToString([]byte(payload + "|" + string(sig)))
+	return base64.RawURLEncoding.EncodeToString([]byte(payload + "|" + sig))
 }
 
 // verify parses and validates a signed cookie value.
@@ -104,7 +110,7 @@ func (c *CookieAuth) verify(encoded string) (string, bool) {
 		return "", false
 	}
 
-	tsStr, userID, sig := parts[0], parts[1], []byte(parts[2])
+	tsStr, userID, sigHex := parts[0], parts[1], parts[2]
 
 	// Check timestamp freshness.
 	ts, err := strconv.ParseInt(tsStr, 10, 64)
@@ -112,6 +118,12 @@ func (c *CookieAuth) verify(encoded string) (string, bool) {
 		return "", false
 	}
 	if time.Since(time.Unix(ts, 0)) > c.maxAge {
+		return "", false
+	}
+
+	// Decode hex-encoded HMAC signature.
+	sig, err := hex.DecodeString(sigHex)
+	if err != nil {
 		return "", false
 	}
 
@@ -129,7 +141,11 @@ func (c *CookieAuth) verify(encoded string) (string, bool) {
 }
 
 // isHTTPS determines if the request was made over HTTPS.
-// Checks TLS state and X-Forwarded-Proto header (reverse proxy).
+// Checks TLS state and X-Forwarded-Proto header (set by reverse proxies).
+// Note: X-Forwarded-Proto is trusted unconditionally — a misconfigured or
+// direct-access client could set this header, causing the Secure flag on
+// the cookie. This is a self-DoS (cookie won't be sent back over HTTP),
+// not a security bypass.
 func isHTTPS(r *http.Request) bool {
 	if r.TLS != nil {
 		return true

--- a/internal/security/cookie.go
+++ b/internal/security/cookie.go
@@ -1,0 +1,138 @@
+// Package security provides HMAC-SHA256 signed cookie authentication for webchat.
+//
+// Cookie format: Base64(timestamp|userID|HMAC(timestamp|userID, secret))
+// Cookie attributes: HttpOnly, SameSite=Strict, Path=/, conditional Secure, 24h Max-Age
+package security
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// cookieName is the HTTP cookie name for webchat session authentication.
+	cookieName = "webchat_session"
+
+	// cookieMaxAge is the default cookie lifetime (24 hours).
+	cookieMaxAge = 24 * time.Hour
+
+	// hmacKeyLen is the HMAC secret key length in bytes.
+	hmacKeyLen = 32
+)
+
+// CookieAuth provides HMAC-SHA256 signed cookie issuance and verification.
+// The HMAC key is generated at startup via crypto/rand — it is never stored
+// on disk or embedded in the binary.
+type CookieAuth struct {
+	secret []byte
+	maxAge time.Duration
+}
+
+// NewCookieAuth creates a CookieAuth with a cryptographically random HMAC key.
+func NewCookieAuth() (*CookieAuth, error) {
+	secret := make([]byte, hmacKeyLen)
+	if _, err := rand.Read(secret); err != nil {
+		return nil, fmt.Errorf("security: generate cookie secret: %w", err)
+	}
+	return &CookieAuth{
+		secret: secret,
+		maxAge: cookieMaxAge,
+	}, nil
+}
+
+// SetCookie issues a new HMAC-signed cookie for the given userID.
+// If the request already carries a valid cookie, this is a no-op (avoids
+// resetting the expiry on every page refresh).
+func (c *CookieAuth) SetCookie(w http.ResponseWriter, r *http.Request, userID string) error {
+	// Skip if the request already has a valid cookie for this user.
+	if uid, ok := c.Authenticate(r); ok && uid == userID {
+		return nil
+	}
+
+	value := c.sign(userID)
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     cookieName,
+		Value:    value,
+		Path:     "/",
+		MaxAge:   int(c.maxAge.Seconds()),
+		HttpOnly: true,
+		Secure:   isHTTPS(r),
+		SameSite: http.SameSiteStrictMode,
+	})
+	return nil
+}
+
+// Authenticate extracts and validates the cookie from the request.
+// Returns (userID, true) if valid, ("", false) otherwise.
+func (c *CookieAuth) Authenticate(r *http.Request) (string, bool) {
+	cookie, err := r.Cookie(cookieName)
+	if err != nil {
+		return "", false
+	}
+	return c.verify(cookie.Value)
+}
+
+// sign creates a signed cookie value: Base64(timestamp|userID|hmac).
+func (c *CookieAuth) sign(userID string) string {
+	ts := time.Now().Unix()
+	payload := fmt.Sprintf("%d|%s", ts, userID)
+
+	mac := hmac.New(sha256.New, c.secret)
+	mac.Write([]byte(payload))
+	sig := mac.Sum(nil)
+
+	return base64.RawURLEncoding.EncodeToString([]byte(payload + "|" + string(sig)))
+}
+
+// verify parses and validates a signed cookie value.
+func (c *CookieAuth) verify(encoded string) (string, bool) {
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", false
+	}
+
+	parts := strings.SplitN(string(raw), "|", 3)
+	if len(parts) != 3 {
+		return "", false
+	}
+
+	tsStr, userID, sig := parts[0], parts[1], []byte(parts[2])
+
+	// Check timestamp freshness.
+	ts, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		return "", false
+	}
+	if time.Since(time.Unix(ts, 0)) > c.maxAge {
+		return "", false
+	}
+
+	// Verify HMAC signature (constant-time comparison via hmac.Equal).
+	payload := tsStr + "|" + userID
+	mac := hmac.New(sha256.New, c.secret)
+	mac.Write([]byte(payload))
+	expected := mac.Sum(nil)
+
+	if !hmac.Equal(sig, expected) {
+		return "", false
+	}
+
+	return userID, true
+}
+
+// isHTTPS determines if the request was made over HTTPS.
+// Checks TLS state and X-Forwarded-Proto header (reverse proxy).
+func isHTTPS(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	return r.Header.Get("X-Forwarded-Proto") == "https"
+}

--- a/internal/security/cookie_test.go
+++ b/internal/security/cookie_test.go
@@ -1,0 +1,233 @@
+package security
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/config"
+)
+
+func TestCookieAuthSignVerify(t *testing.T) {
+	t.Parallel()
+
+	ca, err := NewCookieAuth()
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+
+	// Sign a cookie.
+	err = ca.SetCookie(w, r, "user1")
+	require.NoError(t, err)
+
+	// Extract the cookie from the response.
+	cookies := w.Result().Cookies()
+	require.Len(t, cookies, 1)
+	require.Equal(t, cookieName, cookies[0].Name)
+	require.True(t, cookies[0].HttpOnly)
+	require.Equal(t, http.SameSiteStrictMode, cookies[0].SameSite)
+
+	// Verify the cookie in a new request.
+	r2 := httptest.NewRequest("GET", "/", nil)
+	r2.AddCookie(cookies[0])
+
+	uid, ok := ca.Authenticate(r2)
+	require.True(t, ok)
+	require.Equal(t, "user1", uid)
+}
+
+func TestCookieAuthExpiry(t *testing.T) {
+	t.Parallel()
+
+	ca, err := NewCookieAuth()
+	require.NoError(t, err)
+
+	// Create a cookie with a manually-expired timestamp.
+	ca.maxAge = 1 * time.Nanosecond
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+
+	err = ca.SetCookie(w, r, "expired_user")
+	require.NoError(t, err)
+
+	// Wait for expiry.
+	time.Sleep(10 * time.Millisecond)
+
+	cookies := w.Result().Cookies()
+	require.Len(t, cookies, 1)
+
+	r2 := httptest.NewRequest("GET", "/", nil)
+	r2.AddCookie(cookies[0])
+
+	uid, ok := ca.Authenticate(r2)
+	require.False(t, ok, "expired cookie should be rejected")
+	require.Empty(t, uid)
+
+	// Restore default for other tests.
+	ca.maxAge = cookieMaxAge
+}
+
+func TestCookieAuthTamper(t *testing.T) {
+	t.Parallel()
+
+	ca, err := NewCookieAuth()
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+
+	err = ca.SetCookie(w, r, "user1")
+	require.NoError(t, err)
+
+	cookies := w.Result().Cookies()
+	require.Len(t, cookies, 1)
+
+	// Tamper with the cookie value.
+	tampered := cookies[0].Value + "x"
+	r2 := httptest.NewRequest("GET", "/", nil)
+	r2.AddCookie(&http.Cookie{Name: cookieName, Value: tampered})
+
+	uid, ok := ca.Authenticate(r2)
+	require.False(t, ok, "tampered cookie should be rejected")
+	require.Empty(t, uid)
+
+	// Empty cookie value.
+	r3 := httptest.NewRequest("GET", "/", nil)
+	r3.AddCookie(&http.Cookie{Name: cookieName, Value: ""})
+
+	uid, ok = ca.Authenticate(r3)
+	require.False(t, ok)
+	require.Empty(t, uid)
+
+	// Garbage base64.
+	r4 := httptest.NewRequest("GET", "/", nil)
+	r4.AddCookie(&http.Cookie{Name: cookieName, Value: "!!invalid!!"})
+
+	uid, ok = ca.Authenticate(r4)
+	require.False(t, ok)
+	require.Empty(t, uid)
+}
+
+func TestCookieSecureFlag(t *testing.T) {
+	t.Parallel()
+
+	ca, err := NewCookieAuth()
+	require.NoError(t, err)
+
+	// HTTP request — Secure should be false.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	err = ca.SetCookie(w, r, "user1")
+	require.NoError(t, err)
+
+	cookies := w.Result().Cookies()
+	require.Len(t, cookies, 1)
+	require.False(t, cookies[0].Secure, "Secure flag should be false for HTTP")
+
+	// HTTPS request (TLS) — Secure should be true.
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest("GET", "/", nil)
+	r2.TLS = &tls.ConnectionState{} // Simulate HTTPS
+	err = ca.SetCookie(w2, r2, "user2")
+	require.NoError(t, err)
+
+	cookies2 := w2.Result().Cookies()
+	require.Len(t, cookies2, 1)
+	require.True(t, cookies2[0].Secure, "Secure flag should be true for HTTPS")
+
+	// X-Forwarded-Proto: https — Secure should be true.
+	w3 := httptest.NewRecorder()
+	r3 := httptest.NewRequest("GET", "/", nil)
+	r3.Header.Set("X-Forwarded-Proto", "https")
+	err = ca.SetCookie(w3, r3, "user3")
+	require.NoError(t, err)
+
+	cookies3 := w3.Result().Cookies()
+	require.Len(t, cookies3, 1)
+	require.True(t, cookies3[0].Secure, "Secure flag should be true for X-Forwarded-Proto: https")
+}
+
+func TestCookieNoRepeatIssue(t *testing.T) {
+	t.Parallel()
+
+	ca, err := NewCookieAuth()
+	require.NoError(t, err)
+
+	// First request: issues a cookie.
+	w1 := httptest.NewRecorder()
+	r1 := httptest.NewRequest("GET", "/", nil)
+	err = ca.SetCookie(w1, r1, "user1")
+	require.NoError(t, err)
+	require.Len(t, w1.Result().Cookies(), 1, "should issue cookie on first request")
+
+	// Second request with valid cookie: should NOT re-issue.
+	cookies := w1.Result().Cookies()
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest("GET", "/", nil)
+	r2.AddCookie(cookies[0])
+	err = ca.SetCookie(w2, r2, "user1")
+	require.NoError(t, err)
+	require.Empty(t, w2.Result().Cookies(), "should not re-issue cookie when valid one exists")
+}
+
+func TestAuthenticateRequestCookie(t *testing.T) {
+	t.Parallel()
+
+	ca, err := NewCookieAuth()
+	require.NoError(t, err)
+
+	auth := NewAuthenticator(&config.SecurityConfig{APIKeyHeader: "X-API-Key"})
+	auth.SetCookieAuth(ca)
+
+	// Issue a cookie.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	err = ca.SetCookie(w, r, "cookie_user")
+	require.NoError(t, err)
+
+	// Request with cookie (no API key header/query) should succeed.
+	cookies := w.Result().Cookies()
+	r2 := httptest.NewRequest("GET", "/", nil)
+	r2.AddCookie(cookies[0])
+
+	uid, botID, err2 := auth.AuthenticateRequest(r2)
+	require.NoError(t, err2)
+	require.Equal(t, "cookie_user", uid)
+	require.Empty(t, botID)
+
+	// Request without any auth should fail.
+	r3 := httptest.NewRequest("GET", "/", nil)
+	_, _, err3 := auth.AuthenticateRequest(r3)
+	require.ErrorIs(t, err3, ErrUnauthorized)
+}
+
+func TestCookieAuthWithBotID(t *testing.T) {
+	t.Parallel()
+
+	ca, err := NewCookieAuth()
+	require.NoError(t, err)
+
+	auth := NewAuthenticator(&config.SecurityConfig{APIKeyHeader: "X-API-Key"})
+	auth.SetCookieAuth(ca)
+
+	// Issue a cookie.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	err = ca.SetCookie(w, r, "cookie_user")
+	require.NoError(t, err)
+
+	// Request with cookie + bot_id query param.
+	cookies := w.Result().Cookies()
+	r2 := httptest.NewRequest("GET", "/?bot_id=U12345", nil)
+	r2.AddCookie(cookies[0])
+
+	uid, botID, err2 := auth.AuthenticateRequest(r2)
+	require.NoError(t, err2)
+	require.Equal(t, "cookie_user", uid)
+	require.Equal(t, "U12345", botID)
+}

--- a/internal/security/cookie_test.go
+++ b/internal/security/cookie_test.go
@@ -55,8 +55,8 @@ func TestCookieAuthExpiry(t *testing.T) {
 	err = ca.SetCookie(w, r, "expired_user")
 	require.NoError(t, err)
 
-	// Wait for expiry.
-	time.Sleep(10 * time.Millisecond)
+	// No sleep needed: maxAge is 1ns, so time.Since(ts) in verify() will
+	// always exceed maxAge by the time we reach this point.
 
 	cookies := w.Result().Cookies()
 	require.Len(t, cookies, 1)

--- a/internal/webchat/server.go
+++ b/internal/webchat/server.go
@@ -18,13 +18,16 @@ var fileServer = http.FileServerFS(spaFS)
 // directive when serving from a non-localhost host (e.g. reverse-prod on
 // http://192.168.1.100:9999). Whitespace-only csp is treated as empty.
 //
+// cookieAuth, when non-nil, enables automatic HMAC cookie issuance on the
+// SPA fallback path (index.html). Static assets (/_next/*) skip cookie handling.
+//
 // Routing strategy:
 //   - /_next/*  → static assets with aggressive cache headers (hashed filenames)
 //   - exact file match (favicon, robots.txt) → serve directly
 //   - everything else → fallback to index.html (client-side routing)
 //
 // Must be registered last on the ServeMux so explicit API/WS routes take priority.
-func Handler(csp string) http.Handler {
+func Handler(csp string, cookieAuth *security.CookieAuth) http.Handler {
 	return security.SecurityHeaders(security.DefaultWebChatCSP, csp, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
@@ -68,6 +71,10 @@ func Handler(csp string) http.Handler {
 		}
 
 		// SPA fallback: serve index.html for all non-file paths.
+		// Issue a cookie if cookieAuth is configured and request lacks a valid one.
+		if cookieAuth != nil {
+			_ = cookieAuth.SetCookie(w, r, "webchat_user")
+		}
 		w.Header().Set("Cache-Control", "no-cache")
 		r.URL.Path = "/"
 		fileServer.ServeHTTP(w, r)

--- a/internal/webchat/server.go
+++ b/internal/webchat/server.go
@@ -73,6 +73,10 @@ func Handler(csp string, cookieAuth *security.CookieAuth) http.Handler {
 		// SPA fallback: serve index.html for all non-file paths.
 		// Issue a cookie if cookieAuth is configured and request lacks a valid one.
 		if cookieAuth != nil {
+			// TODO(security): support real user identity via login/OAuth.
+			// Currently all webchat visitors share "webchat_user" identity.
+			// This is sufficient for single-user webchat but prevents cookie-authed
+			// users from accessing sessions created by specific API key identities.
 			_ = cookieAuth.SetCookie(w, r, "webchat_user")
 		}
 		w.Header().Set("Cache-Control", "no-cache")

--- a/webchat/lib/adapters/hotplex-runtime-adapter.ts
+++ b/webchat/lib/adapters/hotplex-runtime-adapter.ts
@@ -10,7 +10,7 @@ import type { ExternalStoreAdapter, ThreadMessageLike, AppendMessage } from '@as
 import { BrowserHotPlexClient } from '@/lib/ai-sdk-transport';
 import type { InitConfig, ContextUsageData, PermissionRequestData, QuestionRequestData, ElicitationRequestData } from '@/lib/ai-sdk-transport/client/types';
 import { WorkerStdioCommand } from '@/lib/ai-sdk-transport/client/constants';
-import { wsUrl, workerType, apiKey, workDir, allowedTools, type ConnectionState } from '@/lib/config';
+import { wsUrl, workerType, apiKey, isSameOrigin, workDir, allowedTools, type ConnectionState } from '@/lib/config';
 import { useMetrics } from '@/lib/hooks/useMetrics';
 import { getSessionHistory, type ConversationRecord } from '@/lib/api/sessions';
 import { conversationTurnsToMessages } from '@/lib/utils/turn-replay';
@@ -300,8 +300,8 @@ export function useHotPlexRuntime({
     const client = new BrowserHotPlexClient({
       url: wsUrl,
       workerType,
-      apiKey,
-      authToken: apiKey, // pass via init envelope auth.token for deferred auth
+      apiKey: isSameOrigin() ? undefined : apiKey,
+      authToken: isSameOrigin() ? undefined : apiKey,
       initConfig,
       heartbeat: {
         pingIntervalMs: 20000,

--- a/webchat/lib/api/sessions.ts
+++ b/webchat/lib/api/sessions.ts
@@ -5,10 +5,26 @@
  * using X-API-Key header for authentication.
  */
 
-import { httpBase, apiKey } from "@/lib/config";
+import { httpBase, apiKey, isSameOrigin } from "@/lib/config";
 
 const BASE = httpBase();
-const AUTH_HEADER = { 'X-API-Key': apiKey };
+
+// Build auth options: same-origin uses cookie auth (credentials: same-origin),
+// cross-origin deployments continue using X-API-Key header.
+function authHeaders(): Record<string, string> {
+  if (isSameOrigin()) return {};
+  return apiKey ? { 'X-API-Key': apiKey } : {};
+}
+
+function authOpts(): RequestInit {
+  if (isSameOrigin()) return { credentials: 'same-origin' as RequestCredentials };
+  return {};
+}
+
+// Merge auth headers with custom headers.
+function withAuth(headers?: Record<string, string>): Record<string, string> {
+  return { ...authHeaders(), ...headers };
+}
 
 export interface SessionInfo {
   id: string;
@@ -82,7 +98,7 @@ function throwIfAuthError(prefix: string, status: number): never | void {
 export async function listSessions(limit = 20, offset = 0, signal?: AbortSignal): Promise<ListSessionsResponse> {
   const res = await fetch(
     `${BASE}/api/sessions?limit=${limit}&offset=${offset}`,
-    { headers: { ...AUTH_HEADER, 'Content-Type': 'application/json' }, signal }
+    { headers: withAuth({ 'Content-Type': 'application/json' }), ...authOpts(), signal }
   );
   throwIfAuthError('listSessions', res.status);
   if (!res.ok) throw new Error(`listSessions failed: ${res.status}`);
@@ -101,7 +117,7 @@ export async function createSession(opts: CreateSessionOptions, signal?: AbortSi
   if (opts.workDir) {
     url += `&work_dir=${encodeURIComponent(opts.workDir)}`;
   }
-  const res = await fetch(url, { method: 'POST', headers: AUTH_HEADER, signal });
+  const res = await fetch(url, { method: 'POST', headers: authHeaders(), ...authOpts(), signal });
   throwIfAuthError('createSession', res.status);
   if (!res.ok) {
     const body = await res.text().catch(() => '');
@@ -113,7 +129,7 @@ export async function createSession(opts: CreateSessionOptions, signal?: AbortSi
 export async function deleteSession(id: string, signal?: AbortSignal): Promise<void> {
   const res = await fetch(
     `${BASE}/api/sessions/${id}`,
-    { method: 'DELETE', headers: AUTH_HEADER, signal }
+    { method: 'DELETE', headers: authHeaders(), ...authOpts(), signal }
   );
   throwIfAuthError('deleteSession', res.status);
   if (!res.ok) throw new Error(`deleteSession failed: ${res.status}`);
@@ -131,7 +147,7 @@ export async function getSessionHistory(
   if (options?.beforeId) {
     url += `&before_id=${options.beforeId}`;
   }
-  const res = await fetch(url, { headers: { ...AUTH_HEADER, 'Content-Type': 'application/json' }, signal: options?.signal });
+  const res = await fetch(url, { headers: withAuth({ 'Content-Type': 'application/json' }), ...authOpts(), signal: options?.signal });
   throwIfAuthError('getSessionHistory', res.status);
   if (!res.ok) throw new Error(`getSessionHistory failed: ${res.status}`);
   return res.json();

--- a/webchat/lib/api/sessions.ts
+++ b/webchat/lib/api/sessions.ts
@@ -1,8 +1,10 @@
 /**
  * Gateway API client for session management.
  *
- * These endpoints are on the same port as WebSocket (gateway :8888),
- * using X-API-Key header for authentication.
+ * These endpoints are on the same port as WebSocket (gateway :8888).
+ * Authentication strategy:
+ *   - Same-origin (embedded webchat): credentials: 'same-origin' (cookie auth)
+ *   - Cross-origin (external deployment): X-API-Key header
  */
 
 import { httpBase, apiKey, isSameOrigin } from "@/lib/config";

--- a/webchat/lib/config.ts
+++ b/webchat/lib/config.ts
@@ -29,7 +29,14 @@ export const workerType: WorkerType =
   (process.env.HOTPLEX_WEBCHAT_WORKER_TYPE as WorkerType) ?? "claude_code";
 
 export const apiKey: string =
-  process.env.HOTPLEX_WEBCHAT_API_KEY ?? "dev";
+  process.env.HOTPLEX_WEBCHAT_API_KEY ?? "";
+
+// isSameOrigin returns true when the webchat is served from the same origin
+// as the gateway (embedded via go:embed). In this mode, cookie auth is used
+// instead of X-API-Key header, so no build-time secret is needed.
+export function isSameOrigin(): boolean {
+  return typeof window !== "undefined" && !process.env.HOTPLEX_WEBCHAT_WS_URL;
+}
 
 // -- Per-session init config -------------------------------------------
 


### PR DESCRIPTION
## Problem

Closes #623

当前 webchat 的 API Key 通过 `.env.local` → `next.config.mjs` → JS bundle → `go:embed` 链路硬编码到二进制中，导致：

1. **二进制泄露密钥**：发布的 hotplex 二进制包含明文 API Key
2. **部署绑定**：不同部署需要重新构建 webchat
3. **违反 OWASP**：API Key 存储在 JS 中可被 XSS 读取

## Solution

HMAC-SHA256 签名 Cookie 认证（运行时生成密钥，零 secret 嵌入）：

```
浏览器 GET / → 检测无 cookie → 签发 HttpOnly cookie → 返回 index.html
后续请求 → 浏览器自动携带 cookie → Gateway 验证 HMAC 签名
```

## Changes

### Go Backend

| File | Change |
|------|--------|
| `internal/security/cookie.go` | **New**: `CookieAuth` — HMAC-SHA256 签发/验证，`crypto/rand` 密钥 |
| `internal/security/auth.go` | `AuthenticateRequest` 增加 cookie 第三优先级回退 |
| `internal/gateway/hub.go` | `HandleHTTP` WS 升级时检查 cookie |
| `internal/webchat/server.go` | SPA fallback 自动签发 cookie |
| `cmd/hotplex/gateway_run.go` | DI 创建 `CookieAuth` 并注入 |

### TypeScript Frontend

| File | Change |
|------|--------|
| `webchat/lib/config.ts` | `apiKey` 默认空，新增 `isSameOrigin()` |
| `webchat/lib/api/sessions.ts` | 同源 → `credentials:same-origin`，跨源 → `X-API-Key` |
| `webchat/lib/adapters/hotplex-runtime-adapter.ts` | 同源省略 `authToken` |

### Tests

8 个新测试：签名验证 round-trip、过期拒绝、篡改拒绝、Secure flag、不重复签发、cookie+botID。

## Backward Compatibility

- `X-API-Key` header 认证 **完全保留**（优先级 1）
- `api_key` query param 认证 **完全保留**（优先级 2）
- Cookie 是第三优先级回退
- 外部部署 webchat（非同源）继续使用 header 认证

## Security

| 威胁 | 防护 |
|------|------|
| 二进制泄露 | HMAC 密钥运行时生成 |
| XSS 窃取 | `HttpOnly` 不可读 |
| CSRF | `SameSite=Strict` |
| 伪造 | HMAC-SHA256 签名验证 |
| 重放 | 内置 timestamp，24h 过期 |