### PR TITLE
fix(session): harden client_session_id migration and decouple title from identity

### DIFF
--- a/docs/guides/developer/websocket-integration.md
+++ b/docs/guides/developer/websocket-integration.md
@@ -300,6 +300,7 @@ WebSocket 连接建立后，**必须在 30 秒内**发送 `init` 作为第一帧
 | ------------------------- | ---- | --------------------------------------------------- |
 | `version`                 | 是   | 固定 `"aep/v1"`                                     |
 | `worker_type`             | 是   | Worker 类型（`claude_code`、`codex_cli`、`acp` 等） |
+| `title`                   | 否   | 会话显示名称，不参与 Session ID 派生                 |
 | `auth.token`              | 条件 | 无 API Key Header/Query 时必需                      |
 | `auth.bot_id`             | 否   | 多 Bot 隔离，优先级低于 Header/Query                |
 | `config.work_dir`         | 否   | 工作目录，安全校验                                  |
@@ -357,9 +358,21 @@ WebSocket 连接建立后，**必须在 30 秒内**发送 `init` 作为第一帧
 
 Session 代表一个独立的对话上下文。每个 Session 绑定一个 Worker 进程，拥有独立的状态和对话历史。
 
-### 5.2 Session ID 如何确定
+### 5.2 Session ID 解析机制
 
-Gateway 使用 **UUIDv5 确定性派生**，从四个维度生成唯一 ID：
+Gateway 使用 **UUIDv5 确定性派生**生成 Session ID，但解析过程分为两步：
+
+```
+init { session_id: X }
+  ├─ X 非空 → sm.Get(X) 按 sessions.id 主键查询
+  │    ├─ 命中且非 Deleted → 直查复用（不派生）
+  │    └─ 未命中 → DeriveSessionKey(userID, wt, X, workDir) → 派生 UUIDv5
+  │         ├─ sm.Get(UUIDv5) 命中 → 恢复
+  │         └─ sm.Get(UUIDv5) 未命中 → 创建新 session
+  └─ X 为空 → DeriveSessionKey(userID, wt, "", workDir) → 固定 UUIDv5
+```
+
+**派生公式**：
 
 ```
 Session ID = UUIDv5(userID | workerType | clientSessionID | workDir)
@@ -367,7 +380,51 @@ Session ID = UUIDv5(userID | workerType | clientSessionID | workDir)
 
 **clientSessionID 是什么**：你在 init 信封 `session_id` 字段传入的值。它**不是** Session ID 本身，只是派生函数的一个输入。该值会被 Gateway 持久化为 `client_key`（可通过 `GET /api/sessions` 的 `client_key` 字段取回，见 §11.1）。
 
-### 5.3 三个关键规则
+> **注意**：`sm.Get(X)` 只按 `sessions.id` 主键（UUIDv5）查询，**不匹配** `client_key` 列。所以传 clientSessionID 永远走不到直查路径——必须先派生成 UUIDv5 再查。
+
+### 5.3 两种创建路径
+
+#### 路径 A：REST + WS（WebChat 模式）
+
+适合需要会话列表 UI 的应用。先用 REST API 创建 session，再用 WS 连接实时通信。
+
+```
+① REST POST /api/sessions?client_session_id=<client_generated>&title=显示名
+   → DeriveSessionKey(userID, wt, clientSessionID, workDir) → UUIDv5
+   → 创建 session + 启动 Worker
+   → 返回 { session_id: UUIDv5 }
+
+② 前端存储 UUIDv5（如 localStorage）
+
+③ WS init { session_id: UUIDv5 }
+   → sm.Get(UUIDv5) → 直查命中 → 复用（一步，不派生）
+
+④ 重连：WS init { session_id: UUIDv5 } → 同 ③
+```
+
+#### 路径 B：纯 WS（SDK/Bot 模式）
+
+适合不需要 session 管理界面的轻量客户端。所有交互通过 WS 完成。
+
+```
+① 首次连接：WS init { session_id: clientSessionID, data: { title: "可选显示名" } }
+   → sm.Get(clientSessionID) → miss（主键是 UUIDv5）
+   → DeriveSessionKey(userID, wt, clientSessionID, workDir) → UUIDv5
+   → sm.Get(UUIDv5) → miss → 创建 session
+   → init_ack 返回 UUIDv5
+
+② 重连方式一（推荐）：存储 init_ack 返回的 UUIDv5，重传
+   WS init { session_id: UUIDv5 }
+   → sm.Get(UUIDv5) → 命中 → 一步恢复
+
+③ 重连方式二（备选）：重传原始 clientSessionID
+   WS init { session_id: clientSessionID }
+   → sm.Get(clientSessionID) → miss → 派生 → 同一 UUIDv5 → sm.Get(UUIDv5) → 命中 → 两步恢复
+```
+
+> **两种重连方式对比**：方式一（传 server UUID）更高效，一步直查恢复。方式二（传 clientSessionID）多一步派生，但在 session 被 GC 物理删除后能重建同一 session——这是它唯一的优势。
+
+### 5.4 四个关键规则
 
 **规则 1：不传 clientSessionID → 自动获得固定会话**
 
@@ -394,24 +451,40 @@ const tabId = `sess_${crypto.randomUUID()}`;
 // init 时传入 → 每个 tab 独立会话
 ```
 
-**规则 3：重连时必须重传原始 clientSessionID**
+**规则 3：REST API 创建 session 必须提供 client_session_id**
 
+```bash
+# client_session_id 用于 Session ID 派生（必填）
+# title 用于显示名称（可选）
+curl -X POST "http://localhost:8888/api/sessions?client_session_id=sess_xxx&title=代码审查" \
+  -H "X-API-Key: your-key"
 ```
-首次:  init { session_id: "sess_tab-abc" }
-       → 派生得到 "a1b2c3d4-..." → init_ack.session_id = "a1b2c3d4-..."
 
-重连:  init { session_id: "sess_tab-abc" }     ← 重传同一个
-       → 再次派生得到 "a1b2c3d4-..."（确定性！） → 自动恢复
+相同的 `client_session_id` → 幂等返回已有 session。不同的 `client_session_id` → 独立 session（`title` 可以相同）。
+
+**规则 4：title 是纯显示名，不参与 Session ID 派生**
+
+```json
+{
+  "event": {
+    "type": "init",
+    "data": {
+      "version": "aep/v1",
+      "worker_type": "claude_code",
+      "title": "Bug Fix Session"
+    }
+  }
+}
 ```
 
-> 如果错误地传 Gateway 返回的 `"a1b2c3d4-..."`，在 Session 被 GC 删除后，派生结果会变，导致创建全新会话、对话历史丢失。
+`title` 仅用于 `GET /api/sessions` 返回的显示名称。多个 session 可以有相同的 title。
 
 **两个 ID 各自的用途**：
 
 | ID                                        | 用在哪                                |
 | ----------------------------------------- | ------------------------------------- |
-| **clientSessionID**（你自己生成的）       | init 握手时传入，重连时重传。REST API 中以 `client_key` 字段返回（§11.1） |
-| **Gateway Session ID**（init_ack 返回的） | REST API 调用（查询历史、删除会话等） |
+| **clientSessionID**（你自己生成的）       | init 握手时传入，参与 Session ID 派生。REST API 以 `client_key` 字段返回（§11.1） |
+| **Gateway Session ID**（init_ack 返回的） | REST API 调用（查询历史、删除会话等）、WS 重连直查 |
 
 ### 5.4 Session 状态
 
@@ -667,14 +740,25 @@ Worker 执行过程中还可能产生：
 
 ## 8. 断线重连
 
-### 8.1 重连步骤
+### 8.1 重连方式
+
+重连时 init 的 `session_id` 字段可以传两种值：
+
+| 传值 | 解析路径 | 特点 |
+|------|---------|------|
+| **服务端 UUID**（init_ack 返回的 `session_id`） | `sm.Get(UUID)` 主键直查命中 → 一步恢复 | 推荐方式，高效 |
+| **客户端 clientSessionID**（首次 init 传的原始值） | `sm.Get()` miss → `DeriveSessionKey` → `sm.Get(派生UUID)` → 两步恢复 | GC 物理删除后能自动重建 |
+
+> **两种方式在 session 未被 GC 删除时效果完全一致**。区别仅在 session 被物理删除后：传 server UUID 会派生出新 UUID（创建全新 session），传 clientSessionID 会派生出相同 UUID（可重建原 session）。
+
+### 8.2 重连步骤
 
 1. WebSocket 断开后，等待指数退避时间（1s, 2s, 4s, 8s...最大 60s）
 2. 重新建立 WebSocket 连接
-3. 发送 init，**携带与首次完全相同的参数**（clientSessionID、auth、workDir）
-4. Gateway 派生出相同的 Session ID → 自动恢复
+3. 发送 init，`session_id` 携带 init_ack 返回的服务端 UUID（推荐）或原始 clientSessionID
+4. Gateway 解析 session → 自动恢复（详见 §5.2 解析流程）
 
-### 8.2 完整重连示例
+### 8.3 完整重连示例
 
 ```javascript
 class HotPlexClient {
@@ -1051,15 +1135,39 @@ curl -H "X-API-Key: your-key" \
 
 | 字段          | 说明                                                                |
 | ------------- | ------------------------------------------------------------------- |
-| `id`          | Session ID（init_ack 返回的权威 ID），用于历史查询、重连等          |
-| `client_key`  | 客户端 init 时传入的原始 `session_id`，即 §5.2 中的 **clientSessionID**。重连时需要此值恢复同一会话 |
-| `state`       | `created` / `running` / `idle` / `terminated`（见 §5.4）           |
-| `title`       | 用户定义的会话名称（WebChat 传入，用于 Session Key 派生）           |
+| `id`          | Session ID（init_ack 返回的权威 ID），用于历史查询、WS 重连直查等   |
+| `client_key`  | 客户端传入的 `session_id` 或 `client_session_id`，参与 Session ID 派生。可用于 GC 删除后的 session 重建 |
+| `state`       | `created` / `running` / `idle` / `terminated`（见 §5.5）           |
+| `title`       | 会话显示名称，不参与 Session ID 派生                                |
 | `work_dir`    | 工作目录（影响 Session Key 派生，重连时需一致）                     |
 
-> **`client_key` = `clientSessionID`**：这两个名称指向同一个值。你在 init 信封 `session_id` 字段传入的 clientSessionID，会被 Gateway 持久化并在本接口以 `client_key` 返回。重连时需要传回此值（见 §8 断线重连）。如果客户端丢失了本地保存的 clientSessionID，可以从本接口的 `client_key` 字段取回。
+> **`client_key` = `clientSessionID`**：这两个名称指向同一个值。REST API 以 `client_session_id` 参数传入，WS init 以 `session_id` 字段传入。Gateway 持久化并在本接口以 `client_key` 返回。如果客户端丢失了本地保存的 clientSessionID，可以从本接口取回。
 
-### 11.2 Turn 级别 — 聊天记录
+### 11.2 创建会话 — `POST /api/sessions`
+
+```bash
+curl -X POST -H "X-API-Key: your-key" \
+  "http://localhost:8888/api/sessions?client_session_id=sess_550e8400&title=代码审查&worker_type=claude_code&work_dir=/home/user/project"
+```
+
+**参数**：
+
+| 参数                | 必需 | 说明                                                        |
+| ------------------- | ---- | ----------------------------------------------------------- |
+| `client_session_id` | 是   | 用于 Session ID 派生。相同值幂等返回已有 session            |
+| `worker_type`       | 否   | Worker 类型，默认 `claude_code`                             |
+| `title`             | 否   | 会话显示名称，不参与 Session ID 派生。纯展示用              |
+| `work_dir`          | 否   | 工作目录，默认使用服务端配置                                |
+
+**响应**：
+
+```json
+{ "session_id": "a1b2c3d4-e5f6-..." }
+```
+
+**幂等性**：相同的 `(client_session_id, worker_type, work_dir)` 在同一用户下总是返回同一个 session ID。
+
+### 11.3 Turn 级别 — 聊天记录
 
 适合展示对话列表（一句提问一句回答）。
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -19,6 +19,12 @@
 | [Interaction-Response-Chain-Fix-Spec.md](./Interaction-Response-Chain-Fix-Spec.md) | 交互响应链修复 — 权限/Q&A 响应路由重构 | proposed | - | - |
 | [Inbound-Event-Storage-Fix-Spec.md](./Inbound-Event-Storage-Fix-Spec.md) | 入站事件存储修复 — 事件持久化一致性 | proposed | 2026-05-07 | - |
 | [Hot-Reload-Spec.md](./Hot-Reload-Spec.md) | 配置热重载修复 — 配置变更即时生效 | draft | 2026-04-22 | 20% |
+| [Gateway-Self-Restart-Spec.md](./Gateway-Self-Restart-Spec.md) | Gateway 自重启 — Worker-initiated 进程重启能力 (AEP-006) | implemented | 2026-05-12 | 100% |
+| [Multi-Bot-Support-Spec.md](./Multi-Bot-Support-Spec.md) | 多 Bot 支持 — 多 bot 实例同时运行与隔离 | implemented | 2026-05-13 | 100% |
+| [agent-config-injection-control.md](./agent-config-injection-control.md) | Agent 配置注入排除 — inject_exclude 3 级回退机制 | implemented | 2026-05-31 | 100% |
+| [pr-review-webhook-driven.md](./pr-review-webhook-driven.md) | PR Review Webhook 触发 — GitHub Webhook 驱动自动化代码审查 | implemented | 2026-05-30 | 90% |
+| [Turns-Materialized-Table-Spec.md](./Turns-Materialized-Table-Spec.md) | Turns 物化表 — eventstore 物化为独立表提升查询性能 | proposed | 2026-05-19 | 0% |
+| [API-Documentation-Hybrid-Generation-Spec.md](./API-Documentation-Hybrid-Generation-Spec.md) | API 文档混合生成 — 手写 + 自动生成方案降低维护风险 | proposed | 2026-06-03 | 0% |
 
 ### Worker 与 Session
 
@@ -31,6 +37,10 @@
 | [Per-Bot-Agent-Config-Spec.md](./Per-Bot-Agent-Config-Spec.md) | Per-Bot Agent 配置 — 独立 Bot 人格与上下文 | implemented | 2026-05-03 | 100% |
 | [Turn-Summary-Spec.md](./Turn-Summary-Spec.md) | Turn 摘要 — 消息轮次总结与统计 | draft | 2026-05-01 | 70% |
 | [Turn-Summary-WorkDir-Fix-Spec.md](./Turn-Summary-WorkDir-Fix-Spec.md) | Turn 摘要 WorkDir 修复 — 缺失工作目录字段 | implemented | 2026-05-04 | 100% |
+| [OCS-Production-Readiness-Spec.md](./OCS-Production-Readiness-Spec.md) | OCS Worker 生产级完善 — 从开发到生产级可靠性提升 | approved | 2026-05-15 | 80% |
+| [ACP-Worker-Enhancement-Spec.md](./ACP-Worker-Enhancement-Spec.md) | ACP Worker 全面增强 — 从可用到生产首选的改进路径 | verified | 2026-05-30 | 0% |
+| [Codex-Reset-Zombie-Fix-Spec.md](./Codex-Reset-Zombie-Fix-Spec.md) | Codex Worker Reset/Zombie 修复 — reset 与 zombie bug 修复 | draft | 2026-05-30 | 0% |
+| [codexcli-full-upgrade-spec.md](./codexcli-full-upgrade-spec.md) | Codex CLI 全功能升级 — 与上游 Codex CLI 100% 协议覆盖 | draft | 2026-05-31 | 0% |
 
 ### 平台适配
 
@@ -38,6 +48,9 @@
 |------|------|------|------|------|
 | [Slack-CLI-Subcommand-Spec.md](./Slack-CLI-Subcommand-Spec.md) | Slack CLI 子命令规格 — 独立 CLI 操作 Slack | draft | 2026-05-03 | - |
 | [Slack-Stream-Rotation-Spec.md](./Slack-Stream-Rotation-Spec.md) | Slack 流式旋转 — TTL 超时自动续流 | implemented | 2026-05-05 | 90% |
+| [Feishu-Card-Header-Spec.md](./Feishu-Card-Header-Spec.md) | 飞书卡片 Header 增强 — 消息卡片 Header 区域 v2.0 设计 | draft | 2026-05-08 | 0% |
+| [Feishu-Interactive-Card-Buttons-Spec.md](./Feishu-Interactive-Card-Buttons-Spec.md) | 飞书交互式卡片按钮 — 权限确认/提问/信息采集 (cardkit-v2) | draft | 2026-05-20 | 0% |
+| [slack-block-kit-upgrade.md](./slack-block-kit-upgrade.md) | Slack Block Kit 升级 — slack-go v0.24.0 新 Block Kit 类型适配 | implemented | 2026-05 | 85% |
 
 ### 定时任务
 
@@ -45,6 +58,7 @@
 |------|------|------|------|------|
 | [AI-Native-Cronjob-Spec.md](./AI-Native-Cronjob-Spec.md) | AI 原生定时任务 — Worker 自管理调度系统 | implemented | 2026-05-09 | 100% |
 | [Cron-Fast-Path-Spec.md](./Cron-Fast-Path-Spec.md) | Cron Fast Path — 会话内回调机制 | draft | 2026-05-11 | 0% |
+| [Cron-Delivery-Retry-Spec.md](./Cron-Delivery-Retry-Spec.md) | Cron 投递重试 — 执行结果消息投递重试机制 | draft | 2026-05-30 | 0% |
 
 ### CLI 与 Onboard
 
@@ -77,16 +91,18 @@
 
 ### 按状态分类
 
-- **implemented**: 4 个 — Per-Bot-Agent-Config, Turn-Summary-WorkDir-Fix, Worker-User-Interaction, Slack-Stream-Rotation
-- **draft**: 8 个 — Gateway-Async-Init, Feishu-Adapter, Hot-Reload, Session-History, Turn-Summary, CLI-Self-Service, Onboard-UX, TTS-Engine
-- **proposed**: 9 个 — GroupChat-Collaboration, Dual-Database-Support, Consolidate-Events-Store, Delta-Optimization, Interaction-Response-Chain-Fix, Inbound-Event-Storage-Fix, Onboard-Go-Embed-AST, WebChat-v2-Revamp, Windows-Support
+- **implemented**: 8 个 — Per-Bot-Agent-Config, Turn-Summary-WorkDir-Fix, Worker-User-Interaction, Slack-Stream-Rotation, Gateway-Self-Restart, Multi-Bot-Support, Agent-Config-Injection-Control, Slack-Block-Kit-Upgrade
+- **approved**: 1 个 — OCS-Production-Readiness
+- **verified**: 1 个 — ACP-Worker-Enhancement
+- **draft**: 12 个 — Gateway-Async-Init, Feishu-Adapter, Hot-Reload, Session-History, Turn-Summary, CLI-Self-Service, Onboard-UX, TTS-Engine, Codex-Reset-Zombie-Fix, Cron-Delivery-Retry, Feishu-Card-Header, Feishu-Interactive-Card-Buttons, Codex-CLI-Full-Upgrade
+- **proposed**: 10 个 — GroupChat-Collaboration, Dual-Database-Support, Consolidate-Events-Store, Delta-Optimization, Interaction-Response-Chain-Fix, Inbound-Event-Storage-Fix, Onboard-Go-Embed-AST, WebChat-v2-Revamp, Windows-Support, Turns-Materialized-Table, API-Documentation-Hybrid-Generation
 
 ### 按领域分类
 
-- **架构/Gateway**: 10 个
-- **Worker/Session**: 5 个
-- **平台适配**: 2 个
-- **定时任务**: 2 个
+- **架构/Gateway**: 16 个
+- **Worker/Session**: 10 个
+- **平台适配**: 5 个
+- **定时任务**: 3 个
 - **CLI/Onboard**: 3 个
 - **前端/平台**: 3 个
 - **跟踪矩阵**: 4 个

--- a/docs/specs/codexcli-full-upgrade-spec.md
+++ b/docs/specs/codexcli-full-upgrade-spec.md
@@ -1,0 +1,655 @@
+# Codex CLI 全功能升级规范
+
+**版本**: 1.1（经上游源码交叉复核）  
+**日期**: 2026-05-31  
+**目标**: 将 HotPlex Codex CLI 适配器 (`internal/worker/codexcli/`) 提升至与上游 Codex CLI (`~/tmp/codex/codex-rs/`) 100% 协议覆盖，并以 Claude Code 适配器 (`internal/worker/claudecode/`) 为基准实现功能对等。
+**复核依据**: HotPlex 源码 + Codex CLI 上游 `codex-rs/app-server-protocol/src/protocol/common.rs:445-900`（ClientRequest wire format）
+
+---
+
+## 目录
+
+1. [现状概述](#现状概述)
+2. [Phase 0 —— 紧急协议修复（P0）](#phase-0--紧急协议修复p0)
+3. [Phase 1 —— 功能对等（P1）](#phase-1--功能对等p1)
+4. [Phase 2 —— 协议完整性（P2）](#phase-2--协议完整性p2)
+5. [Phase 3 —— 标志与配置（P3）](#phase-3--标志与配置p3)
+6. [Phase 4 —— 跨模块修复](#phase-4--跨模块修复)
+7. [验证计划](#验证计划)
+8. [文件影响矩阵](#文件影响矩阵)
+
+---
+
+## 现状概述
+
+| 维度 | 当前覆盖率 | 目标 |
+|------|-----------|------|
+| Exec 事件类型 | 7/8 (87%) | 8/8 (100%) |
+| Item 类型映射 | 6/9 (67%) | 9/9 (100%) |
+| AppServer JSON-RPC 方法 | 5/25+ (≤20%) | 25/25+ (100%) |
+| AppServer 通知 | 14/20 (70%) | 20/20 (100%) |
+| Exec CLI 标志传递 | 6/14 (43%) | 14/14 (100%) |
+| 交互式响应 | 1/3 (33%) | 3/3 (100%) |
+| WorkerCommander 方法 | 0/3 (0%) | 3/3 (100%) |
+| 模态 | 2/3 (67%) | 3/3 (100%) |
+
+---
+
+## Phase 0 —— 紧急协议修复（P0）
+
+> **目标**: 修复直接影响流式输出和协议完整性的阻塞性问题。
+> **预计工时**: ~4h
+> **风险**: 低（所有修改均基于上游协议定义）
+
+### Task 0.1: 添加 `item.updated` 事件处理
+
+**文件**: `internal/worker/codexcli/types.go`, `parser.go`, `mapper.go`, `worker.go`
+
+**背景**: Codex CLI 上游定义了 8 种事件类型（`exec_events.rs:8-37`），HotPlex 仅处理 7 种。缺失的 `item.updated` 是流式增量更新的核心事件，其缺失会导致实时文件变更、命令输出流等增量内容完全丢失。
+
+**修改**:
+
+1. **`types.go`** —— 添加事件常量：
+   ```go
+   const EventItemUpdated = "item.updated"  // 追加至 EventItemCompleted 之后
+   ```
+
+2. **`parser.go`** —— `ParseLine` 无变化（事件类型字段即 type）。
+
+3. **`mapper.go`** —— 在 `Map()` 的 switch 中追加：
+   ```go
+   case EventItemUpdated:
+       return m.mapItemUpdated(event.Item)
+   ```
+   新增私有方法 `mapItemUpdated(item *CodexItem) []*events.Envelope`：
+   - `AgentMessage` → `MessageDelta`（增量文本内容）
+   - `CommandExecution` → `ToolResult`（流式 stdout 增量）
+   - `FileChange` → `ToolResult`（补丁进度更新）
+   - `Reasoning` → `Reasoning`（推理增量）
+   - `TodoList` → `State`（计划进度更新）
+   - 其他类型 → 记录 debug 日志后跳过
+
+4. **`worker.go`** —— `readOutput()` 中不必退出循环于 `EventItemUpdated`（它不是终止事件）。
+
+**QA**: 
+- 执行 `codex exec --json "create a file"` → 确认 item.updated 事件被解析并映射为 AEP 信封
+- 确认 MessageDelta 流不被重复计数
+
+---
+
+### Task 0.2: 更新模态声明——添加 `image`
+
+**文件**: `internal/worker/codexcli/worker.go`（两处：`ExecWorker.Modalities()` 和 `AppServerWorker.Modalities()`）
+
+**背景**: Codex CLI 上游通过 `--image`/`-i` 标志（`shared_options.rs:10-18`）原生支持图像。HotPlex 声明 `Modalities() = ["text", "code"]` 但应声明 `["text", "code", "image"]`。
+
+**修改**:
+```go
+// 之前
+func (w *ExecWorker) Modalities() []string    { return []string{"text", "code"} }
+func (w *AppServerWorker) Modalities() []string { return []string{"text", "code"} }
+
+// 之后
+func (w *ExecWorker) Modalities() []string    { return []string{"text", "code", "image"} }
+func (w *AppServerWorker) Modalities() []string { return []string{"text", "code", "image"} }
+```
+
+**QA**: 网关应广播 `capabilities.modalities` 包含 `"image"`。
+
+---
+
+### Task 0.3: 移除幻影 `ItemImageGeneration` 常量
+
+**文件**: `internal/worker/codexcli/types.go`, `mapper.go`
+
+**背景**: `ItemImageGeneration = "image_generation"` 在 Codex CLI 上游（`exec_events.rs`）中不存在。图像是通过 `--image` CLI 标志（而非事件类型）处理的。保留此常量会产生误导。
+
+**修改**:
+
+1. **`types.go`** —— 删除 `ItemImageGeneration = "image_generation"`。
+2. **`mapper.go`** —— 删除 `mapItemCompleted` 中 `case ItemImageGeneration:` 分支。
+
+**QA**: 编译通过，无未引用常量。
+
+---
+
+## Phase 1 —— 功能对等（P1）
+
+> **目标**: 实现 WorkerCommander、交互式响应，并补齐所有缺失的 Item 类型映射。
+> **预计工时**: ~12h
+> **风险**: 中（WorkerCommander 依赖 AppServer 协议；需谨慎测试）
+
+### Task 1.1: 实现 WorkerCommander 接口
+
+**文件**: `internal/worker/codexcli/worker.go`, `commands.go`
+
+**背景**: HotPlex gateway 的直通命令（`/compact`、`/clear`、`/rewind`）通过 `WorkerCommander` 接口分发（`gateway/worker_cmds.go:132`）。Codex CLI 未实现该接口，导致命令静默降级为 `w.Input()` 原始文本。
+
+Claude Code 将 Compact/Clear/Rewind 实现为结构化操作；Codex CLI 对应的协议方法为：`thread/compact/start`（显式的压缩方法，`common.rs:541`）、`thread/rollback`（回滚，`common.rs:562`）、`thread/name/set` + 新 thread/start（清除）、`turn/interrupt`（中断，`common.rs:762`）。
+
+**修改**:
+
+1. **`worker.go`** —— 追加编译时断言：
+   ```go
+   var _ worker.WorkerCommander = (*AppServerWorker)(nil)
+   ```
+
+2. **`commands.go`** —— 扩展 `ServerCommander`：
+   ```go
+   // Compact 发送 thread/compact/start 请求，触发上下文压缩。
+   // 上游 wire format: "thread/compact/start" (common.rs:541)
+   func (sc *ServerCommander) Compact(ctx context.Context, _ map[string]any) error
+
+   // Clear 通过杀死当前线程并以相同配置创建新线程来清空上下文。
+   // 实现：调用 turn/interrupt → thread/unsubscribe → thread/start（新线程）
+   func (sc *ServerCommander) Clear(ctx context.Context) error
+
+   // Rewind 发送 thread/rollback 请求，回滚至前一个助理消息。
+   // 上游 wire format: "thread/rollback" (common.rs:562)
+   func (sc *ServerCommander) Rewind(ctx context.Context, targetID string) error
+   ```
+
+3. **`worker.go`** —— 将 `ServerCommander` 作为接口暴露给 `AppServerWorker`：
+   ```go
+   func (w *AppServerWorker) Compact(ctx context.Context, args map[string]any) error {
+       return w.commands.Compact(ctx, args)
+   }
+   func (w *AppServerWorker) Clear(ctx context.Context) error {
+       return w.commands.Clear(ctx)
+   }
+   func (w *AppServerWorker) Rewind(ctx context.Context, targetID string) error {
+       return w.commands.Rewind(ctx, targetID)
+   }
+   ```
+
+4. **`worker.go`** —— `ExecWorker` 同样添加（必要时可返回 `ErrNotImplemented` 并附带解释性日志）：
+   ```go
+   func (w *ExecWorker) Compact(ctx context.Context, args map[string]any) error {
+       return fmt.Errorf("codexcli: compact not supported in exec mode; use app-server mode")
+   }
+   // Clear, Rewind 同理
+   ```
+
+**QA**: 
+- 在 WebChat/Slack/飞书中发送 `/compact` → 确认通过 `ServerCommander.Compact()` 分发（非 `w.Input()`）
+- 验证 `gateway/worker_cmds.go:132` 的类型断言成功
+- 验证命令反馈消息被正确发送（`sendCommandFeedback`）
+
+---
+
+### Task 1.2: 实现 HandleQuestionResponse
+
+**文件**: `internal/worker/codexcli/worker.go`, `manager.go`
+
+**背景**: 当 Codex CLI 调用 `AskUserQuestion` 工具时，HotPlex 会发出 `QuestionRequest` AEP 事件。用户回答后，gateway 调用 `HandleQuestionResponse()`——当前该方法返回 `"not supported in app-server mode yet"`。
+
+**修改**:
+
+1. **`worker.go`** —— `AppServerWorker.HandleQuestionResponse`：
+   ```go
+   func (w *AppServerWorker) HandleQuestionResponse(ctx context.Context, reqID string, answers map[string]string) error {
+       result := map[string]any{
+           "behavior": "allow",
+           "updatedInput": map[string]any{
+               "answers": answers,
+           },
+       }
+       return w.manager.RespondServerRequest(reqID, result)
+   }
+   ```
+
+2. **`worker.go`** —— `ExecWorker.HandleQuestionResponse`：记录该单次模式不支持此功能，并返回错误。
+
+**QA**: 向 Codex CLI 发送需要 AskUserQuestion 的提示词 → 确认问题已传递至用户 → 用户回答后确认响应已发送。
+
+---
+
+### Task 1.3: 实现 HandleElicitationResponse
+
+**文件**: `internal/worker/codexcli/worker.go`, `manager.go`
+
+**背景**: 与 QuestionResponse 相同模式，用于 MCP 引导请求。
+
+**修改**:
+
+1. **`worker.go`** —— `AppServerWorker.HandleElicitationResponse`：
+   ```go
+   func (w *AppServerWorker) HandleElicitationResponse(ctx context.Context, reqID, action string, content map[string]any) error {
+       result := map[string]any{
+           "action":  action,
+           "content": content,
+       }
+       return w.manager.RespondServerRequest(reqID, result)
+   }
+   ```
+
+**QA**: 向支持引导的 Codex CLI 发送 MCP 提示词 → 确认引导已传递至用户 → 用户操作后确认响应已发送。
+
+---
+
+### Task 1.4: 添加缺失的 Item 类型映射
+
+**文件**: `internal/worker/codexcli/mapper.go`, `types.go`
+
+**背景**: Codex CLI 上游定义了 9 种 Item 类型（`exec_events.rs:104-130`）。HotPlex 映射了其中 6 种。缺失 3 种：`CollabToolCall`、`WebSearch`、`Error`（Item 级别）。`TodoList` 被映射为 `ItemPlan`，但上游结构更丰富。
+
+**修改**:
+
+1. **`types.go`** —— 添加 Item 类型常量：
+   ```go
+   const (
+       ItemCollabToolCall = "collab_tool_call"
+       ItemWebSearch      = "web_search"
+       ItemError          = "error"          // Item 级别（不同于 event 级别 EventError）
+       ItemTodoList       = "todo_list"      // 替换 ItemPlan
+   )
+   ```
+   扩展 `CodexItem` 结构体以支持这些类型（`CollabTool`、`AgentsStates`、`Query`、`Action`、`TodoItems` 等）。
+
+2. **`mapper.go`** —— `mapItemStarted`：
+   ```go
+   case ItemCollabToolCall:
+       // 映射至 ToolCall(collab:X) —— 类似于 MCP 工具调用模式
+   case ItemWebSearch:
+       // 映射至 ToolCall(web_search) 
+   ```
+
+3. **`mapper.go`** —— `mapItemCompleted`：
+   ```go
+   case ItemCollabToolCall:
+       // 映射至 ToolResult
+   case ItemWebSearch:
+       // 映射至 ToolResult with query + results summary
+   case ItemError:
+       // 映射至 Error 事件（非致命项目错误）
+   case ItemTodoList:
+       // 映射至 State(planning) 并附带结构化 todo items
+   ```
+
+**QA**: 
+- 对每种 Item 类型，确认从 `codex exec --json` 输出中解析
+- 确认 AEP 信封格式与现有模式一致
+- 对不熟悉的上游代码，需从 `~/tmp/codex/codex-rs/exec/src/exec_events.rs` 获得精确的字段定义
+
+---
+
+## Phase 2 —— 协议完整性（P2）
+
+> **目标**: 暴露 Codex CLI 的完整 AppServer JSON-RPC 2.0 协议。
+> **预计工时**: ~16h
+> **风险**: 高（上游协议接口可能变更；需防御性实现）
+
+### Task 2.1: Thread 生命周期方法
+
+**文件**: `internal/worker/codexcli/manager.go`, `worker.go`
+
+**上游源文件**: `~/tmp/codex/codex-rs/app-server-protocol/src/protocol/common.rs:445-600`（ClientRequest wire format 定义）
+
+| Wire 方法名 | 用途 | 使用位置 |
+|--------|-------|---------|
+| `thread/resume` | 通过 `thread_id` 恢复已有线程（`common.rs:451`） | `Resume()` 应使用此方法（而非重启） |
+| `thread/fork` | 基于现有线程创建新线程（`common.rs:457`） | `session.ForkSession` 支持 |
+| `thread/archive` | 归档线程（`common.rs:463`） | 会话清理 |
+| `thread/unarchive` | 取消归档线程（`common.rs:536`） | 会话恢复 |
+| `thread/name/set` | 重命名线程（`common.rs:492`） | 用户面向的命名 |
+| `thread/goal/set` | 设置线程目标（`common.rs:497`） | 上下文感知 |
+| `thread/goal/get` | 获取线程目标（`common.rs:502`） | 状态查询 |
+| `thread/goal/clear` | 清除线程目标（`common.rs:507`） | 上下文重置 |
+| `thread/settings/update` | 更新运行时配置（`common.rs:518`） | 热重载（模型、沙箱等） |
+| `thread/compact/start` | 显式触发上下文压缩（`common.rs:541`） | **WorkerCommander.Compact() 直接映射** |
+| `thread/rollback` | 回滚至先前状态（`common.rs:562`） | **WorkerCommander.Rewind() 直接映射** |
+
+> ⚠️ **注意**: `thread/settings`（只读）在上游协议中**不存在**——仅有 `thread/settings/update`（写入）。如需读取设置，请通过 `thread/read` 获取。
+> ⚠️ **注意**: `thread/goal` 是**三个独立方法**（set/get/clear），而非单一读写方法。
+
+**修改**:
+
+1. **`manager.go`** —— 添加以下方法：
+   - `ResumeThread(id, params)` → 调用 `"thread/resume"`
+   - `ForkThread(id, params)` → 调用 `"thread/fork"`
+   - `ArchiveThread(id)` / `UnarchiveThread(id)` → 调用 `"thread/archive"` / `"thread/unarchive"`
+   - `SetThreadName(id, name)` → 调用 `"thread/name/set"`
+   - `SetThreadGoal(id, goal)` / `GetThreadGoal(id)` / `ClearThreadGoal(id)` → 调用 `"thread/goal/set"` / `"thread/goal/get"` / `"thread/goal/clear"`
+   - `UpdateThreadSettings(id, settings)` → 调用 `"thread/settings/update"`
+   - `CompactThread(id)` → 调用 `"thread/compact/start"`
+   - `RollbackThread(id, targetID)` → 调用 `"thread/rollback"`
+
+2. **`worker.go`** —— 更新 `Resume()` 使用 `thread/resume` 协议方法（而非 `thread/start`）。为新会话添加 `ForkSession` 支持。
+
+**QA**: 每个方法均需独立验证其请求/响应是否符合上游协议定义。
+
+---
+
+### Task 2.2: Turn 控制方法 + 环境变量
+
+**文件**: `internal/worker/codexcli/manager.go`, `worker.go`
+
+**上游源文件**: `~/tmp/codex/codex-rs/app-server-protocol/src/protocol/common.rs:750-768`
+
+| Wire 方法名 | 用途 | 对应 WorkerCommander |
+|--------|-------|---------------------|
+| `turn/steer` | 转向运行中的轮次（`common.rs:756`） | 用于 `Compact()` 的备选方案（主方案为 `thread/compact/start`） |
+| `turn/interrupt` | 中断运行中的轮次（`common.rs:762`） | `Clear()` 流程的第一步 |
+| `environment/add` | 添加环境变量（`common.rs:862`） | `session.ConfigEnv` 支持 |
+
+> ⚠️ **注意**: `turn/environment` 在上游协议中**不存在**。环境变量通过全局的 `environment/add` 方法设置，而非 per-turn 方法。
+
+**修改**:
+
+1. **`manager.go`** —— 添加 `SteerTurn(threadID, params)`、`InterruptTurn(threadID)`、`AddEnvironment(env)`。
+
+2. **`worker.go`** —— 在 `Compact()` 中连接 `thread/compact/start`（主方案）或 `turn/steer`（备选）；在 `Clear()` 中连接 `turn/interrupt` 后执行 `thread/unsubscribe` + `thread/start`。
+
+**QA**: 转向正在执行命令的轮次（例如 `"write a large file"`）→ 确认轮次被转向至压缩上下文。
+
+---
+
+### Task 2.3: MCP 服务器方法
+
+**文件**: `internal/worker/codexcli/manager.go`, `commands.go`
+
+**上游源文件**: `~/tmp/codex/codex-rs/app-server-protocol/src/protocol/common.rs:868-898`
+
+| Wire 方法名 | 用途 |
+|--------|-------|
+| `mcpServerStatus/list` | 列出所有 MCP 服务器及其状态（`common.rs:880`） |
+| `mcpServer/resource/read` | 从 MCP 服务器读取资源（`common.rs:886`） |
+| `mcpServer/tool/call` | 直接调用 MCP 工具（`common.rs:892`） |
+| `config/mcpServer/reload` | 刷新 MCP 服务器配置（`common.rs:874`） |
+| `mcpServer/oauth/login` | 启动 MCP OAuth 登录流程（`common.rs:868`） |
+
+> ⚠️ **注意**: MCP 方法使用 **camelCase 分段 + 斜杠** 混合格式，与 thread/turn 方法的全小写格式不同。例如 `mcpServerStatus/list`（而非 `mcp/server/listStatus`）。
+
+**修改**:
+
+1. **`manager.go`** —— 添加 `ListMCPServerStatus()`、`ReadMCPResource(uri)`、`CallMCPTool(server, tool, args)`、`RefreshMCPServer(name)`、`MCPServerOAuthLogin(name)`。
+
+2. **`commands.go`** —— 在 `SendControlRequest` 中暴露 `mcp_status`、`mcp_refresh`、`mcp_oauth` 子类型。
+
+**QA**: 配置带 Codex CLI 的 MCP 服务器 → 通过网关控制命令验证状态/刷新。
+
+---
+
+### Task 2.4: Review 支持
+
+**文件**: `internal/worker/codexcli/manager.go`, `worker.go`
+
+**上游源文件**: `~/tmp/codex/codex-rs/app-server-protocol/src/protocol/v2/review.rs`
+
+| 方法 | 用途 |
+|--------|-------|
+| `review/start` | 以审查模式启动会话（未提交的/基于分支的分支/基于提交的分支） |
+
+**修改**:
+
+1. **`manager.go`** —— 添加 `StartReview(params)`，支持 `ReviewTarget::Uncommitted`、`ReviewTarget::Branch(name)`、`ReviewTarget::Commit(sha)`。
+
+2. **`worker.go`** —— 当 `session.Review` 标志被设置时（如果网关传递了该标志），于 `Start()` 中连接。
+
+**QA**: 在 Git 仓库中启动审查会话 → 确认审查事件已正确传递至 AEP。
+
+---
+
+### Task 2.5: 缺失的通知处理
+
+**文件**: `internal/worker/codexcli/mapper.go`, `manager.go`
+
+**背景**: HotPlex 在 `MapNotification()` 中当前处理 20 种通知中的 14 种。
+
+| 缺失的通知 | 映射 |
+|---------|-------|
+| `item/updated` | → 根据 Item 类型映射为 `MessageDelta` / `ToolResult` / `Reasoning` / `State` |
+| `turn/diff/updated` | → 映射为 `ToolResult`（diff 输出）或 `Raw` |
+| `turn/plan/updated` | → 映射为 `State(planning)` 并附带结构化步骤 |
+| `thread/settings/updated` | → 映射为 `State`（新配置） |
+| `serverRequest/resolved` | → 映射为日志条目（通常无需用户交互） |
+| `deprecationNotice` | → 映射为 `Step(deprecation)` |
+| `guardianWarning` | → 映射为 `Step(guardian)` 或 `Error`（取决于严重程度） |
+
+**修改**:
+
+1. **`mapper.go`** —— 在 `MapNotification()` 的 switch 中追加 7 个 case，分别包含适当的映射逻辑。
+
+2. **`types.go`** —— 根据需要为通知负载添加类型。
+
+**QA**: 验证来自 Codex CLI 上游的每种通知类型均能被解析，不会导致 "unknown notification" 日志。
+
+---
+
+## Phase 3 —— 标志与配置（P3）
+
+> **目标**: 将 Codex CLI 的所有 CLI 标志传递至 `buildArgs()` 和 `buildThreadStartParams()`。
+> **预计工时**: ~6h
+> **风险**: 低（纯追加性修改）
+
+### Task 3.1: Exec CLI 标志传递
+
+**文件**: `internal/worker/codexcli/worker.go` (`buildArgs`), `internal/config/config.go`
+
+**上游源文件**: `~/tmp/codex/codex-rs/exec/src/cli.rs`, `~/tmp/codex/codex-rs/utils/cli/src/shared_options.rs`
+
+| Codex CLI 标志 | 来自 SessionInfo 的数据源 | 状态 |
+|-------------|---------------------|--------|
+| `--image` / `-i` | `session.Images`（需新增字段） | 缺失 |
+| `--output-schema` | `session.JSONSchema`（已存在） | 缺失 |
+| `--add-dir` | `session.AllowedDirs`（已存在） | 缺失 |
+| `--color` | 新配置或 `session.Color` | 缺失 |
+| `--output-last-message` / `-o` | `session.OutputFile` | 缺失 |
+| `--strict-config` | `session.StrictConfig` | 缺失 |
+| `--skip-git-repo-check` | `session.SkipGitRepoCheck` | 缺失 |
+| `--ignore-user-config` | `session.IgnoreUserConfig` | 缺失 |
+| `--ignore-rules` | `session.IgnoreRules` | 缺失 |
+| `--oss` | 新配置 | 缺失 |
+| `--local-provider` | `session.LocalProvider` | 缺失 |
+| `--profile` / `-p` | `session.ConfigProfile` | 缺失 |
+| `--dangerously-bypass-hook-trust` | `session.BypassHookTrust` | 缺失 |
+| `resume --last` | `session.ResumeLast` | 缺失 |
+
+**修改**:
+
+1. **`worker.go`** —— 在 `buildArgs()` 中追加 14+ 个条件标志。
+2. **`internal/config/config.go`** —— 在 `CodexCLIConfig` 中添加默认值（`Color`、`IgnoredRules` 等）。
+3. **`internal/worker/worker.go`** —— 根据需要扩展 `SessionInfo` 结构体。
+
+**QA**: 通过 `SessionInfo` 设置每个标志 → 确认标志已追加至进程参数列表。
+
+---
+
+### Task 3.2: AppServer Thread Start 参数
+
+**文件**: `internal/worker/codexcli/worker.go` (`buildThreadStartParams`)
+
+同样在 `thread/start` 参数中暴露缺失的标志：
+- `images`（作为图片附件传递）
+- `outputSchema`（JSON Schema 文件路径）
+- `additionalDirectories`（写访问权限）
+- `color`、`strictConfig`、`ignoreRules` 等
+
+---
+
+## Phase 4 —— 跨模块修复
+
+> **目标**: 修复 Cron、Gateway API 和 Brain 中的硬编码缺点。
+> **预计工时**: ~4h
+> **风险**: 低
+
+### Task 4.1: Cron SessionKey 硬编码
+
+**文件**: `internal/cron/types.go`
+
+**修改**（第 69 行）:
+```go
+// 之前
+func (j *CronJob) SessionKey() string {
+    return session.DerivePlatformSessionKey(j.Payload.OwnerID, worker.TypeClaudeCode, pctx)
+}
+
+// 之后
+func (j *CronJob) SessionKey() string {
+    wt := j.Payload.WorkerType
+    if wt == "" {
+        wt = worker.TypeClaudeCode  // 保留下兼容默认值
+    }
+    return session.DerivePlatformSessionKey(j.Payload.OwnerID, wt, pctx)
+}
+```
+
+**QA**: 创建 `worker_type: codex_cli` 的 cron 任务 → 确认 session key 推导使用正确的 worker type。
+
+---
+
+### Task 4.2: EnvBlocklist 补充
+
+**文件**: `internal/worker/codexcli/types.go`
+
+**修改**:
+```go
+// 之前
+var EnvBlocklist = []string{"HOTPLEX_", "CODEX_"}
+
+// 之后（添加嵌套代理检测，与 claudecode 的做法一致）
+var EnvBlocklist = []string{"HOTPLEX_", "CODEX_", "CODEXCLI"}
+```
+
+**QA**: 确认 `CODEXCLI=` 不会泄露至 worker 子进程。
+
+---
+
+## 验证计划
+
+### 每项 Task 的通用 QA 步骤
+
+1. **编译**: `go build ./internal/worker/codexcli/...`
+2. **Lint**: `golangci-lint run ./internal/worker/codexcli/...`
+3. **现有测试**: `go test -race -count=1 ./internal/worker/codexcli/...` —— 必须全部通过
+4. **新增测试**: 每个公共方法至少一个 table-driven 测试
+
+### Phase 0 QA
+
+| 测试用例 | 输入 | 预期输出 | 验证方法 |
+|-----------|-------|--------|-----------|
+| item.updated 事件被解析 | `{"type":"item.updated","item":{...}}` | AEP 信封（MessageDelta/ToolResult/Reasoning） | 单元测试 |
+| 模态包含 image | `worker.Modalities()` | `["text","code","image"]` | 单元测试 |
+| ImageGeneration 已移除 | 代码搜索 | 无引用 | grep |
+
+### Phase 1 QA
+
+| 测试用例 | 输入 | 预期输出 | 验证方法 |
+|-----------|-------|--------|-----------|
+| /compact（AppServerWorker） | `Compact(ctx, nil)` | `thread/compact/start` 请求已发送至 Manager | 集成测试 |
+| /compact（ExecWorker） | `Compact(ctx, nil)` | `ErrNotImplemented` 并附带解释性错误消息 | 单元测试 |
+| HandleQuestionResponse | `HandleQuestionResponse(ctx, "req1", {"q1":"a"})` | `RespondServerRequest` 已调用 | 集成测试 |
+| HandleElicitationResponse | `HandleElicitationResponse(ctx, "req1", "accept", {...})` | `RespondServerRequest` 已调用 | 集成测试 |
+| CollabToolCall 已映射 | `{"type":"collab_tool_call",...}` | `ToolCall(collab:X)` AEP 信封 | 单元测试 |
+| WebSearch 已映射 | `{"type":"web_search",...}` | `ToolCall(web_search)` AEP 信封 | 单元测试 |
+
+### Phase 2 QA
+
+| 测试用例 | 输入 | 预期输出 | 验证方法 |
+|-----------|-------|--------|-----------|
+| thread/resume | `ResumeThread("thread-123")` | 成功响应 | 集成测试 |
+| thread/fork | `ForkThread("thread-123")` | 新 thread ID | 集成测试 |
+| thread/name/set | `SetThreadName("thread-123", "My Thread")` | 成功响应 | 集成测试 |
+| thread/goal/set | `SetThreadGoal("thread-123", goal)` | 成功响应 | 集成测试 |
+| thread/goal/get | `GetThreadGoal("thread-123")` | goal 对象 | 集成测试 |
+| thread/goal/clear | `ClearThreadGoal("thread-123")` | 成功响应 | 集成测试 |
+| thread/compact/start | `CompactThread("thread-123")` | 成功响应 | 集成测试 |
+| thread/rollback | `RollbackThread("thread-123", "")` | 成功响应 | 集成测试 |
+| turn/interrupt | `InterruptTurn("thread-123")` | 成功响应 | 集成测试 |
+| mcpServerStatus/list | `ListMCPServerStatus()` | 服务器列表 | 集成测试 |
+| mcpServer/resource/read | `ReadMCPResource("uri")` | 资源内容 | 集成测试 |
+| mcpServer/tool/call | `CallMCPTool("server", "tool", args)` | 工具结果 | 集成测试 |
+| config/mcpServer/reload | `RefreshMCPServer("name")` | 成功响应 | 集成测试 |
+| mcpServer/oauth/login | `MCPServerOAuthLogin("name")` | OAuth URL | 集成测试 |
+| review/start | `StartReview({target:Uncommitted})` | 新线程已创建，审查事件 | 集成测试 |
+
+### Phase 3 QA
+
+| 测试用例 | 输入 | 预期输出 | 验证方法 |
+|-----------|-------|--------|-----------|
+| buildArgs --image | `session.Images = ["a.png"]` | `["exec","--json","--image","a.png",...]` | 单元测试 |
+| buildArgs --output-schema | `session.JSONSchema = "{}"` | `["exec","--json","--output-schema","/tmp/...",...]` | 单元测试 |
+| buildArgs --add-dir | `session.AllowedDirs = ["/tmp"]` | `["exec","--json","--add-dir","/tmp",...]` | 单元测试 |
+
+### Phase 4 QA
+
+| 测试用例 | 输入 | 预期输出 | 验证方法 |
+|-----------|-------|--------|-----------|
+| Cron SessionKey with codex_cli | `Payload{WorkerType:"codex_cli", OwnerID:"u1"}` | key 推导使用 TypeCodexCLI | 单元测试 |
+| CODEXCLI env blocked | `os.Setenv("CODEXCLI", "v")` → worker process | CODEXCLI 在子进程中不存在 | 集成测试 |
+
+---
+
+## 文件影响矩阵
+
+| 文件 | Phase 0 | Phase 1 | Phase 2 | Phase 3 | Phase 4 | 受影响行数 |
+|------|---------|---------|---------|---------|---------|------|
+| `types.go` | +1 常量, -1 常量 | +4 常量, +struct 字段 | — | — | +1 env | **~30** |
+| `parser.go` | 无变更 | — | — | — | — | **0** |
+| `mapper.go` | +1 事件 case, +1 方法 | +4 item case, +4 方法 | +7 通知 case | — | — | **~200** |
+| `worker.go` | +1 模态字段 | +6 方法, +2 接口断言 | +5 方法 | +14 标志 | — | **~150** |
+| `commands.go` | — | +3 方法 | +2 方法 | — | — | **~80** |
+| `manager.go` | — | — | +22 方法 | — | — | **~480** |
+| `config.go` | — | — | — | +字段 | — | **~20** |
+| `internal/config/config.go` | — | — | — | +字段 | — | **~15** |
+| `internal/worker/worker.go` | — | — | — | +SessionInfo 字段 | — | **~10** |
+| `internal/cron/types.go` | — | — | — | — | +修复 | **~5** |
+| **总计** | | | | | | **~990 行** |
+
+---
+
+## 依赖关系
+
+```
+Phase 0 (无依赖)
+  ├── Task 0.1 (item.updated) ── 独立
+  ├── Task 0.2 (modalities) ── 独立
+  └── Task 0.3 (remove phantom) ── 独立
+
+Phase 1 (依赖 Phase 0 中已定义的 item 类型)
+  ├── Task 1.1 (WorkerCommander) ── 依赖 Task 2.1 (thread/compact/start, thread/rollback)
+  ├── Task 1.2 (QuestionResponse) ── 独立
+  ├── Task 1.3 (ElicitationResponse) ── 独立
+  └── Task 1.4 (item types) ── 独立
+
+Phase 2 (依赖 Phase 1 中已定义的 manager 方法)
+  ├── Task 2.1 (thread 方法) ── 独立；被 Task 1.1 依赖
+  ├── Task 2.2 (turn 方法 + 环境变量) ── 独立
+  ├── Task 2.3 (MCP 方法) ── 独立
+  ├── Task 2.4 (review) ── 独立
+  └── Task 2.5 (notifications) ── 独立
+
+Phase 3 (无依赖)
+  └── Task 3.1+3.2 (标志) ── 独立
+
+Phase 4 (无依赖)
+  ├── Task 4.1 (cron) ── 独立
+  └── Task 4.2 (env blocklist) ── 独立
+```
+
+---
+
+## 风险与缓解措施
+
+| 风险 | 影响 | 缓解措施 |
+|------|--------|----------|
+| 上游 Codex CLI 协议可能在无通知的情况下变更 | 对新字段的反序列化失败 | 对所有 JSON 结构体使用 `json:"..."` + `omitempty`；对未知字段优雅降级 |
+| AppServer 单例管理器死锁 | 网关挂起 | 遵循现有的 mutex 排序（`m.mu` → `writeMu`）；所有新方法复用 `Call()` 的超时机制 |
+| `thread/compact/start` 或 `turn/steer` 可能无响应地挂起 | Worker 挂起 | Manager 的 `Call()` 已设置 30s 超时（`defaultCallTimeout`） |
+| Wire format 错误（如 spec 中之前错误的 `mcp/server/listStatus`） | JSON-RPC 调用失败 | 所有方法名已通过上游 `common.rs` 的 `#[serde(rename)]` 定义验证 |
+| 破坏现有的 ExecWorker 行为 | 功能回归 | 首先运行现有测试；使用 `t.Parallel()` 隔离新测试 |
+
+---
+
+## 术语表
+
+| 术语 | 定义 |
+|------|------------|
+| **AEP** | Agent 交换协议 —— HotPlex 的 WebSocket 事件协议 |
+| **Exec 模式** | 单次 `codex exec --json <prompt>` —— 每次输入对应一个进程 |
+| **AppServer 模式** | 持久的 `codex app-server` —— 所有会话共享一个 JSON-RPC 进程 |
+| **WorkerCommander** | 支持 Compact/Clear/Rewind 直通命令的 Worker 接口 |
+| **Thread** | Codex CLI 会话 —— 包含多个轮次（turns） |
+| **Turn** | 单次提示词-响应循环 |
+| **Item** | 轮次内的内容单元（代理消息、命令、文件变更等） |
+| **Steer** | 在运行中的轮次中改变代理行为的中途指令 |

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -124,21 +124,30 @@ func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	title := strings.TrimSpace(r.URL.Query().Get("title"))
-	title = messaging.SanitizeText(title)
-	wt := worker.WorkerType(r.URL.Query().Get("worker_type"))
-	if wt == "" {
-		wt = worker.TypeClaudeCode
-	}
-	if title == "" {
-		g.log.Warn("gateway: create session missing title", "method", r.Method, "path", r.URL.Path)
-		http.Error(w, "title is required", http.StatusBadRequest)
+	clientSessionID := strings.TrimSpace(r.URL.Query().Get("client_session_id"))
+	clientSessionID = messaging.SanitizeText(clientSessionID)
+	if clientSessionID == "" {
+		g.log.Warn("gateway: create session missing client_session_id", "method", r.Method, "path", r.URL.Path)
+		http.Error(w, "client_session_id is required", http.StatusBadRequest)
 		return
 	}
+	if len(clientSessionID) > 256 {
+		g.log.Warn("gateway: create session client_session_id too long", "method", r.Method, "path", r.URL.Path, "len", len(clientSessionID))
+		http.Error(w, "client_session_id too long (max 256 chars)", http.StatusBadRequest)
+		return
+	}
+
+	title := strings.TrimSpace(r.URL.Query().Get("title"))
+	title = messaging.SanitizeText(title)
 	if len(title) > 256 {
 		g.log.Warn("gateway: create session title too long", "method", r.Method, "path", r.URL.Path, "title_len", len(title))
 		http.Error(w, "title too long (max 256 chars)", http.StatusBadRequest)
 		return
+	}
+
+	wt := worker.WorkerType(r.URL.Query().Get("worker_type"))
+	if wt == "" {
+		wt = worker.TypeClaudeCode
 	}
 
 	// Resolve work dir: use client-provided value or default from config.
@@ -159,7 +168,7 @@ func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 	// Derive session ID via UUIDv5 for consistency with WebSocket path.
 	// Both REST and WS use the auth userID ("anonymous" in dev mode, "api_user"
 	// with API keys) so they produce the same derived session ID.
-	id := session.DeriveSessionKey(userID, wt, title, workDir)
+	id := session.DeriveSessionKey(userID, wt, clientSessionID, workDir)
 
 	// Default userID after derivation — bridge expects non-empty.
 	if userID == "" {
@@ -177,7 +186,7 @@ func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 		_ = g.sm.DeletePhysical(r.Context(), id)
 	}
 
-	if err := g.bridge.StartSession(r.Context(), id, userID, botID, wt, nil, workDir, platformWebChat, nil, title, ""); err != nil {
+	if err := g.bridge.StartSession(r.Context(), id, userID, botID, wt, nil, workDir, platformWebChat, nil, title, clientSessionID); err != nil {
 		g.log.Error("gateway: create session failed", "session_id", id, "worker_type", wt, "work_dir", workDir, "err", err)
 		http.Error(w, "failed to create session", http.StatusInternalServerError)
 		return

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -131,17 +132,17 @@ func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "client_session_id is required", http.StatusBadRequest)
 		return
 	}
-	if len(clientSessionID) > 256 {
+	if len(clientSessionID) > session.MaxClientKeyLen {
 		g.log.Warn("gateway: create session client_session_id too long", "method", r.Method, "path", r.URL.Path, "len", len(clientSessionID))
-		http.Error(w, "client_session_id too long (max 256 chars)", http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("client_session_id too long (max %d chars)", session.MaxClientKeyLen), http.StatusBadRequest)
 		return
 	}
 
 	title := strings.TrimSpace(r.URL.Query().Get("title"))
 	title = messaging.SanitizeText(title)
-	if len(title) > 256 {
+	if len(title) > session.MaxClientKeyLen {
 		g.log.Warn("gateway: create session title too long", "method", r.Method, "path", r.URL.Path, "title_len", len(title))
-		http.Error(w, "title too long (max 256 chars)", http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("title too long (max %d chars)", session.MaxClientKeyLen), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/gateway/api_test.go
+++ b/internal/gateway/api_test.go
@@ -116,7 +116,7 @@ type mockAPIBridge struct {
 }
 
 func (m *mockAPIBridge) StartSession(ctx context.Context, id, userID, botID string, wt worker.WorkerType, allowedTools []string, workDir string, platform string, platformKey map[string]string, title, clientKey string, _ ...string) error {
-	return m.Called(ctx, id, userID, botID, wt, allowedTools, workDir, platform, platformKey, title).Error(0)
+	return m.Called(ctx, id, userID, botID, wt, allowedTools, workDir, platform, platformKey, title, clientKey).Error(0)
 }
 
 func (m *mockAPIBridge) ResumeSession(ctx context.Context, id string, workDir string) error {
@@ -213,7 +213,7 @@ func setupMux(api *GatewayAPI) *http.ServeMux {
 
 // ─── CreateSession tests ────────────────────────────────────────────────────────
 
-func TestCreateSession_TitlePreferred(t *testing.T) {
+func TestCreateSession_WithClientSessionID(t *testing.T) {
 	t.Parallel()
 	sm := new(mockAPISM)
 	bridge := new(mockAPIBridge)
@@ -222,10 +222,10 @@ func TestCreateSession_TitlePreferred(t *testing.T) {
 	// Get returns not found → no idempotency path
 	sm.On("Get", mock.Anything).Return(nil, session.ErrSessionNotFound)
 	bridge.On("StartSession", mock.Anything, mock.Anything, "anonymous", "", worker.TypeClaudeCode,
-		([]string)(nil), "", "webchat", map[string]string(nil), "my-title").Return(nil)
+		([]string)(nil), "", "webchat", map[string]string(nil), "my-title", "client-1").Return(nil)
 
 	w := httptest.NewRecorder()
-	api.CreateSession(w, authedReq("POST", "/api/sessions?title=my-title", nil))
+	api.CreateSession(w, authedReq("POST", "/api/sessions?client_session_id=client-1&title=my-title", nil))
 
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp map[string]string
@@ -234,21 +234,7 @@ func TestCreateSession_TitlePreferred(t *testing.T) {
 	bridge.AssertExpectations(t)
 }
 
-func TestCreateSession_SessionIDOnlyRejected(t *testing.T) {
-	t.Parallel()
-	sm := new(mockAPISM)
-	bridge := new(mockAPIBridge)
-	api := newTestAPI(t, sm, bridge)
-
-	// session_id alone without title is rejected
-	w := httptest.NewRecorder()
-	api.CreateSession(w, authedReq("POST", "/api/sessions?session_id=fallback-id", nil))
-
-	require.Equal(t, http.StatusBadRequest, w.Code)
-	require.Contains(t, w.Body.String(), "title is required")
-}
-
-func TestCreateSession_MissingTitleAndSessionID(t *testing.T) {
+func TestCreateSession_MissingClientSessionID(t *testing.T) {
 	t.Parallel()
 	sm := new(mockAPISM)
 	bridge := new(mockAPIBridge)
@@ -258,7 +244,25 @@ func TestCreateSession_MissingTitleAndSessionID(t *testing.T) {
 	api.CreateSession(w, authedReq("POST", "/api/sessions", nil))
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
-	require.Contains(t, w.Body.String(), "title is required")
+	require.Contains(t, w.Body.String(), "client_session_id is required")
+}
+
+func TestCreateSession_ClientSessionIDOnlyNoTitle(t *testing.T) {
+	t.Parallel()
+	sm := new(mockAPISM)
+	bridge := new(mockAPIBridge)
+	api := newTestAPI(t, sm, bridge)
+
+	// title is optional, client_session_id alone should work
+	sm.On("Get", mock.Anything).Return(nil, session.ErrSessionNotFound)
+	bridge.On("StartSession", mock.Anything, mock.Anything, "anonymous", "", worker.TypeClaudeCode,
+		([]string)(nil), "", "webchat", map[string]string(nil), "", "csid-only").Return(nil)
+
+	w := httptest.NewRecorder()
+	api.CreateSession(w, authedReq("POST", "/api/sessions?client_session_id=csid-only", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	bridge.AssertExpectations(t)
 }
 
 func TestCreateSession_IdempotentActiveSession(t *testing.T) {
@@ -272,7 +276,7 @@ func TestCreateSession_IdempotentActiveSession(t *testing.T) {
 	// bridge.StartSession should NOT be called
 
 	w := httptest.NewRecorder()
-	api.CreateSession(w, authedReq("POST", "/api/sessions?title=test", nil))
+	api.CreateSession(w, authedReq("POST", "/api/sessions?client_session_id=test&title=test", nil))
 
 	require.Equal(t, http.StatusOK, w.Code)
 	bridge.AssertNotCalled(t, "StartSession", mock.Anything)
@@ -288,10 +292,10 @@ func TestCreateSession_DeletedSessionRecreated(t *testing.T) {
 	sm.On("Get", mock.Anything).Return(deleted, nil)
 	sm.On("DeletePhysical", mock.Anything, mock.Anything).Return(nil)
 	bridge.On("StartSession", mock.Anything, mock.Anything, "anonymous", "",
-		worker.TypeClaudeCode, ([]string)(nil), "", "webchat", map[string]string(nil), "test").Return(nil)
+		worker.TypeClaudeCode, ([]string)(nil), "", "webchat", map[string]string(nil), "test", "test-csid").Return(nil)
 
 	w := httptest.NewRecorder()
-	api.CreateSession(w, authedReq("POST", "/api/sessions?title=test", nil))
+	api.CreateSession(w, authedReq("POST", "/api/sessions?client_session_id=test-csid&title=test", nil))
 
 	require.Equal(t, http.StatusOK, w.Code)
 	sm.AssertCalled(t, "DeletePhysical", mock.Anything, mock.Anything)
@@ -306,11 +310,11 @@ func TestCreateSession_BridgeError(t *testing.T) {
 
 	sm.On("Get", mock.Anything).Return(nil, session.ErrSessionNotFound)
 	bridge.On("StartSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(errTestBridge)
 
 	w := httptest.NewRecorder()
-	api.CreateSession(w, authedReq("POST", "/api/sessions?title=fail", nil))
+	api.CreateSession(w, authedReq("POST", "/api/sessions?client_session_id=fail&title=fail", nil))
 
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 	require.Contains(t, w.Body.String(), "failed to create session")
@@ -326,11 +330,11 @@ func TestCreateSession_WithWorkDir(t *testing.T) {
 
 	sm.On("Get", mock.Anything).Return(nil, session.ErrSessionNotFound)
 	bridge.On("StartSession", mock.Anything, mock.Anything, "anonymous", "",
-		worker.TypeClaudeCode, ([]string)(nil), mock.Anything, "webchat", map[string]string(nil), "with-workdir").
+		worker.TypeClaudeCode, ([]string)(nil), mock.Anything, "webchat", map[string]string(nil), "with-workdir", "workdir-csid").
 		Return(nil)
 
 	w := httptest.NewRecorder()
-	api.CreateSession(w, authedReq("POST", "/api/sessions?title=with-workdir&work_dir=/tmp", nil))
+	api.CreateSession(w, authedReq("POST", "/api/sessions?client_session_id=workdir-csid&title=with-workdir&work_dir=/tmp", nil))
 
 	require.Equal(t, http.StatusOK, w.Code)
 	bridge.AssertExpectations(t)

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -402,7 +402,7 @@ func (c *Conn) handleSessionNotFound(sessionID string, initData InitData, workDi
 	}
 
 	if c.starter != nil {
-		if err := c.starter.StartSession(context.Background(), sessionID, c.userID, c.botID, initData.WorkerType, initData.Config.AllowedTools, workDir, platformWebChat, nil, "", clientKey); err != nil {
+		if err := c.starter.StartSession(context.Background(), sessionID, c.userID, c.botID, initData.WorkerType, initData.Config.AllowedTools, workDir, platformWebChat, nil, initData.Title, clientKey); err != nil {
 			c.hub.InitThrottle.RecordFailure(sessionID)
 			c.sendInitError(events.ErrCodeInternalError, "failed to create session")
 			metrics.GatewayErrorsTotal.WithLabelValues(string(events.ErrCodeInternalError)).Inc()
@@ -419,7 +419,7 @@ func (c *Conn) handleSessionNotFound(sessionID string, initData InitData, workDi
 	}
 
 	// Test mode: create directly via session manager.
-	si, err := sm.CreateWithBot(context.Background(), sessionID, c.userID, c.botID, initData.WorkerType, initData.Config.AllowedTools, platformWebChat, nil, workDir, "", clientKey)
+	si, err := sm.CreateWithBot(context.Background(), sessionID, c.userID, c.botID, initData.WorkerType, initData.Config.AllowedTools, platformWebChat, nil, workDir, initData.Title, clientKey)
 	if err != nil {
 		c.hub.InitThrottle.RecordFailure(sessionID)
 		c.sendInitError(events.ErrCodeInternalError, "failed to create session")
@@ -432,7 +432,7 @@ func (c *Conn) startCreatedSession(sessionID string, initData InitData, workDir 
 	if c.starter == nil {
 		return si, nil // no starter in test mode, session stays CREATED
 	}
-	if err := c.starter.StartSession(context.Background(), sessionID, c.userID, c.botID, initData.WorkerType, initData.Config.AllowedTools, workDir, platformWebChat, nil, "", clientKey); err != nil {
+	if err := c.starter.StartSession(context.Background(), sessionID, c.userID, c.botID, initData.WorkerType, initData.Config.AllowedTools, workDir, platformWebChat, nil, initData.Title, clientKey); err != nil {
 		c.hub.InitThrottle.RecordFailure(sessionID)
 		c.sendInitError(events.ErrCodeInternalError, "failed to start session")
 		metrics.GatewayErrorsTotal.WithLabelValues(string(events.ErrCodeInternalError)).Inc()
@@ -450,14 +450,14 @@ func (c *Conn) recreateDeletedSession(sessionID string, initData InitData, workD
 	_ = sm.DeletePhysical(context.Background(), sessionID)
 	if c.starter == nil {
 		// Test mode: re-create session directly since the old one was physically deleted.
-		newSI, err := sm.CreateWithBot(context.Background(), sessionID, c.userID, c.botID, initData.WorkerType, initData.Config.AllowedTools, platformWebChat, nil, workDir, "", clientKey)
+		newSI, err := sm.CreateWithBot(context.Background(), sessionID, c.userID, c.botID, initData.WorkerType, initData.Config.AllowedTools, platformWebChat, nil, workDir, initData.Title, clientKey)
 		if err != nil {
 			return nil, fmt.Errorf("recreate deleted session (test mode): %w", err)
 		}
 		return newSI, nil
 	}
 	if err := c.starter.StartSession(context.Background(), sessionID, c.userID, c.botID,
-		initData.WorkerType, initData.Config.AllowedTools, workDir, platformWebChat, nil, "", clientKey); err != nil {
+		initData.WorkerType, initData.Config.AllowedTools, workDir, platformWebChat, nil, initData.Title, clientKey); err != nil {
 		c.hub.InitThrottle.RecordFailure(sessionID)
 		c.sendInitError(events.ErrCodeInternalError, fmt.Sprintf("failed to recreate deleted session: %v", err))
 		metrics.GatewayErrorsTotal.WithLabelValues(string(events.ErrCodeInternalError)).Inc()
@@ -494,10 +494,12 @@ func (c *Conn) handleExistingSession(sessionID, workDir string, sm connSM, si *s
 		return si, nil
 	}
 
-	resumeErr := c.starter.ResumeSession(context.Background(), sessionID, workDir)
+	resumeCtx, resumeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer resumeCancel()
+	resumeErr := c.starter.ResumeSession(resumeCtx, sessionID, workDir)
 	if resumeErr != nil {
-		if err := c.starter.StartSession(context.Background(), sessionID, c.userID, c.botID,
-			initData.WorkerType, initData.Config.AllowedTools, workDir, platformWebChat, nil, "", clientKey); err != nil {
+		if err := c.starter.StartSession(resumeCtx, sessionID, c.userID, c.botID,
+			initData.WorkerType, initData.Config.AllowedTools, workDir, platformWebChat, nil, initData.Title, clientKey); err != nil {
 			c.hub.InitThrottle.RecordFailure(sessionID)
 			msg := fmt.Sprintf("resume failed (%v), then start also failed (%v)", resumeErr, err)
 			c.sendInitError(events.ErrCodeInternalError, msg)

--- a/internal/gateway/conn.go
+++ b/internal/gateway/conn.go
@@ -498,7 +498,9 @@ func (c *Conn) handleExistingSession(sessionID, workDir string, sm connSM, si *s
 	defer resumeCancel()
 	resumeErr := c.starter.ResumeSession(resumeCtx, sessionID, workDir)
 	if resumeErr != nil {
-		if err := c.starter.StartSession(resumeCtx, sessionID, c.userID, c.botID,
+		startCtx, startCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer startCancel()
+		if err := c.starter.StartSession(startCtx, sessionID, c.userID, c.botID,
 			initData.WorkerType, initData.Config.AllowedTools, workDir, platformWebChat, nil, initData.Title, clientKey); err != nil {
 			c.hub.InitThrottle.RecordFailure(sessionID)
 			msg := fmt.Sprintf("resume failed (%v), then start also failed (%v)", resumeErr, err)

--- a/internal/gateway/init.go
+++ b/internal/gateway/init.go
@@ -4,7 +4,9 @@ package gateway
 import (
 	"time"
 
+	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/security"
+	"github.com/hrygo/hotplex/internal/session"
 	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/aep"
 	"github.com/hrygo/hotplex/pkg/events"
@@ -145,6 +147,12 @@ func ValidateInit(env *events.Envelope) (InitData, *InitError) {
 
 	sessionID, _ := data["session_id"].(string)
 	title, _ := data["title"].(string)
+	title = messaging.SanitizeText(title)
+	if len(title) > session.MaxClientKeyLen {
+		return InitData{}, &InitError{Code: events.ErrCodeInvalidMessage,
+			Message: "init: title too long"}
+	}
+	sessionID = messaging.SanitizeText(sessionID)
 
 	var auth InitAuth
 	if authData, ok := data["auth"].(map[string]any); ok {

--- a/internal/gateway/init.go
+++ b/internal/gateway/init.go
@@ -20,6 +20,7 @@ type InitData struct {
 	Version    string            `json:"version"`
 	WorkerType worker.WorkerType `json:"worker_type"`
 	SessionID  string            `json:"session_id,omitempty"`
+	Title      string            `json:"title,omitempty"`
 	Auth       InitAuth          `json:"auth,omitempty"`
 	Config     InitConfig        `json:"config,omitempty"`
 	ClientCaps ClientCaps        `json:"client_caps,omitempty"`
@@ -143,6 +144,7 @@ func ValidateInit(env *events.Envelope) (InitData, *InitError) {
 	}
 
 	sessionID, _ := data["session_id"].(string)
+	title, _ := data["title"].(string)
 
 	var auth InitAuth
 	if authData, ok := data["auth"].(map[string]any); ok {
@@ -199,6 +201,7 @@ func ValidateInit(env *events.Envelope) (InitData, *InitError) {
 		Version:    version,
 		WorkerType: worker.WorkerType(wt),
 		SessionID:  sessionID,
+		Title:      title,
 		Auth:       auth,
 		Config:     cfg,
 	}, nil

--- a/internal/session/key.go
+++ b/internal/session/key.go
@@ -20,7 +20,8 @@ var CronNamespace = uuid.NewHash(sha1.New(), hotplexNamespace, []byte("cron"), 5
 
 // DeriveSessionKey generates a deterministic server-side session ID using UUIDv5.
 // Same (ownerID, workerType, clientKey, workDir) always maps to the same session.
-// clientKey is either a user-specified title (WebChat) or a protocol session ID (WS).
+// clientKey is a client-provided opaque identifier: REST API uses client_session_id,
+// WebSocket init uses session_id field. Title is NOT a valid clientKey (since v1.25).
 func DeriveSessionKey(ownerID string, wt worker.WorkerType, clientKey, workDir string) string {
 	// UUIDv5 = SHA-1(namespace+name) — deterministic, no randomness.
 	name := ownerID + "|" + string(wt) + "|" + clientKey + "|" + workDir

--- a/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
+++ b/webchat/app/components/chat/ChatContainer.assistant-ui.tsx
@@ -220,7 +220,6 @@ export default function ChatContainer() {
         <NewSessionModal
           onConfirm={handleModalConfirm}
           onCancel={() => setShowNewModal(false)}
-          existingTitles={sessions.filter(s => s.title).map(s => s.title!)}
         />
       )}
     </div>

--- a/webchat/app/components/chat/NewSessionModal.tsx
+++ b/webchat/app/components/chat/NewSessionModal.tsx
@@ -41,20 +41,16 @@ const WORKER_OPTIONS: WorkerOption[] = [
 interface NewSessionModalProps {
   onConfirm: (title: string, workerType: string, workDir: string) => void;
   onCancel: () => void;
-  existingTitles?: string[];
 }
 
-export function NewSessionModal({ onConfirm, onCancel, existingTitles = [] }: NewSessionModalProps) {
+export function NewSessionModal({ onConfirm, onCancel }: NewSessionModalProps) {
   const [title, setTitle] = useState("");
   const [selectedWorker, setSelectedWorker] = useState("claude_code");
   const [workDir, setWorkDir] = useState(configWorkDir);
 
   const trimmedTitle = title.trim();
-  const isDuplicate = trimmedTitle.length > 0 && existingTitles.includes(trimmedTitle);
-  const canConfirm = trimmedTitle.length > 0;
 
   const handleConfirm = () => {
-    if (!canConfirm) return;
     onConfirm(trimmedTitle, selectedWorker, workDir.trim());
   };
 
@@ -91,7 +87,7 @@ export function NewSessionModal({ onConfirm, onCancel, existingTitles = [] }: Ne
         {/* Session Title */}
         <div className="px-6 pb-4">
           <label className="text-[10px] font-mono font-bold text-[var(--text-faint)] uppercase tracking-widest block mb-2">
-            Session Name
+            Session Name (optional)
           </label>
           <input
             id="session-title"
@@ -102,22 +98,12 @@ export function NewSessionModal({ onConfirm, onCancel, existingTitles = [] }: Ne
             placeholder="e.g. HotPlex Bug Fix"
             autoFocus
             className={`w-full px-3 py-2.5 rounded-[var(--radius-md)] bg-[var(--bg-elevated)] border text-sm text-[var(--text-primary)] placeholder:text-[var(--text-faint)] focus:outline-none focus:ring-2 transition-all font-mono ${
-              isDuplicate
-                ? 'border-[var(--accent-gold)] focus:ring-[rgba(251,191,36,0.15)]'
-                : trimmedTitle.length > 0
-                  ? 'border-[var(--accent-emerald)] focus:ring-[rgba(16,185,129,0.15)]'
-                  : 'border-[var(--border-default)] focus:ring-[rgba(251,191,36,0.1)] focus:border-[var(--amber-border)]'
+              trimmedTitle.length > 0
+                ? 'border-[var(--accent-emerald)] focus:ring-[rgba(16,185,129,0.15)]'
+                : 'border-[var(--border-default)] focus:ring-[rgba(251,191,36,0.1)] focus:border-[var(--amber-border)]'
             }`}
             onKeyDown={(e) => e.stopPropagation()}
           />
-          {isDuplicate && (
-            <p className="text-[10px] text-[var(--accent-gold)] mt-1.5 flex items-center gap-1">
-              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              Will reuse existing session
-            </p>
-          )}
         </div>
 
         {/* Worker Selection */}
@@ -178,8 +164,7 @@ export function NewSessionModal({ onConfirm, onCancel, existingTitles = [] }: Ne
           </button>
           <button
             onClick={handleConfirm}
-            disabled={!canConfirm}
-            className="px-6 py-2 rounded-[var(--radius-md)] bg-[var(--accent-gold)] text-black text-xs font-bold transition-all hover:bg-[var(--accent-gold-bright)] active:scale-[0.98] shadow-[0_4px_16px_rgba(251,191,36,0.15)] disabled:opacity-40 disabled:cursor-not-allowed disabled:active:scale-100"
+            className="px-6 py-2 rounded-[var(--radius-md)] bg-[var(--accent-gold)] text-black text-xs font-bold transition-all hover:bg-[var(--accent-gold-bright)] active:scale-[0.98] shadow-[0_4px_16px_rgba(251,191,36,0.15)]"
           >
             Start Session
           </button>

--- a/webchat/lib/api/sessions.ts
+++ b/webchat/lib/api/sessions.ts
@@ -108,14 +108,18 @@ export async function listSessions(limit = 20, offset = 0, signal?: AbortSignal)
 }
 
 export interface CreateSessionOptions {
+  clientSessionId: string;
   workerType?: string;
-  title: string;
+  title?: string;
   workDir?: string;
 }
 
 export async function createSession(opts: CreateSessionOptions, signal?: AbortSignal): Promise<{ session_id: string }> {
   const workerType = opts.workerType ?? 'claude_code';
-  let url = `${BASE}/api/sessions?worker_type=${encodeURIComponent(workerType)}&title=${encodeURIComponent(opts.title)}`;
+  let url = `${BASE}/api/sessions?client_session_id=${encodeURIComponent(opts.clientSessionId)}&worker_type=${encodeURIComponent(workerType)}`;
+  if (opts.title) {
+    url += `&title=${encodeURIComponent(opts.title)}`;
+  }
   if (opts.workDir) {
     url += `&work_dir=${encodeURIComponent(opts.workDir)}`;
   }

--- a/webchat/lib/hooks/useSessions.ts
+++ b/webchat/lib/hooks/useSessions.ts
@@ -19,6 +19,7 @@ import {
   type SessionInfo,
 } from '@/lib/api/sessions';
 import { workerType as defaultWorkerType, workDir as configWorkDir } from '@/lib/config';
+import { newSessionId } from '@/lib/ai-sdk-transport/client/envelope';
 import { logger } from '@/lib/logger';
 
 export interface UseSessionsOptions {
@@ -63,9 +64,9 @@ export function useSessions({
   const STORAGE_KEY = 'hotplex_active_session_id';
   const DEFAULT_WORKER_TYPE = defaultWorkerType;
 
-  // Deterministic anchor session title — ensures the first auto-created session
-  // maps to the same server-side key via DeriveSessionKey(userID, workerType, title, workDir).
-  const MAIN_SESSION_TITLE = 'main';
+  // Deterministic anchor session — ensures the first auto-created session
+  // maps to the same server-side key via DeriveSessionKey(userID, workerType, "main", workDir).
+  const ANCHOR_SESSION_ID = 'main';
 
   const refreshSessions = useCallback(async () => {
     try {
@@ -115,14 +116,14 @@ export function useSessions({
         isCreating.current = true;
         try {
           const effectiveWorkDir = configWorkDir || undefined;
-          const { session_id } = await createSession({ workerType: DEFAULT_WORKER_TYPE, title: MAIN_SESSION_TITLE, workDir: effectiveWorkDir });
+          const { session_id } = await createSession({ clientSessionId: ANCHOR_SESSION_ID, workerType: DEFAULT_WORKER_TYPE, title: ANCHOR_SESSION_ID, workDir: effectiveWorkDir });
           const now = new Date().toISOString();
           const newSession: SessionInfo = {
             id: session_id,
             user_id: '',
             worker_type: DEFAULT_WORKER_TYPE,
             state: 'created',
-            title: MAIN_SESSION_TITLE,
+            title: ANCHOR_SESSION_ID,
             work_dir: effectiveWorkDir,
             created_at: now,
             updated_at: now,
@@ -162,7 +163,7 @@ export function useSessions({
     isCreating.current = true;
     setIsLoading(true);
     try {
-      const { session_id } = await createSession({ workerType: wt, title, workDir: effectiveWorkDir });
+      const { session_id } = await createSession({ clientSessionId: newSessionId(), workerType: wt, title: title || undefined, workDir: effectiveWorkDir });
       const now = new Date().toISOString();
       const newSession: SessionInfo = {
         id: session_id,


### PR DESCRIPTION
## Summary

- 恢复 title 长度校验（max 256），与 client_session_id 对称防护
- 复用已有 `newSessionId()` 替换内联 `crypto.randomUUID()`（含非安全上下文降级）
- 合并 `MAIN_SESSION_CLIENT_ID`/`MAIN_SESSION_TITLE` 为单一 `ANCHOR_SESSION_ID`
- 更新 `DeriveSessionKey` 注释反映 client_session_id 语义
- ResumeSession/StartSession fallback 加 30s 超时 context

同时包含完整的 client_session_id 迁移变更：
- 后端 `CreateSession` 改为要求 `client_session_id`、title 可选
- 前端自动创建使用确定性 `'main'`，手动创建使用 UUID
- 文档更新 session 身份、创建路径、重连机制

Closes #634

## Test plan

- [x] Go 全量测试通过（`go test ./internal/... -count=1`）
- [x] TypeScript 编译通过（`npx tsc --noEmit`）
- [x] CreateSession 7 个测试全部通过
- [x] Pre-push 质量门禁通过（fmt + lint + vet + build + test）
- [ ] 验证 WebChat 自动创建 session 仍使用确定性 key
- [ ] 验证手动创建 session 仍正常工作
- [ ] 验证超长 title 被正确拒绝