### PR TITLE
chore(docs): archive GroupChat collaboration spec (#633)

### DIFF
--- a/docs/specs/GroupChat-Collaboration-Spec.md
+++ b/docs/specs/GroupChat-Collaboration-Spec.md
@@ -2,8 +2,10 @@
 type: spec
 tags: [project/HotPlex, feature/multi-bot-collaboration, area/messaging]
 date: 2026-06-03
-status: proposed
+status: archived
 progress: 0
+archived_reason: "Gateway-level multi-bot orchestration reimplements Agent-level multi-agent capabilities (Claude Code native subagents). No incremental value — see PR #636 closure comment."
+archived_date: 2026-06-04
 ---
 
 # 群聊多 Bot 协作


### PR DESCRIPTION
## 变更

- 将 `GroupChat-Collaboration-Spec.md` 状态标记为 `archived`，附归档原因和日期

## 背景

Issue #633 / PR #636 经架构评估后关闭：Gateway 层多 Bot 轮询编排是对 Agent 层原生 multi-agent 能力的重复实现，无增量价值。

🤖 Generated with [Claude Code](https://claude.com/claude-code)