### PR TITLE
feat(docs): API 文档混合生成 — swaggo 注解 + Scalar 控制台 (closes #632)

### DIFF
--- a/.github/actions/setup-go-webchat/action.yml
+++ b/.github/actions/setup-go-webchat/action.yml
@@ -67,7 +67,7 @@ runs:
       uses: actions/cache@v5
       with:
         path: internal/docs/out
-        key: docs-${{ hashFiles('docs/**/*.md', 'cmd/build-docs/**') }}
+        key: docs-${{ hashFiles('docs/**/*.md', 'docs/swagger/swagger.json', 'cmd/build-docs/**') }}
 
     - name: Build docs
       if: steps.docs-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - 'internal/webchat/**'
       - 'configs/**'
       - 'docs/**/*.md'
+      - 'docs/swagger/**'
       - 'cmd/build-docs/**'
       - '.github/workflows/**'
   pull_request:
@@ -27,6 +28,7 @@ on:
       - 'internal/webchat/**'
       - 'configs/**'
       - 'docs/**/*.md'
+      - 'docs/swagger/**'
       - 'cmd/build-docs/**'
       - '.github/workflows/**'
 
@@ -191,6 +193,12 @@ jobs:
 
       - name: Build & validate docs
         run: make docs-build
+
+      - name: Install swag
+        run: go install github.com/swaggo/swag/cmd/swag@latest
+
+      - name: Check swagger freshness
+        run: make check-swagger
 
       - name: Build gateway binary
         run: |

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ CYAN   := \033[36m
 .PHONY: pg-start pg-stop pg-status pg-logs pg-reset dev-pg
 .PHONY: gateway-start gateway-stop gateway-status gateway-logs
 .PHONY: webchat-dev webchat-stop webchat-embed webchat-rebuild
-.PHONY: docs-build docs-clean docs-lint
+.PHONY: docs-build docs-clean docs-lint swagger check-swagger scalar-assets
 .PHONY: test test-short lint fmt quality check clean
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -335,6 +335,58 @@ docs-clean:
 docs-lint: docs-build
 	@echo "$(CYAN)Docs link validation passed$(RESET)"
 
+SWAGGER_DIR     := docs/swagger
+SCALAR_VERSION  := 1.26.0
+
+swagger:
+	@echo "  $(CYAN)Swagger$(RESET)$(DIM) generating API spec...$(RESET)"
+	@command -v swag > /dev/null 2>&1 || { \
+		echo "  $(RED)swag not found$(RESET)$(DIM) — run: go install github.com/swaggo/swag/cmd/swag@latest$(RESET)"; \
+		exit 1; \
+	}
+	@mkdir -p $(SWAGGER_DIR)
+	@swag init \
+		--generalInfo doc.go \
+		--dir cmd/hotplex,internal/admin,internal/gateway \
+		--output $(SWAGGER_DIR) \
+		--outputTypes json \
+		--parseInternal \
+		--quiet
+	@echo "  $(GREEN)✓$(RESET) $(SWAGGER_DIR)/swagger.json"
+
+check-swagger:
+	@echo "  $(CYAN)Check$(RESET)$(DIM) swagger freshness...$(RESET)"
+	@command -v swag > /dev/null 2>&1 || { \
+		echo "  $(RED)swag not found$(RESET) — run: go install github.com/swaggo/swag/cmd/swag@latest"; \
+		exit 1; \
+	}
+	@mkdir -p /tmp/swagger-check
+	@swag init \
+		--generalInfo doc.go \
+		--dir cmd/hotplex,internal/admin,internal/gateway \
+		--output /tmp/swagger-check \
+		--outputTypes json \
+		--parseInternal \
+		--quiet
+	@if ! diff -q $(SWAGGER_DIR)/swagger.json /tmp/swagger-check/swagger.json > /dev/null 2>&1; then \
+		echo "  $(RED)✗$(RESET) swagger.json is out of date — run: make swagger"; \
+		diff $(SWAGGER_DIR)/swagger.json /tmp/swagger-check/swagger.json | head -40; \
+		exit 1; \
+	fi
+	@echo "  $(GREEN)✓$(RESET) swagger.json is up to date"
+
+scalar-assets:
+	@echo "  $(CYAN)Scalar$(RESET)$(DIM) downloading assets...$(RESET)"
+	@mkdir -p docs/assets/scalar
+	@if [ ! -f docs/assets/scalar/scalar.js ]; then \
+		curl -fsSL \
+			"https://cdn.jsdelivr.net/npm/@scalar/api-reference@$(SCALAR_VERSION)/dist/browser/standalone.min.js" \
+			-o docs/assets/scalar/scalar.js && \
+		echo "  $(GREEN)✓$(RESET) Scalar bundle downloaded ($(SCALAR_VERSION))"; \
+	else \
+		echo "  $(DIM)Scalar ✓ cached$(RESET)"; \
+	fi
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Clean
 # ─────────────────────────────────────────────────────────────────────────────
@@ -392,8 +444,11 @@ help:
 	@printf "    $(CYAN)make %-15s$(RESET)  %s\n" "gateway-logs"   "Gateway logs"
 	@echo ""
 	@echo "  $(BOLD)📖 Documentation"
-	@printf "    $(CYAN)make %-15s$(RESET)  %s\n" "docs-build"    "Build static HTML docs"
-	@printf "    $(CYAN)make %-15s$(RESET)  %s\n" "docs-clean"    "Remove generated docs"
+	@printf "    $(CYAN)make %-15s$(RESET)  %s\n" "docs-build"     "Build static HTML docs"
+	@printf "    $(CYAN)make %-15s$(RESET)  %s\n" "docs-clean"     "Remove generated docs"
+	@printf "    $(CYAN)make %-15s$(RESET)  %s\n" "swagger"        "Generate docs/swagger/swagger.json"
+	@printf "    $(CYAN)make %-15s$(RESET)  %s\n" "check-swagger"  "Verify swagger.json is up to date"
+	@printf "    $(CYAN)make %-15s$(RESET)  %s\n" "scalar-assets"  "Download Scalar UI bundle locally"
 	@echo ""
 	@echo "  $(BOLD)🔄 Workflow"
 	@printf "    $(CYAN)make %-15s$(RESET)  %s\n" "dev-reset"   "Restart all services"

--- a/cmd/build-docs/main.go
+++ b/cmd/build-docs/main.go
@@ -184,6 +184,14 @@ func main() {
 		log.Printf("Warning: failed to copy logo.webp: %v", err)
 	}
 
+	// Copy swagger.json for Scalar API console
+	swaggerDst := filepath.Join(docsDest, "swagger", "swagger.json")
+	if err := os.MkdirAll(filepath.Dir(swaggerDst), 0o755); err != nil {
+		log.Printf("Warning: failed to create swagger output dir: %v", err)
+	} else if err := copyFile(filepath.Join("docs", "swagger", "swagger.json"), swaggerDst); err != nil {
+		log.Printf("Warning: failed to copy swagger.json: %v", err)
+	}
+
 	// Phase 3: Process discovered markdown files
 	for relPath := range discoveredFiles {
 		srcPath := filepath.Join(docsSrc, relPath)
@@ -540,10 +548,6 @@ func processFile(path string, nav []NavItem) error {
 
 	content := buf.String()
 	// Removed naive strings.ReplaceAll, now handled by linkTransformer
-
-	// Wrap tables in scrollable containers for horizontal overflow
-	content = strings.ReplaceAll(content, "<table>", `<div class="table-wrap"><table>`)
-	content = strings.ReplaceAll(content, "</table>", "</table></div>")
 
 	page.Content = template.HTML(content)
 	page.Nav = nav
@@ -961,47 +965,29 @@ const layout = `
         .prose a:hover { border-bottom-color: var(--clay); }
 
         /* Tables */
-        .table-wrap {
-            overflow-x: auto;
-            border: 1px solid var(--gray-300);
-            border-radius: 12px;
-            margin: 40px 0;
-            -webkit-overflow-scrolling: touch;
-        }
         .prose table {
-            width: max-content;
-            min-width: 100%;
+            width: 100%;
             border-collapse: separate;
             border-spacing: 0;
-            font-size: 13.5px;
+            margin: 40px 0;
+            font-size: 15px;
+            border: 1px solid var(--gray-300);
+            border-radius: 12px;
+            overflow: hidden;
         }
         .prose th {
             background: var(--gray-50);
             text-align: left;
-            padding: 10px 14px;
+            padding: 14px 20px;
             border-bottom: 1px solid var(--gray-300);
             color: var(--slate);
             font-weight: 600;
             font-family: var(--font-display);
-            font-size: 12px;
-            white-space: nowrap;
-            text-transform: uppercase;
-            letter-spacing: 0.03em;
         }
         .prose td {
-            padding: 10px 14px;
+            padding: 14px 20px;
             border-bottom: 1px solid var(--gray-100);
             color: var(--gray-700);
-            vertical-align: top;
-        }
-        .prose td code {
-            white-space: nowrap;
-            font-size: 0.82em;
-            padding: 2px 5px;
-        }
-        .prose th code {
-            white-space: nowrap;
-            font-size: 0.88em;
         }
         .prose tr:last-child td { border-bottom: none; }
 

--- a/cmd/hotplex/doc.go
+++ b/cmd/hotplex/doc.go
@@ -1,0 +1,28 @@
+// Package main is the entry point for the HotPlex Worker Gateway.
+//
+//	@title          HotPlex API
+//	@version        1.24.4
+//	@description    HotPlex Worker Gateway — unified access layer for AI Coding Agent sessions.
+//	@contact.name   HotPlex
+//	@contact.url    https://github.com/hrygo/hotplex/issues
+//	@license.name   MIT
+//	@license.url    https://github.com/hrygo/hotplex/blob/main/LICENSE
+//
+//	@host     localhost:8888
+//	@BasePath /
+//
+//	@tag.name         Gateway API
+//	@tag.description  Session management for end users (port 8888, header: X-Api-Key)
+//	@tag.name         Admin API
+//	@tag.description  Administrative endpoints (port 9999, header: Authorization Bearer <token>)
+//
+//	@securityDefinitions.apikey ApiKeyAuth
+//	@in                         header
+//	@name                       X-Api-Key
+//	@description                API key for Gateway endpoints (port 8888)
+//
+//	@securityDefinitions.apikey AdminBearerAuth
+//	@in                         header
+//	@name                       Authorization
+//	@description                Bearer token for Admin endpoints (port 9999). Format: "Bearer <token>"
+package main

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,20 +90,21 @@ HotPlex 是一个 AI Coding Agent 统一管理平台。通过飞书、Slack 或 
 
 权威、完整的技术细节。
 
-| 参考                                               | 说明                                |
-| -------------------------------------------------- | ----------------------------------- |
-| [CLI 命令参考](reference/cli.md)                   | 全部 38 个 CLI 子命令和参数         |
-| [配置参考](reference/configuration.md)             | 全部 14 个配置段的字段级文档        |
-| [Admin API 参考](reference/admin-api.md)           | 管理端点、Scope 权限、请求/响应格式 |
-| [AEP 协议参考](reference/aep-protocol.md)          | Agent Exchange Protocol v1 完整规范 |
-| [事件参考](reference/events.md)                    | 全部 AEP 事件类型和数据结构         |
-| [安全策略参考](reference/security-policies.md)     | API Key、Bot ID、SSRF、命令白名单、工具控制     |
-| [Metrics 参考](reference/metrics.md)               | Prometheus 指标、scrape 配置        |
-| [术语表](reference/glossary.md)                    | HotPlex 核心术语解释                |
-| [Go SDK 参考](reference/sdk-go.md)                 | Go 客户端 SDK API 文档              |
-| [TypeScript SDK 参考](reference/sdk-typescript.md) | TypeScript SDK API 文档             |
-| [Python SDK 参考](reference/sdk-python.md)         | Python SDK API 文档                 |
-| [Java SDK 参考](reference/sdk-java.md)             | Java SDK API 文档                   |
+| 参考                                               | 说明                                         |
+| -------------------------------------------------- | -------------------------------------------- |
+| [CLI 命令参考](reference/cli.md)                   | 全部 38 个 CLI 子命令和参数                  |
+| [配置参考](reference/configuration.md)             | 全部 14 个配置段的字段级文档                 |
+| [Admin API 参考](reference/admin-api.md)           | 管理端点、Scope 权限、请求/响应格式          |
+| [API 控制台](reference/api-console.html)           | 交互式 Scalar 控制台，可在线测试所有端点     |
+| [AEP 协议参考](reference/aep-protocol.md)          | Agent Exchange Protocol v1 完整规范          |
+| [事件参考](reference/events.md)                    | 全部 AEP 事件类型和数据结构                  |
+| [安全策略参考](reference/security-policies.md)     | API Key、Bot ID、SSRF、命令白名单、工具控制  |
+| [Metrics 参考](reference/metrics.md)               | Prometheus 指标、scrape 配置                 |
+| [术语表](reference/glossary.md)                    | HotPlex 核心术语解释                         |
+| [Go SDK 参考](reference/sdk-go.md)                 | Go 客户端 SDK API 文档                       |
+| [TypeScript SDK 参考](reference/sdk-typescript.md) | TypeScript SDK API 文档                      |
+| [Python SDK 参考](reference/sdk-python.md)         | Python SDK API 文档                          |
+| [Java SDK 参考](reference/sdk-java.md)             | Java SDK API 文档                            |
 
 ## 概念解释
 

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -8,6 +8,9 @@ description: HotPlex Gateway 管理 API 完整参考：Session 管理、Cron 任
 
 HotPlex Admin API 提供网关运维管理能力：会话管理、健康检查、监控指标、配置审计、日志查询和定时任务控制。默认监听 `localhost:9999`，独立于网关主端口（`8888`）。
 
+> **交互式 API 控制台**：可直接在浏览器中浏览和测试所有端点 → [打开 API 控制台](api-console.html)
+> （基于 OpenAPI 规范自动生成，与代码保持同步）
+
 ## 认证
 
 所有 Admin 端点（`/admin/health` 和 `/admin/health/ready` 除外）均需 Bearer Token 认证。Token 通过以下两种方式传递：

--- a/docs/reference/api-console.html
+++ b/docs/reference/api-console.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <title>HotPlex API Console</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body { margin: 0; padding: 0; }
+    </style>
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="/docs/swagger/swagger.json"
+      src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.26.0/dist/browser/standalone.min.js"
+    ></script>
+    <script>
+      // Configure multiple servers since Admin API (port 9999) and Gateway API (port 8888)
+      // run on different ports. Scalar will show a server selector in the UI.
+      document.getElementById('api-reference').dataset.configuration = JSON.stringify({
+        servers: [
+          { url: window.location.protocol + '//' + window.location.hostname + ':8888', description: 'Gateway API (port 8888)' },
+          { url: window.location.protocol + '//' + window.location.hostname + ':9999', description: 'Admin API (port 9999)' }
+        ],
+        theme: 'default'
+      });
+    </script>
+  </body>
+</html>

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1,0 +1,2907 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "HotPlex Worker Gateway — unified access layer for AI Coding Agent sessions.",
+        "title": "HotPlex API",
+        "contact": {
+            "name": "HotPlex",
+            "url": "https://github.com/hrygo/hotplex/issues"
+        },
+        "license": {
+            "name": "MIT",
+            "url": "https://github.com/hrygo/hotplex/blob/main/LICENSE"
+        },
+        "version": "1.24.4"
+    },
+    "host": "localhost:8888",
+    "basePath": "/",
+    "paths": {
+        "/admin/api-keys": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns all API key user records. API keys are masked in the response. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "List API key users",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/admin.APIKeyUser"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Creates a new API key user. If api_key is omitted, one is auto-generated. Returns the full API key only on creation. Requires admin:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Create API key user",
+                "parameters": [
+                    {
+                        "description": "API key user to create",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.CreateAPIKeyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/admin.APIKeyUser"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON or validation failed",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Create failed",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/api-keys/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns a single API key user by ID. API key is masked. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get API key user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "API key user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.APIKeyUser"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Permanently deletes an API key user and revokes the associated API key. Requires admin:write scope.",
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Delete API key user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "API key user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Deleted"
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Updates the user_id and description of an existing API key user. The api_key itself is immutable. Requires admin:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Update API key user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "API key user ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.CreateAPIKeyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.APIKeyUser"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON or validation failed",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/bots": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns all registered bots and their current connection status. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "List bots",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/admin.BotEntry"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Registers a new bot with the specified platform configuration. Requires admin:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Create bot",
+                "parameters": [
+                    {
+                        "description": "Bot creation request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.CreateBotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Bot created"
+                    },
+                    "400": {
+                        "description": "Invalid JSON or missing bot name",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/bots/config": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns full configuration for all registered bots. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "List bot configs",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/admin.BotConfigEntry"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/bots/{name}": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns details for a single registered bot. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get bot",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bot name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.BotEntry"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Bot not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Removes a bot registration by name. Returns 409 if the bot is currently running. Requires admin:write scope.",
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Delete bot",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bot name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Bot deleted"
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Bot not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Bot is currently running",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Partially updates an existing bot's configuration attributes. Requires admin:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Update bot config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bot name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Config fields to update",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.BotConfigAttrs"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Config updated"
+                    },
+                    "400": {
+                        "description": "Invalid JSON or update failed",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/bots/{name}/config": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns the full configuration including agent config summary for a single bot. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get bot config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bot name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.BotConfigEntry"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Bot not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/bots/{name}/config/{file}": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns the content of a single agent config file (SOUL.md, AGENTS.md, SKILLS.md, USER.md, MEMORY.md). Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get agent config file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bot name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "SOUL.md",
+                            "AGENTS.md",
+                            "SKILLS.md",
+                            "USER.md",
+                            "MEMORY.md"
+                        ],
+                        "type": "string",
+                        "description": "Config file name",
+                        "name": "file",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.AgentConfigFile"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid config file name",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "File not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Writes content to a single agent config file (SOUL.md, AGENTS.md, SKILLS.md, USER.md, MEMORY.md). Requires admin:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Write agent config file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bot name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "SOUL.md",
+                            "AGENTS.md",
+                            "SKILLS.md",
+                            "USER.md",
+                            "MEMORY.md"
+                        ],
+                        "type": "string",
+                        "description": "Config file name",
+                        "name": "file",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "File content",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.WriteAgentConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "File written"
+                    },
+                    "400": {
+                        "description": "Invalid config file or write failed",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/bots/{name}/preview": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns the fully assembled system prompt for a bot, combining all agent config files. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Preview system prompt",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bot name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.SystemPromptPreviewResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Bot not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/config/rollback": {
+            "post": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Reverts the live configuration to a specified history version. Requires config:read scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Rollback config",
+                "parameters": [
+                    {
+                        "description": "Version to roll back to",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.RollbackRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.RollbackResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid version or rollback failed",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need config:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Config rollback not available",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/config/validate": {
+            "post": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Validates a partial configuration object and returns any errors or warnings. Requires config:read scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Validate config",
+                "parameters": [
+                    {
+                        "description": "Partial configuration to validate",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.ConfigValidateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ConfigValidateResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Validation failed",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ConfigValidateResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need config:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/cron/jobs": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns all configured cron jobs. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "List cron jobs",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Creates a new scheduled cron job. Requires admin:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Create cron job",
+                "parameters": [
+                    {
+                        "description": "Cron job definition",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Job created"
+                    },
+                    "400": {
+                        "description": "Invalid JSON",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/cron/jobs/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns details for a single cron job by ID. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get cron job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cron job ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Job not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Permanently deletes a cron job. Requires admin:write scope.",
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Delete cron job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cron job ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Job deleted"
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Job not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Partially updates an existing cron job. Requires admin:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Update cron job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cron job ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Job updated"
+                    },
+                    "400": {
+                        "description": "Invalid JSON",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Job not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/cron/jobs/{id}/run": {
+            "post": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Manually triggers an immediate run of a cron job. Requires admin:write scope.",
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Trigger cron job",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cron job ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Job triggered"
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Job not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/cron/jobs/{id}/runs": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns the execution history for a cron job. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get cron job run history",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cron job ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Job not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/debug/sessions/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns session details plus debug snapshot including worker state and turn count. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Debug session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.DebugSessionResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/health": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns health status for gateway, database, and workers. Requires health:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get gateway health",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.HealthResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need health:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/health/workers": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns health status for each connected worker. Returns 503 if any worker is unhealthy.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get worker health",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.WorkerHealthResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need health:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "One or more workers are unhealthy",
+                        "schema": {
+                            "$ref": "#/definitions/admin.WorkerHealthResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/logs": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns the most recent log entries from the in-memory ring buffer. Requires admin:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get recent logs",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 100,
+                        "description": "Max entries to return (1-1000)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.LogsResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/restart": {
+            "post": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Triggers a graceful gateway restart via the restart helper. Requires admin:write scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Restart gateway",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.RestartResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need admin:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Restart not configured",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/sessions": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Lists all sessions, optionally filtered by user_id and platform. Requires session:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "List sessions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by user ID",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by platform (webchat/slack/feishu)",
+                        "name": "platform",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 100,
+                        "description": "Max results",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.SessionListResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need session:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to list sessions",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Creates a new AI agent session. Requires session:write scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Create session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Custom session ID (auto-generated if omitted)",
+                        "name": "session_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "anonymous",
+                        "description": "User identity",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "claudecode",
+                        "description": "Worker type",
+                        "name": "worker_type",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.CreateSessionResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need session:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to create session",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/sessions/pool": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns total, max, and per-user session pool counts. Requires stats:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get pool stats",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.PoolStatsResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need stats:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/sessions/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns full session details by ID. Requires session:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need session:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Permanently deletes a session. Requires session:delete scope.",
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Delete session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Session deleted"
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need session:delete",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to delete session",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/sessions/{id}/stats": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns turn count and token usage statistics for a session. Requires session:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get session stats",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need session:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Turn stats not available",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/sessions/{id}/terminate": {
+            "post": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Sends termination signal to the session worker (SIGTERM then SIGKILL). Requires session:write scope.",
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Terminate session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Session terminated"
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need session:write",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to terminate session",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/stats": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearerAuth": []
+                    }
+                ],
+                "description": "Returns uptime, active sessions, WebSocket connections, and per-worker-type aggregates.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin API"
+                ],
+                "summary": "Get gateway statistics",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.StatsResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient scope: need stats:read",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Failed to query sessions",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/sessions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns paginated list of sessions for the caller's user identity. Default platform filter is \"webchat\"; pass platform=all to include all platforms.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Gateway API"
+                ],
+                "summary": "List sessions",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 100,
+                        "description": "Maximum results (1-500)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "webchat",
+                        "description": "Platform filter (webchat/slack/feishu/all)",
+                        "name": "platform",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.GatewaySessionListResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Creates a new AI agent session. client_session_id is required and must be unique per user. Uses UUIDv5 derivation for idempotency.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Gateway API"
+                ],
+                "summary": "Create session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Client-provided session identifier (max 128 chars)",
+                        "name": "client_session_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Human-readable session title",
+                        "name": "title",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "claudecode",
+                        "description": "Worker type",
+                        "name": "worker_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Working directory",
+                        "name": "work_dir",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.GatewayCreateSessionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Missing or invalid client_session_id",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to create session",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/sessions/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns full session details. Ownership check: caller must own the session.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Gateway API"
+                ],
+                "summary": "Get session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Ownership required",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Gracefully terminates the worker and physically deletes the session. Ownership check applies.",
+                "tags": [
+                    "Gateway API"
+                ],
+                "summary": "Delete session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Session deleted"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Ownership required",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to delete session",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/sessions/{id}/cd": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Changes the working directory for an active session. Creates a new derived session ID. Ownership check applies.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Gateway API"
+                ],
+                "summary": "Switch working directory",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New working directory",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.SwitchWorkDirRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.SwitchWorkDirResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid body or path",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Ownership required",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Session not active",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/sessions/{id}/events": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns paginated AEP events for a session. Use cursor and direction for navigation. Ownership check applies.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Gateway API"
+                ],
+                "summary": "Get session events",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 200,
+                        "description": "Max events (1-1000)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Cursor sequence number",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "latest",
+                        "description": "Cursor direction (after/before/latest)",
+                        "name": "direction",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.EventsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Ownership required",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to get events",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/sessions/{id}/history": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns paginated turn records for a session. Use before_id for cursor-based pagination. Ownership check applies.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Gateway API"
+                ],
+                "summary": "Get session history",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Max records (1-200)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Return records before this turn ID",
+                        "name": "before_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.HistoryResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Ownership required",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to get history",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "admin.APIKeyUser": {
+            "type": "object",
+            "properties": {
+                "api_key": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.AgentConfigFile": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.AgentConfigMeta": {
+            "type": "object",
+            "properties": {
+                "size": {
+                    "type": "integer"
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.AgentConfigSummary": {
+            "type": "object",
+            "properties": {
+                "agents": {
+                    "$ref": "#/definitions/admin.AgentConfigMeta"
+                },
+                "memory": {
+                    "$ref": "#/definitions/admin.AgentConfigMeta"
+                },
+                "skills": {
+                    "$ref": "#/definitions/admin.AgentConfigMeta"
+                },
+                "soul": {
+                    "$ref": "#/definitions/admin.AgentConfigMeta"
+                },
+                "user": {
+                    "$ref": "#/definitions/admin.AgentConfigMeta"
+                }
+            }
+        },
+        "admin.BotConfigAttrs": {
+            "type": "object",
+            "properties": {
+                "allow_dm_from": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "allow_from": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "allow_group_from": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "app_id": {
+                    "type": "string"
+                },
+                "app_secret": {
+                    "type": "string"
+                },
+                "app_token": {
+                    "type": "string"
+                },
+                "bot_token": {
+                    "description": "Credentials — only used during creation; never returned in GET responses.",
+                    "type": "string"
+                },
+                "dm_policy": {
+                    "type": "string"
+                },
+                "group_policy": {
+                    "type": "string"
+                },
+                "platform": {
+                    "type": "string"
+                },
+                "require_mention": {
+                    "type": "boolean"
+                },
+                "stt": {
+                    "$ref": "#/definitions/admin.STTAttrs"
+                },
+                "tts": {
+                    "$ref": "#/definitions/admin.TTSAttrs"
+                },
+                "work_dir": {
+                    "type": "string"
+                },
+                "worker_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.BotConfigEntry": {
+            "type": "object",
+            "properties": {
+                "agent_configs": {
+                    "$ref": "#/definitions/admin.AgentConfigSummary"
+                },
+                "bot_id": {
+                    "type": "string"
+                },
+                "config": {
+                    "$ref": "#/definitions/admin.BotConfigAttrs"
+                },
+                "connected_at": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "platform": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.BotEntry": {
+            "type": "object",
+            "properties": {
+                "bot_id": {
+                    "type": "string"
+                },
+                "connected_at": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "platform": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "worker_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.ConfigValidateDB": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.ConfigValidateGateway": {
+            "type": "object",
+            "properties": {
+                "addr": {
+                    "type": "string"
+                },
+                "broadcast_queue_size": {
+                    "type": "integer"
+                },
+                "read_buffer_size": {
+                    "type": "integer"
+                },
+                "write_buffer_size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "admin.ConfigValidatePool": {
+            "type": "object",
+            "properties": {
+                "max_size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "admin.ConfigValidateRequest": {
+            "type": "object",
+            "properties": {
+                "db": {
+                    "$ref": "#/definitions/admin.ConfigValidateDB"
+                },
+                "gateway": {
+                    "$ref": "#/definitions/admin.ConfigValidateGateway"
+                },
+                "pool": {
+                    "$ref": "#/definitions/admin.ConfigValidatePool"
+                },
+                "security": {
+                    "$ref": "#/definitions/admin.ConfigValidateSecurity"
+                },
+                "session": {
+                    "$ref": "#/definitions/admin.ConfigValidateSession"
+                },
+                "worker": {
+                    "$ref": "#/definitions/admin.ConfigValidateWorker"
+                }
+            }
+        },
+        "admin.ConfigValidateResponse": {
+            "type": "object",
+            "properties": {
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "valid": {
+                    "type": "boolean"
+                },
+                "warnings": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "admin.ConfigValidateSecurity": {
+            "type": "object",
+            "properties": {
+                "tls_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "admin.ConfigValidateSession": {
+            "type": "object",
+            "properties": {
+                "gc_scan_interval": {
+                    "type": "string"
+                },
+                "retention_period": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.ConfigValidateWorker": {
+            "type": "object",
+            "properties": {
+                "execution_timeout": {
+                    "type": "string"
+                },
+                "idle_timeout": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.CreateAPIKeyRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "CI bot token"
+                },
+                "user_id": {
+                    "type": "string",
+                    "example": "alice"
+                }
+            }
+        },
+        "admin.CreateBotRequest": {
+            "type": "object",
+            "properties": {
+                "allow_dm_from": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "allow_from": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "allow_group_from": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "app_id": {
+                    "type": "string"
+                },
+                "app_secret": {
+                    "type": "string"
+                },
+                "app_token": {
+                    "type": "string"
+                },
+                "bot_token": {
+                    "description": "Credentials — only used during creation; never returned in GET responses.",
+                    "type": "string"
+                },
+                "dm_policy": {
+                    "type": "string"
+                },
+                "group_policy": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "my-bot"
+                },
+                "platform": {
+                    "type": "string"
+                },
+                "require_mention": {
+                    "type": "boolean"
+                },
+                "stt": {
+                    "$ref": "#/definitions/admin.STTAttrs"
+                },
+                "tts": {
+                    "$ref": "#/definitions/admin.TTSAttrs"
+                },
+                "work_dir": {
+                    "type": "string"
+                },
+                "worker_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.CreateSessionResponse": {
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                }
+            }
+        },
+        "admin.DatabaseStatsDetail": {
+            "type": "object",
+            "properties": {
+                "db_size_mb": {
+                    "type": "integer"
+                },
+                "sessions_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "admin.DebugInfo": {
+            "type": "object",
+            "properties": {
+                "available": {
+                    "type": "boolean"
+                },
+                "has_worker": {
+                    "type": "boolean"
+                },
+                "last_seq_sent": {},
+                "turn_count": {
+                    "type": "integer"
+                },
+                "worker_health": {}
+            }
+        },
+        "admin.DebugSessionResponse": {
+            "type": "object",
+            "properties": {
+                "debug": {
+                    "$ref": "#/definitions/admin.DebugInfo"
+                },
+                "session": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            }
+        },
+        "admin.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "example": "not found"
+                }
+            }
+        },
+        "admin.EventsResponse": {
+            "type": "object",
+            "properties": {
+                "events": {
+                    "type": "array",
+                    "items": {}
+                },
+                "has_older": {
+                    "type": "boolean"
+                },
+                "newest_seq": {
+                    "type": "integer"
+                },
+                "oldest_seq": {
+                    "type": "integer"
+                }
+            }
+        },
+        "admin.GatewayCreateSessionResponse": {
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                }
+            }
+        },
+        "admin.GatewaySessionListResponse": {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "example": 100
+                },
+                "offset": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "platform": {
+                    "type": "string",
+                    "example": "webchat"
+                },
+                "sessions": {
+                    "type": "array",
+                    "items": {}
+                }
+            }
+        },
+        "admin.GatewayStatsDetail": {
+            "type": "object",
+            "properties": {
+                "sessions_active": {
+                    "type": "integer"
+                },
+                "sessions_total": {
+                    "type": "integer"
+                },
+                "uptime_seconds": {
+                    "type": "integer"
+                },
+                "websocket_connections": {
+                    "type": "integer"
+                }
+            }
+        },
+        "admin.HealthResponse": {
+            "type": "object",
+            "properties": {
+                "checks": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "status": {
+                    "type": "string",
+                    "example": "healthy"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.HistoryResponse": {
+            "type": "object",
+            "properties": {
+                "has_more": {
+                    "type": "boolean"
+                },
+                "records": {
+                    "type": "array",
+                    "items": {}
+                }
+            }
+        },
+        "admin.LogEntry": {
+            "type": "object",
+            "properties": {
+                "level": {
+                    "type": "string"
+                },
+                "msg": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "time": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.LogsResponse": {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "example": 100
+                },
+                "logs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/admin.LogEntry"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "admin.PoolStatsResponse": {
+            "type": "object",
+            "properties": {
+                "max": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "users": {
+                    "type": "integer"
+                }
+            }
+        },
+        "admin.RestartResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "example": "restarting"
+                }
+            }
+        },
+        "admin.RollbackRequest": {
+            "type": "object",
+            "properties": {
+                "version": {
+                    "type": "integer",
+                    "example": 3
+                }
+            }
+        },
+        "admin.RollbackResponse": {
+            "type": "object",
+            "properties": {
+                "history_index": {
+                    "type": "integer"
+                },
+                "ok": {
+                    "type": "boolean"
+                },
+                "rolled_back": {
+                    "type": "integer"
+                }
+            }
+        },
+        "admin.STTAttrs": {
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.SessionListResponse": {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "example": 100
+                },
+                "offset": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "sessions": {
+                    "type": "array",
+                    "items": {}
+                }
+            }
+        },
+        "admin.StatsResponse": {
+            "type": "object",
+            "properties": {
+                "database": {
+                    "$ref": "#/definitions/admin.DatabaseStatsDetail"
+                },
+                "gateway": {
+                    "$ref": "#/definitions/admin.GatewayStatsDetail"
+                },
+                "workers": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            }
+        },
+        "admin.SwitchWorkDirRequest": {
+            "type": "object",
+            "properties": {
+                "work_dir": {
+                    "type": "string",
+                    "example": "/home/user/project"
+                }
+            }
+        },
+        "admin.SwitchWorkDirResponse": {
+            "type": "object",
+            "properties": {
+                "new_session_id": {
+                    "type": "string"
+                },
+                "old_session_id": {
+                    "type": "string"
+                },
+                "work_dir": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.SystemPromptPreviewResponse": {
+            "type": "object",
+            "properties": {
+                "preview": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.TTSAttrs": {
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string"
+                },
+                "voice": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.WorkerHealthResponse": {
+            "type": "object",
+            "properties": {
+                "checked_at": {
+                    "type": "string",
+                    "example": "2024-01-01T00:00:00Z"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "ok"
+                },
+                "workers": {
+                    "type": "array",
+                    "items": {}
+                }
+            }
+        },
+        "admin.WriteAgentConfigRequest": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "You are a helpful assistant."
+                }
+            }
+        }
+    },
+    "securityDefinitions": {
+        "AdminBearerAuth": {
+            "description": "Bearer token for Admin endpoints (port 9999). Format: \"Bearer \u003ctoken\u003e\"",
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
+        },
+        "ApiKeyAuth": {
+            "description": "API key for Gateway endpoints (port 8888)",
+            "type": "apiKey",
+            "name": "X-Api-Key",
+            "in": "header"
+        }
+    },
+    "tags": [
+        {
+            "description": "Session management for end users (port 8888, header: X-Api-Key)",
+            "name": "Gateway API"
+        },
+        {
+            "description": "Administrative endpoints (port 9999, header: Authorization Bearer \u003ctoken\u003e)",
+            "name": "Admin API"
+        }
+    ]
+}

--- a/internal/admin/apikey_handlers.go
+++ b/internal/admin/apikey_handlers.go
@@ -177,6 +177,17 @@ func (s *apiKeyUserStore) delete(ctx context.Context, id int64) error {
 	})
 }
 
+// HandleAPIKeyUserList returns all API key users.
+//
+// @Summary      List API key users
+// @Description  Returns all API key user records. API keys are masked in the response. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Success      200  {array}   APIKeyUser
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Failure      500  {object}  ErrorResponse  "Internal error"
+// @Router       /admin/api-keys [get]
 func (a *AdminAPI) HandleAPIKeyUserList(w http.ResponseWriter, r *http.Request) {
 	if a.akStore == nil {
 		respondJSON(w, []APIKeyUser{})
@@ -197,6 +208,20 @@ func (a *AdminAPI) HandleAPIKeyUserList(w http.ResponseWriter, r *http.Request) 
 	respondJSON(w, users)
 }
 
+// HandleAPIKeyUserCreate creates a new API key user.
+//
+// @Summary      Create API key user
+// @Description  Creates a new API key user. If api_key is omitted, one is auto-generated. Returns the full API key only on creation. Requires admin:write scope.
+// @Tags         Admin API
+// @Accept       json
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        body  body      CreateAPIKeyRequest  true  "API key user to create"
+// @Success      201   {object}  APIKeyUser
+// @Failure      400   {object}  ErrorResponse  "Invalid JSON or validation failed"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Failure      500   {object}  ErrorResponse  "Create failed"
+// @Router       /admin/api-keys [post]
 func (a *AdminAPI) HandleAPIKeyUserCreate(w http.ResponseWriter, r *http.Request) {
 	if a.akStore == nil {
 		http.Error(w, "database resolver not enabled", http.StatusNotImplemented)
@@ -230,6 +255,19 @@ func (a *AdminAPI) HandleAPIKeyUserCreate(w http.ResponseWriter, r *http.Request
 	respondJSON(w, u)
 }
 
+// HandleAPIKeyUserGet returns a single API key user.
+//
+// @Summary      Get API key user
+// @Description  Returns a single API key user by ID. API key is masked. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        id   path      int  true  "API key user ID"
+// @Success      200  {object}  APIKeyUser
+// @Failure      400  {object}  ErrorResponse  "Invalid ID"
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Failure      404  {object}  ErrorResponse  "Not found"
+// @Router       /admin/api-keys/{id} [get]
 func (a *AdminAPI) HandleAPIKeyUserGet(w http.ResponseWriter, r *http.Request) {
 	if a.akStore == nil {
 		http.Error(w, "database resolver not enabled", http.StatusNotImplemented)
@@ -250,6 +288,21 @@ func (a *AdminAPI) HandleAPIKeyUserGet(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, u)
 }
 
+// HandleAPIKeyUserUpdate updates an existing API key user.
+//
+// @Summary      Update API key user
+// @Description  Updates the user_id and description of an existing API key user. The api_key itself is immutable. Requires admin:write scope.
+// @Tags         Admin API
+// @Accept       json
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        id    path      int              true  "API key user ID"
+// @Param        body  body      CreateAPIKeyRequest  true  "Fields to update"
+// @Success      200   {object}  APIKeyUser
+// @Failure      400   {object}  ErrorResponse  "Invalid JSON or validation failed"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Failure      404   {object}  ErrorResponse  "Not found"
+// @Router       /admin/api-keys/{id} [patch]
 func (a *AdminAPI) HandleAPIKeyUserUpdate(w http.ResponseWriter, r *http.Request) {
 	if a.akStore == nil {
 		http.Error(w, "database resolver not enabled", http.StatusNotImplemented)
@@ -292,6 +345,18 @@ func (a *AdminAPI) HandleAPIKeyUserUpdate(w http.ResponseWriter, r *http.Request
 	respondJSON(w, APIKeyUser{ID: id, APIKey: maskAPIKey(oldUser.APIKey), UserID: u.UserID, Description: u.Description})
 }
 
+// HandleAPIKeyUserDelete deletes an API key user.
+//
+// @Summary      Delete API key user
+// @Description  Permanently deletes an API key user and revokes the associated API key. Requires admin:write scope.
+// @Tags         Admin API
+// @Security     AdminBearerAuth
+// @Param        id   path  int  true  "API key user ID"
+// @Success      204  "Deleted"
+// @Failure      400  {object}  ErrorResponse  "Invalid ID"
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Failure      404  {object}  ErrorResponse  "Not found"
+// @Router       /admin/api-keys/{id} [delete]
 func (a *AdminAPI) HandleAPIKeyUserDelete(w http.ResponseWriter, r *http.Request) {
 	if a.akStore == nil {
 		http.Error(w, "database resolver not enabled", http.StatusNotImplemented)

--- a/internal/admin/bot_config_handlers.go
+++ b/internal/admin/bot_config_handlers.go
@@ -9,6 +9,16 @@ import (
 )
 
 // HandleListBotConfigs returns all registered bot configurations.
+//
+// @Summary      List bot configs
+// @Description  Returns full configuration for all registered bots. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Success      200  {array}   BotConfigEntry
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Failure      500  {object}  ErrorResponse  "Internal error"
+// @Router       /admin/bots/config [get]
 // GET /admin/bots/config
 func (a *AdminAPI) HandleListBotConfigs(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminRead) {
@@ -27,6 +37,17 @@ func (a *AdminAPI) HandleListBotConfigs(w http.ResponseWriter, r *http.Request) 
 }
 
 // HandleGetBotConfig returns the full configuration for a single bot.
+//
+// @Summary      Get bot config
+// @Description  Returns the full configuration including agent config summary for a single bot. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        name  path      string  true  "Bot name"
+// @Success      200   {object}  BotConfigEntry
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Failure      404   {object}  ErrorResponse  "Bot not found"
+// @Router       /admin/bots/{name}/config [get]
 // GET /admin/bots/{name}/config
 func (a *AdminAPI) HandleGetBotConfig(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminRead) {
@@ -50,6 +71,19 @@ func (a *AdminAPI) HandleGetBotConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleGetAgentConfigFile reads a single agent config file for a bot.
+//
+// @Summary      Get agent config file
+// @Description  Returns the content of a single agent config file (SOUL.md, AGENTS.md, SKILLS.md, USER.md, MEMORY.md). Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        name  path      string  true  "Bot name"
+// @Param        file  path      string  true  "Config file name"  Enums(SOUL.md,AGENTS.md,SKILLS.md,USER.md,MEMORY.md)
+// @Success      200   {object}  AgentConfigFile
+// @Failure      400   {object}  ErrorResponse  "Invalid config file name"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Failure      404   {object}  ErrorResponse  "File not found"
+// @Router       /admin/bots/{name}/config/{file} [get]
 // GET /admin/bots/{name}/config/{file}
 func (a *AdminAPI) HandleGetAgentConfigFile(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminRead) {
@@ -79,6 +113,17 @@ func (a *AdminAPI) HandleGetAgentConfigFile(w http.ResponseWriter, r *http.Reque
 }
 
 // HandleSystemPromptPreview returns the assembled system prompt for a bot.
+//
+// @Summary      Preview system prompt
+// @Description  Returns the fully assembled system prompt for a bot, combining all agent config files. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        name  path      string  true  "Bot name"
+// @Success      200   {object}  SystemPromptPreviewResponse
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Failure      404   {object}  ErrorResponse  "Bot not found"
+// @Router       /admin/bots/{name}/preview [get]
 // GET /admin/bots/{name}/preview
 func (a *AdminAPI) HandleSystemPromptPreview(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminRead) {
@@ -102,6 +147,18 @@ func (a *AdminAPI) HandleSystemPromptPreview(w http.ResponseWriter, r *http.Requ
 }
 
 // HandleUpdateBotConfig applies partial updates to an existing bot configuration.
+//
+// @Summary      Update bot config
+// @Description  Partially updates an existing bot's configuration attributes. Requires admin:write scope.
+// @Tags         Admin API
+// @Accept       json
+// @Security     AdminBearerAuth
+// @Param        name  path  string          true  "Bot name"
+// @Param        body  body  BotConfigAttrs  true  "Config fields to update"
+// @Success      204   "Config updated"
+// @Failure      400   {object}  ErrorResponse  "Invalid JSON or update failed"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Router       /admin/bots/{name} [patch]
 // PATCH /admin/bots/{name}
 func (a *AdminAPI) HandleUpdateBotConfig(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminWrite) {
@@ -132,6 +189,17 @@ func (a *AdminAPI) HandleUpdateBotConfig(w http.ResponseWriter, r *http.Request)
 }
 
 // HandleCreateBot registers a new bot.
+//
+// @Summary      Create bot
+// @Description  Registers a new bot with the specified platform configuration. Requires admin:write scope.
+// @Tags         Admin API
+// @Accept       json
+// @Security     AdminBearerAuth
+// @Param        body  body  CreateBotRequest  true  "Bot creation request"
+// @Success      201   "Bot created"
+// @Failure      400   {object}  ErrorResponse  "Invalid JSON or missing bot name"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Router       /admin/bots [post]
 // POST /admin/bots
 func (a *AdminAPI) HandleCreateBot(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminWrite) {
@@ -162,6 +230,17 @@ func (a *AdminAPI) HandleCreateBot(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleDeleteBot removes a bot registration.
+//
+// @Summary      Delete bot
+// @Description  Removes a bot registration by name. Returns 409 if the bot is currently running. Requires admin:write scope.
+// @Tags         Admin API
+// @Security     AdminBearerAuth
+// @Param        name  path  string  true  "Bot name"
+// @Success      204   "Bot deleted"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Failure      404   {object}  ErrorResponse  "Bot not found"
+// @Failure      409   {object}  ErrorResponse  "Bot is currently running"
+// @Router       /admin/bots/{name} [delete]
 // DELETE /admin/bots/{name}
 func (a *AdminAPI) HandleDeleteBot(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminWrite) {
@@ -190,6 +269,19 @@ func (a *AdminAPI) HandleDeleteBot(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleWriteAgentConfigFile writes content to a single agent config file for a bot.
+//
+// @Summary      Write agent config file
+// @Description  Writes content to a single agent config file (SOUL.md, AGENTS.md, SKILLS.md, USER.md, MEMORY.md). Requires admin:write scope.
+// @Tags         Admin API
+// @Accept       json
+// @Security     AdminBearerAuth
+// @Param        name  path  string                 true  "Bot name"
+// @Param        file  path  string                 true  "Config file name"  Enums(SOUL.md,AGENTS.md,SKILLS.md,USER.md,MEMORY.md)
+// @Param        body  body  WriteAgentConfigRequest  true  "File content"
+// @Success      204   "File written"
+// @Failure      400   {object}  ErrorResponse  "Invalid config file or write failed"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Router       /admin/bots/{name}/config/{file} [put]
 // PUT /admin/bots/{name}/config/{file}
 func (a *AdminAPI) HandleWriteAgentConfigFile(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminWrite) {

--- a/internal/admin/bot_handlers.go
+++ b/internal/admin/bot_handlers.go
@@ -21,6 +21,15 @@ type BotEntry struct {
 }
 
 // HandleListBots returns all registered bots.
+//
+// @Summary      List bots
+// @Description  Returns all registered bots and their current connection status. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Success      200  {array}   BotEntry
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Router       /admin/bots [get]
 func (a *AdminAPI) HandleListBots(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminRead) {
 		return
@@ -35,6 +44,17 @@ func (a *AdminAPI) HandleListBots(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleGetBot returns details for a single bot by name.
+//
+// @Summary      Get bot
+// @Description  Returns details for a single registered bot. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        name  path      string  true  "Bot name"
+// @Success      200   {object}  BotEntry
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Failure      404   {object}  ErrorResponse  "Bot not found"
+// @Router       /admin/bots/{name} [get]
 func (a *AdminAPI) HandleGetBot(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminRead) {
 		return

--- a/internal/admin/cron_handlers.go
+++ b/internal/admin/cron_handlers.go
@@ -19,6 +19,16 @@ type CronSchedulerProvider interface {
 }
 
 // HandleCronList returns all cron jobs.
+//
+// @Summary      List cron jobs
+// @Description  Returns all configured cron jobs. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Success      200  {array}   object
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Failure      500  {object}  ErrorResponse  "Internal error"
+// @Router       /admin/cron/jobs [get]
 func (a *AdminAPI) HandleCronList(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminRead) {
 		return
@@ -36,6 +46,17 @@ func (a *AdminAPI) HandleCronList(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleCronGet returns a single cron job.
+//
+// @Summary      Get cron job
+// @Description  Returns details for a single cron job by ID. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        id   path      string  true  "Cron job ID"
+// @Success      200  {object}  object
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Failure      404  {object}  ErrorResponse  "Job not found"
+// @Router       /admin/cron/jobs/{id} [get]
 func (a *AdminAPI) HandleCronGet(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminRead) {
 		return
@@ -54,6 +75,18 @@ func (a *AdminAPI) HandleCronGet(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleCronCreate creates a new cron job.
+//
+// @Summary      Create cron job
+// @Description  Creates a new scheduled cron job. Requires admin:write scope.
+// @Tags         Admin API
+// @Accept       json
+// @Security     AdminBearerAuth
+// @Param        body  body  object  true  "Cron job definition"
+// @Success      201   "Job created"
+// @Failure      400   {object}  ErrorResponse  "Invalid JSON"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Failure      500   {object}  ErrorResponse  "Internal error"
+// @Router       /admin/cron/jobs [post]
 func (a *AdminAPI) HandleCronCreate(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminWrite) {
 		return
@@ -76,6 +109,19 @@ func (a *AdminAPI) HandleCronCreate(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleCronUpdate updates an existing cron job.
+//
+// @Summary      Update cron job
+// @Description  Partially updates an existing cron job. Requires admin:write scope.
+// @Tags         Admin API
+// @Accept       json
+// @Security     AdminBearerAuth
+// @Param        id    path  string  true  "Cron job ID"
+// @Param        body  body  object  true  "Fields to update"
+// @Success      204   "Job updated"
+// @Failure      400   {object}  ErrorResponse  "Invalid JSON"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Failure      404   {object}  ErrorResponse  "Job not found"
+// @Router       /admin/cron/jobs/{id} [patch]
 func (a *AdminAPI) HandleCronUpdate(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminWrite) {
 		return
@@ -99,6 +145,16 @@ func (a *AdminAPI) HandleCronUpdate(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleCronDelete deletes a cron job.
+//
+// @Summary      Delete cron job
+// @Description  Permanently deletes a cron job. Requires admin:write scope.
+// @Tags         Admin API
+// @Security     AdminBearerAuth
+// @Param        id   path  string  true  "Cron job ID"
+// @Success      204  "Job deleted"
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Failure      404  {object}  ErrorResponse  "Job not found"
+// @Router       /admin/cron/jobs/{id} [delete]
 func (a *AdminAPI) HandleCronDelete(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminWrite) {
 		return
@@ -117,6 +173,16 @@ func (a *AdminAPI) HandleCronDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleCronTrigger manually triggers a cron job run.
+//
+// @Summary      Trigger cron job
+// @Description  Manually triggers an immediate run of a cron job. Requires admin:write scope.
+// @Tags         Admin API
+// @Security     AdminBearerAuth
+// @Param        id   path  string  true  "Cron job ID"
+// @Success      202  "Job triggered"
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Failure      404  {object}  ErrorResponse  "Job not found"
+// @Router       /admin/cron/jobs/{id}/run [post]
 func (a *AdminAPI) HandleCronTrigger(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminWrite) {
 		return
@@ -134,7 +200,18 @@ func (a *AdminAPI) HandleCronTrigger(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 }
 
-// HandleCronRunHistory returns the turn history for a cron job's latest run.
+// HandleCronRunHistory returns the run history for a cron job.
+//
+// @Summary      Get cron job run history
+// @Description  Returns the execution history for a cron job. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        id   path      string  true  "Cron job ID"
+// @Success      200  {array}   object
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Failure      404  {object}  ErrorResponse  "Job not found"
+// @Router       /admin/cron/jobs/{id}/runs [get]
 func (a *AdminAPI) HandleCronRunHistory(w http.ResponseWriter, r *http.Request) {
 	if !requireScope(w, r, ScopeAdminRead) {
 		return

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -14,6 +14,17 @@ import (
 	"github.com/hrygo/hotplex/internal/session"
 )
 
+// HandleStats returns gateway runtime statistics.
+//
+// @Summary      Get gateway statistics
+// @Description  Returns uptime, active sessions, WebSocket connections, and per-worker-type aggregates.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Success      200  {object}  StatsResponse
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need stats:read"
+// @Failure      503  {object}  ErrorResponse  "Failed to query sessions"
+// @Router       /admin/stats [get]
 func (a *AdminAPI) HandleStats(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeStatsRead) {
 		http.Error(w, "insufficient scope: need stats:read", http.StatusForbidden)
@@ -60,6 +71,16 @@ func (a *AdminAPI) HandleStats(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// HandleHealth reports the health of all gateway components.
+//
+// @Summary      Get gateway health
+// @Description  Returns health status for gateway, database, and workers. Requires health:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Success      200  {object}  HealthResponse
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need health:read"
+// @Router       /admin/health [get]
 func (a *AdminAPI) HandleHealth(w http.ResponseWriter, r *http.Request) {
 	cfg := a.cfg.Get()
 	dbHealthy := true
@@ -100,6 +121,17 @@ func (a *AdminAPI) HandleHealth(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// HandleWorkerHealth reports per-worker health statuses.
+//
+// @Summary      Get worker health
+// @Description  Returns health status for each connected worker. Returns 503 if any worker is unhealthy.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Success      200  {object}  WorkerHealthResponse
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need health:read"
+// @Failure      503  {object}  WorkerHealthResponse  "One or more workers are unhealthy"
+// @Router       /admin/health/workers [get]
 func (a *AdminAPI) HandleWorkerHealth(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeHealthRead) {
 		http.Error(w, "insufficient scope: need health:read", http.StatusForbidden)
@@ -127,6 +159,17 @@ func (a *AdminAPI) HandleWorkerHealth(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(body)
 }
 
+// HandleLogs returns recent gateway log entries.
+//
+// @Summary      Get recent logs
+// @Description  Returns the most recent log entries from the in-memory ring buffer. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        limit  query    int  false  "Max entries to return (1-1000)"  default(100)
+// @Success      200    {object}  LogsResponse
+// @Failure      403    {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Router       /admin/logs [get]
 func (a *AdminAPI) HandleLogs(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeAdminRead) {
 		http.Error(w, "insufficient scope: need admin:read", http.StatusForbidden)
@@ -149,6 +192,19 @@ func (a *AdminAPI) HandleLogs(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// HandleConfigValidate validates a partial gateway configuration without applying it.
+//
+// @Summary      Validate config
+// @Description  Validates a partial configuration object and returns any errors or warnings. Requires config:read scope.
+// @Tags         Admin API
+// @Accept       json
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        body  body      ConfigValidateRequest  true  "Partial configuration to validate"
+// @Success      200   {object}  ConfigValidateResponse
+// @Failure      400   {object}  ConfigValidateResponse  "Validation failed"
+// @Failure      403   {object}  ErrorResponse           "Insufficient scope: need config:read"
+// @Router       /admin/config/validate [post]
 func (a *AdminAPI) HandleConfigValidate(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeConfigRead) {
 		http.Error(w, "insufficient scope: need config:read", http.StatusForbidden)
@@ -236,6 +292,20 @@ func (a *AdminAPI) HandleConfigValidate(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// HandleConfigRollback rolls back the gateway configuration to a previous version.
+//
+// @Summary      Rollback config
+// @Description  Reverts the live configuration to a specified history version. Requires config:read scope.
+// @Tags         Admin API
+// @Accept       json
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        body  body      RollbackRequest  true  "Version to roll back to"
+// @Success      200   {object}  RollbackResponse
+// @Failure      400   {object}  ErrorResponse  "Invalid version or rollback failed"
+// @Failure      403   {object}  ErrorResponse  "Insufficient scope: need config:read"
+// @Failure      503   {object}  ErrorResponse  "Config rollback not available"
+// @Router       /admin/config/rollback [post]
 func (a *AdminAPI) HandleConfigRollback(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeConfigRead) {
 		http.Error(w, "insufficient scope: need config:read", http.StatusForbidden)
@@ -272,6 +342,18 @@ func (a *AdminAPI) HandleConfigRollback(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// HandleDebugSession returns extended debug information for a session.
+//
+// @Summary      Debug session
+// @Description  Returns session details plus debug snapshot including worker state and turn count. Requires admin:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        id   path      string  true  "Session ID"
+// @Success      200  {object}  DebugSessionResponse
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:read"
+// @Failure      404  {object}  ErrorResponse  "Session not found"
+// @Router       /admin/debug/sessions/{id} [get]
 func (a *AdminAPI) HandleDebugSession(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeAdminRead) {
 		http.Error(w, "insufficient scope: need admin:read", http.StatusForbidden)
@@ -302,6 +384,17 @@ func (a *AdminAPI) HandleDebugSession(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// HandleRestart initiates a graceful gateway restart.
+//
+// @Summary      Restart gateway
+// @Description  Triggers a graceful gateway restart via the restart helper. Requires admin:write scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Success      200  {object}  RestartResponse
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need admin:write"
+// @Failure      503  {object}  ErrorResponse  "Restart not configured"
+// @Router       /admin/restart [post]
 func (a *AdminAPI) HandleRestart(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeAdminWrite) {
 		http.Error(w, "insufficient scope: need admin:write", http.StatusForbidden)

--- a/internal/admin/models.go
+++ b/internal/admin/models.go
@@ -1,0 +1,225 @@
+package admin
+
+// ErrorResponse is the standard error envelope returned by all endpoints.
+type ErrorResponse struct {
+	Error string `json:"error" example:"not found"`
+}
+
+// StatusResponse is returned for simple ok/status operations.
+type StatusResponse struct {
+	Status string `json:"status" example:"ok"`
+}
+
+// SessionListResponse is returned by GET /admin/sessions.
+type SessionListResponse struct {
+	Sessions []any `json:"sessions"`
+	Limit    int   `json:"limit" example:"100"`
+	Offset   int   `json:"offset" example:"0"`
+}
+
+// CreateSessionResponse is returned by POST /admin/sessions.
+type CreateSessionResponse struct {
+	SessionID string `json:"session_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+}
+
+// GatewaySessionListResponse is returned by GET /api/sessions.
+type GatewaySessionListResponse struct {
+	Sessions []any  `json:"sessions"`
+	Limit    int    `json:"limit" example:"100"`
+	Offset   int    `json:"offset" example:"0"`
+	Platform string `json:"platform" example:"webchat"`
+}
+
+// GatewayCreateSessionResponse is returned by POST /api/sessions.
+type GatewayCreateSessionResponse struct {
+	SessionID string `json:"session_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+}
+
+// SwitchWorkDirRequest is the request body for POST /api/sessions/{id}/cd.
+type SwitchWorkDirRequest struct {
+	WorkDir string `json:"work_dir" example:"/home/user/project"`
+}
+
+// SwitchWorkDirResponse is returned by POST /api/sessions/{id}/cd.
+type SwitchWorkDirResponse struct {
+	OldSessionID string `json:"old_session_id"`
+	NewSessionID string `json:"new_session_id"`
+	WorkDir      string `json:"work_dir"`
+}
+
+// HistoryResponse is returned by GET /api/sessions/{id}/history.
+type HistoryResponse struct {
+	Records []any `json:"records"`
+	HasMore bool  `json:"has_more"`
+}
+
+// EventsResponse is returned by GET /api/sessions/{id}/events.
+type EventsResponse struct {
+	Events    []any `json:"events"`
+	OldestSeq int64 `json:"oldest_seq"`
+	NewestSeq int64 `json:"newest_seq"`
+	HasOlder  bool  `json:"has_older"`
+}
+
+// GatewayStatsDetail holds per-component gateway statistics.
+type GatewayStatsDetail struct {
+	UptimeSeconds        int `json:"uptime_seconds"`
+	WebsocketConnections int `json:"websocket_connections"`
+	SessionsActive       int `json:"sessions_active"`
+	SessionsTotal        int `json:"sessions_total"`
+}
+
+// DatabaseStatsDetail holds database statistics.
+type DatabaseStatsDetail struct {
+	SessionsCount int `json:"sessions_count"`
+	DBSizeMB      int `json:"db_size_mb"`
+}
+
+// StatsResponse is returned by GET /admin/stats.
+type StatsResponse struct {
+	Gateway  GatewayStatsDetail     `json:"gateway"`
+	Workers  map[string]interface{} `json:"workers"`
+	Database DatabaseStatsDetail    `json:"database"`
+}
+
+// HealthResponse is returned by GET /admin/health.
+type HealthResponse struct {
+	Status  string                 `json:"status" example:"healthy"`
+	Checks  map[string]interface{} `json:"checks"`
+	Version string                 `json:"version"`
+}
+
+// WorkerHealthResponse is returned by GET /admin/health/workers.
+type WorkerHealthResponse struct {
+	Status    string        `json:"status" example:"ok"`
+	Workers   []interface{} `json:"workers"`
+	CheckedAt string        `json:"checked_at" example:"2024-01-01T00:00:00Z"`
+}
+
+// LogEntry is a single log record returned by GET /admin/logs.
+type LogEntry struct {
+	Time      string `json:"time"`
+	Level     string `json:"level"`
+	Msg       string `json:"msg"`
+	SessionID string `json:"session_id,omitempty"`
+}
+
+// LogsResponse is returned by GET /admin/logs.
+type LogsResponse struct {
+	Logs  []LogEntry `json:"logs"`
+	Total int        `json:"total"`
+	Limit int        `json:"limit" example:"100"`
+}
+
+// PoolStatsResponse is returned by GET /admin/sessions/pool.
+type PoolStatsResponse struct {
+	Total int `json:"total"`
+	Max   int `json:"max"`
+	Users int `json:"users"`
+}
+
+// ConfigValidateRequest is the request body for POST /admin/config/validate.
+type ConfigValidateRequest struct {
+	Gateway  *ConfigValidateGateway  `json:"gateway,omitempty"`
+	DB       *ConfigValidateDB       `json:"db,omitempty"`
+	Worker   *ConfigValidateWorker   `json:"worker,omitempty"`
+	Security *ConfigValidateSecurity `json:"security,omitempty"`
+	Session  *ConfigValidateSession  `json:"session,omitempty"`
+	Pool     *ConfigValidatePool     `json:"pool,omitempty"`
+}
+
+// ConfigValidateGateway holds gateway sub-config for validation.
+type ConfigValidateGateway struct {
+	Addr               string `json:"addr,omitempty"`
+	ReadBufferSize     int    `json:"read_buffer_size,omitempty"`
+	WriteBufferSize    int    `json:"write_buffer_size,omitempty"`
+	BroadcastQueueSize int    `json:"broadcast_queue_size,omitempty"`
+}
+
+// ConfigValidateDB holds DB sub-config for validation.
+type ConfigValidateDB struct {
+	Path string `json:"path,omitempty"`
+}
+
+// ConfigValidateWorker holds worker sub-config for validation.
+type ConfigValidateWorker struct {
+	IdleTimeout      string `json:"idle_timeout,omitempty"`
+	ExecutionTimeout string `json:"execution_timeout,omitempty"`
+}
+
+// ConfigValidateSecurity holds security sub-config for validation.
+type ConfigValidateSecurity struct {
+	TLSEnabled bool `json:"tls_enabled,omitempty"`
+}
+
+// ConfigValidateSession holds session sub-config for validation.
+type ConfigValidateSession struct {
+	RetentionPeriod string `json:"retention_period,omitempty"`
+	GCScanInterval  string `json:"gc_scan_interval,omitempty"`
+}
+
+// ConfigValidatePool holds pool sub-config for validation.
+type ConfigValidatePool struct {
+	MaxSize int `json:"max_size,omitempty"`
+}
+
+// ConfigValidateResponse is returned by POST /admin/config/validate.
+type ConfigValidateResponse struct {
+	Valid    bool     `json:"valid"`
+	Errors   []string `json:"errors"`
+	Warnings []string `json:"warnings"`
+}
+
+// RollbackRequest is the request body for POST /admin/config/rollback.
+type RollbackRequest struct {
+	Version int `json:"version" example:"3"`
+}
+
+// RollbackResponse is returned by POST /admin/config/rollback.
+type RollbackResponse struct {
+	OK           bool `json:"ok"`
+	RolledBack   int  `json:"rolled_back"`
+	HistoryIndex int  `json:"history_index"`
+}
+
+// DebugSessionResponse is returned by GET /admin/debug/sessions/{id}.
+type DebugSessionResponse struct {
+	Session map[string]interface{} `json:"session"`
+	Debug   DebugInfo              `json:"debug"`
+}
+
+// DebugInfo holds debug details for a session.
+type DebugInfo struct {
+	Available    bool        `json:"available"`
+	HasWorker    bool        `json:"has_worker"`
+	TurnCount    int         `json:"turn_count"`
+	LastSeqSent  interface{} `json:"last_seq_sent"`
+	WorkerHealth interface{} `json:"worker_health"`
+}
+
+// RestartResponse is returned by POST /admin/restart.
+type RestartResponse struct {
+	Status string `json:"status" example:"restarting"`
+}
+
+// CreateAPIKeyRequest is the request body for POST /admin/api-keys.
+type CreateAPIKeyRequest struct {
+	UserID      string `json:"user_id" example:"alice"`
+	Description string `json:"description,omitempty" example:"CI bot token"`
+}
+
+// SystemPromptPreviewResponse is returned by GET /admin/bots/{name}/preview.
+type SystemPromptPreviewResponse struct {
+	Preview string `json:"preview"`
+}
+
+// WriteAgentConfigRequest is the request body for PUT /admin/bots/{name}/config/{file}.
+type WriteAgentConfigRequest struct {
+	Content string `json:"content" example:"You are a helpful assistant."`
+}
+
+// CreateBotRequest is the request body for POST /admin/bots.
+type CreateBotRequest struct {
+	Name string `json:"name" example:"my-bot"`
+	BotConfigAttrs
+}

--- a/internal/admin/sessions.go
+++ b/internal/admin/sessions.go
@@ -14,6 +14,20 @@ func addCORSHeaders(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Api-Key")
 }
 
+// CreateSession creates a new session.
+//
+// @Summary      Create session
+// @Description  Creates a new AI agent session. Requires session:write scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        session_id   query    string  false  "Custom session ID (auto-generated if omitted)"
+// @Param        user_id      query    string  false  "User identity"           default(anonymous)
+// @Param        worker_type  query    string  false  "Worker type"             default(claudecode)
+// @Success      200          {object}  CreateSessionResponse
+// @Failure      403          {object}  ErrorResponse  "Insufficient scope: need session:write"
+// @Failure      500          {object}  ErrorResponse  "Failed to create session"
+// @Router       /admin/sessions [post]
 func (a *AdminAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeSessionWrite) {
 		http.Error(w, "insufficient scope: need session:write", http.StatusForbidden)
@@ -45,6 +59,21 @@ func (a *AdminAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, map[string]string{"session_id": id})
 }
 
+// ListSessions returns all sessions visible to the admin.
+//
+// @Summary      List sessions
+// @Description  Lists all sessions, optionally filtered by user_id and platform. Requires session:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        user_id   query    string  false  "Filter by user ID"
+// @Param        platform  query    string  false  "Filter by platform (webchat/slack/feishu)"
+// @Param        limit     query    int     false  "Max results"  default(100)
+// @Param        offset    query    int     false  "Pagination offset"  default(0)
+// @Success      200       {object}  SessionListResponse
+// @Failure      403       {object}  ErrorResponse  "Insufficient scope: need session:read"
+// @Failure      500       {object}  ErrorResponse  "Failed to list sessions"
+// @Router       /admin/sessions [get]
 func (a *AdminAPI) ListSessions(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeSessionRead) {
 		http.Error(w, "insufficient scope: need session:read", http.StatusForbidden)
@@ -80,6 +109,18 @@ func (a *AdminAPI) ListSessions(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// GetSession returns details for a single session.
+//
+// @Summary      Get session
+// @Description  Returns full session details by ID. Requires session:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        id   path      string  true  "Session ID"
+// @Success      200  {object}  object
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need session:read"
+// @Failure      404  {object}  ErrorResponse  "Session not found"
+// @Router       /admin/sessions/{id} [get]
 func (a *AdminAPI) GetSession(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeSessionRead) {
 		http.Error(w, "insufficient scope: need session:read", http.StatusForbidden)
@@ -95,6 +136,17 @@ func (a *AdminAPI) GetSession(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, si)
 }
 
+// DeleteSession deletes a session by ID.
+//
+// @Summary      Delete session
+// @Description  Permanently deletes a session. Requires session:delete scope.
+// @Tags         Admin API
+// @Security     AdminBearerAuth
+// @Param        id   path  string  true  "Session ID"
+// @Success      204  "Session deleted"
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need session:delete"
+// @Failure      500  {object}  ErrorResponse  "Failed to delete session"
+// @Router       /admin/sessions/{id} [delete]
 func (a *AdminAPI) DeleteSession(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeSessionKill) {
 		http.Error(w, "insufficient scope: need session:delete", http.StatusForbidden)
@@ -113,6 +165,17 @@ func (a *AdminAPI) DeleteSession(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// TerminateSession gracefully terminates a session's worker.
+//
+// @Summary      Terminate session
+// @Description  Sends termination signal to the session worker (SIGTERM then SIGKILL). Requires session:write scope.
+// @Tags         Admin API
+// @Security     AdminBearerAuth
+// @Param        id   path  string  true  "Session ID"
+// @Success      204  "Session terminated"
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need session:write"
+// @Failure      500  {object}  ErrorResponse  "Failed to terminate session"
+// @Router       /admin/sessions/{id}/terminate [post]
 func (a *AdminAPI) TerminateSession(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeSessionWrite) {
 		http.Error(w, "insufficient scope: need session:write", http.StatusForbidden)
@@ -131,6 +194,16 @@ func (a *AdminAPI) TerminateSession(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// PoolStats returns session pool statistics.
+//
+// @Summary      Get pool stats
+// @Description  Returns total, max, and per-user session pool counts. Requires stats:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Success      200  {object}  PoolStatsResponse
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need stats:read"
+// @Router       /admin/sessions/pool [get]
 func (a *AdminAPI) PoolStats(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeStatsRead) {
 		http.Error(w, "insufficient scope: need stats:read", http.StatusForbidden)
@@ -144,6 +217,19 @@ func (a *AdminAPI) PoolStats(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// HandleSessionStats returns turn statistics for a session.
+//
+// @Summary      Get session stats
+// @Description  Returns turn count and token usage statistics for a session. Requires session:read scope.
+// @Tags         Admin API
+// @Produce      json
+// @Security     AdminBearerAuth
+// @Param        id   path      string  true  "Session ID"
+// @Success      200  {object}  object
+// @Failure      403  {object}  ErrorResponse  "Insufficient scope: need session:read"
+// @Failure      404  {object}  ErrorResponse  "Session not found"
+// @Failure      503  {object}  ErrorResponse  "Turn stats not available"
+// @Router       /admin/sessions/{id}/stats [get]
 func (a *AdminAPI) HandleSessionStats(w http.ResponseWriter, r *http.Request) {
 	if !hasScope(r, ScopeSessionRead) {
 		http.Error(w, "insufficient scope: need session:read", http.StatusForbidden)

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -80,6 +80,20 @@ func (g *GatewayAPI) authorizeSession(w http.ResponseWriter, r *http.Request) (s
 	return id, si, true
 }
 
+// ListSessions returns sessions belonging to the authenticated user.
+//
+// @Summary      List sessions
+// @Description  Returns paginated list of sessions for the caller's user identity. Default platform filter is "webchat"; pass platform=all to include all platforms.
+// @Tags         Gateway API
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        limit     query    int     false  "Maximum results (1-500)"                                      default(100)
+// @Param        offset    query    int     false  "Pagination offset"                                             default(0)
+// @Param        platform  query    string  false  "Platform filter (webchat/slack/feishu/all)"  default(webchat)
+// @Success      200  {object}  admin.GatewaySessionListResponse
+// @Failure      401  {object}  admin.ErrorResponse  "Unauthorized"
+// @Failure      500  {object}  admin.ErrorResponse  "Internal error"
+// @Router       /api/sessions [get]
 func (g *GatewayAPI) ListSessions(w http.ResponseWriter, r *http.Request) {
 	userID, _, err := g.auth.AuthenticateRequest(r)
 	if err != nil {
@@ -118,6 +132,22 @@ func (g *GatewayAPI) ListSessions(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, map[string]any{"sessions": sessions, "limit": limit, "offset": offset, "platform": platform})
 }
 
+// CreateSession creates a new AI agent session.
+//
+// @Summary      Create session
+// @Description  Creates a new AI agent session. client_session_id is required and must be unique per user. Uses UUIDv5 derivation for idempotency.
+// @Tags         Gateway API
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        client_session_id  query    string  true   "Client-provided session identifier (max 128 chars)"
+// @Param        title              query    string  false  "Human-readable session title"
+// @Param        worker_type        query    string  false  "Worker type"      default(claudecode)
+// @Param        work_dir           query    string  false  "Working directory"
+// @Success      200  {object}  admin.GatewayCreateSessionResponse
+// @Failure      400  {object}  admin.ErrorResponse  "Missing or invalid client_session_id"
+// @Failure      401  {object}  admin.ErrorResponse  "Unauthorized"
+// @Failure      500  {object}  admin.ErrorResponse  "Failed to create session"
+// @Router       /api/sessions [post]
 func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 	userID, botID, err := g.auth.AuthenticateRequest(r)
 	if err != nil {
@@ -195,6 +225,19 @@ func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, map[string]string{"session_id": id})
 }
 
+// GetSession returns details for a single session.
+//
+// @Summary      Get session
+// @Description  Returns full session details. Ownership check: caller must own the session.
+// @Tags         Gateway API
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        id   path      string  true  "Session ID"
+// @Success      200  {object}  object
+// @Failure      401  {object}  admin.ErrorResponse  "Unauthorized"
+// @Failure      403  {object}  admin.ErrorResponse  "Ownership required"
+// @Failure      404  {object}  admin.ErrorResponse  "Session not found"
+// @Router       /api/sessions/{id} [get]
 func (g *GatewayAPI) GetSession(w http.ResponseWriter, r *http.Request) {
 	_, si, ok := g.authorizeSession(w, r)
 	if !ok {
@@ -203,6 +246,19 @@ func (g *GatewayAPI) GetSession(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, si)
 }
 
+// DeleteSession terminates and deletes a session.
+//
+// @Summary      Delete session
+// @Description  Gracefully terminates the worker and physically deletes the session. Ownership check applies.
+// @Tags         Gateway API
+// @Security     ApiKeyAuth
+// @Param        id   path  string  true  "Session ID"
+// @Success      204  "Session deleted"
+// @Failure      401  {object}  admin.ErrorResponse  "Unauthorized"
+// @Failure      403  {object}  admin.ErrorResponse  "Ownership required"
+// @Failure      404  {object}  admin.ErrorResponse  "Session not found"
+// @Failure      500  {object}  admin.ErrorResponse  "Failed to delete session"
+// @Router       /api/sessions/{id} [delete]
 func (g *GatewayAPI) DeleteSession(w http.ResponseWriter, r *http.Request) {
 	id, _, ok := g.authorizeSession(w, r)
 	if !ok {
@@ -223,6 +279,23 @@ func (g *GatewayAPI) DeleteSession(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// SwitchWorkDir changes the working directory for a session.
+//
+// @Summary      Switch working directory
+// @Description  Changes the working directory for an active session. Creates a new derived session ID. Ownership check applies.
+// @Tags         Gateway API
+// @Accept       json
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        id    path      string                     true  "Session ID"
+// @Param        body  body      admin.SwitchWorkDirRequest  true  "New working directory"
+// @Success      200   {object}  admin.SwitchWorkDirResponse
+// @Failure      400   {object}  admin.ErrorResponse  "Invalid body or path"
+// @Failure      401   {object}  admin.ErrorResponse  "Unauthorized"
+// @Failure      403   {object}  admin.ErrorResponse  "Ownership required"
+// @Failure      409   {object}  admin.ErrorResponse  "Session not active"
+// @Failure      500   {object}  admin.ErrorResponse  "Internal error"
+// @Router       /api/sessions/{id}/cd [post]
 func (g *GatewayAPI) SwitchWorkDir(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		WorkDir string `json:"work_dir"`
@@ -280,6 +353,21 @@ func (g *GatewayAPI) SwitchWorkDir(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// GetHistory returns turn history for a session.
+//
+// @Summary      Get session history
+// @Description  Returns paginated turn records for a session. Use before_id for cursor-based pagination. Ownership check applies.
+// @Tags         Gateway API
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        id         path      string  true   "Session ID"
+// @Param        limit      query     int     false  "Max records (1-200)"  default(50)
+// @Param        before_id  query     int     false  "Return records before this turn ID"
+// @Success      200  {object}  admin.HistoryResponse
+// @Failure      401  {object}  admin.ErrorResponse  "Unauthorized"
+// @Failure      403  {object}  admin.ErrorResponse  "Ownership required"
+// @Failure      500  {object}  admin.ErrorResponse  "Failed to get history"
+// @Router       /api/sessions/{id}/history [get]
 func (g *GatewayAPI) GetHistory(w http.ResponseWriter, r *http.Request) {
 	id, _, ok := g.authorizeSession(w, r)
 	if !ok {
@@ -335,6 +423,22 @@ func (g *GatewayAPI) GetHistory(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, map[string]any{"records": records, "has_more": hasMore})
 }
 
+// GetEvents returns AEP events for a session.
+//
+// @Summary      Get session events
+// @Description  Returns paginated AEP events for a session. Use cursor and direction for navigation. Ownership check applies.
+// @Tags         Gateway API
+// @Produce      json
+// @Security     ApiKeyAuth
+// @Param        id         path      string  true   "Session ID"
+// @Param        limit      query     int     false  "Max events (1-1000)"                              default(200)
+// @Param        cursor     query     int     false  "Cursor sequence number"
+// @Param        direction  query     string  false  "Cursor direction (after/before/latest)"  default(latest)
+// @Success      200  {object}  admin.EventsResponse
+// @Failure      401  {object}  admin.ErrorResponse  "Unauthorized"
+// @Failure      403  {object}  admin.ErrorResponse  "Ownership required"
+// @Failure      500  {object}  admin.ErrorResponse  "Failed to get events"
+// @Router       /api/sessions/{id}/events [get]
 func (g *GatewayAPI) GetEvents(w http.ResponseWriter, r *http.Request) {
 	if g.eventStore == nil {
 		respondJSON(w, map[string]any{"events": []any{}, "oldest_seq": 0, "newest_seq": 0, "has_older": false})


### PR DESCRIPTION
## Summary

为 Admin API（42+ 端点）和 Gateway API（7 端点）添加 swaggo 注解，自动生成 OpenAPI 2.0 规范，并提供 Scalar 交互式 API 控制台。CI 新增 `check-swagger` 步骤确保代码注解与规范文件同步。

## Changes

| 类型 | 文件 | 说明 |
|------|------|------|
| 新增 | `cmd/hotplex/doc.go` | 全局 swaggo 注解（title、host、securityDefinitions） |
| 新增 | `internal/admin/models.go` | 30+ 具名响应类型供 swaggo `{object}` schema 引用 |
| 新增 | `docs/reference/api-console.html` | Scalar 控制台，支持 Gateway(8888) + Admin(9999) 双端口 |
| 新增 | `docs/swagger/swagger.json` | 生成的 OpenAPI 规范（30 路径，43 类型定义） |
| 修改 | `internal/admin/handlers.go` 等 7 个 handler | 添加 `@Summary` / `@Router` / `@Security` 注解 |
| 修改 | `Makefile` | 新增 `swagger` / `check-swagger` / `scalar-assets` 目标 |
| 修改 | `cmd/build-docs/main.go` | 构建时复制 swagger.json 到静态资源输出目录 |
| 修改 | `.github/workflows/ci.yml` | 新增 swag 安装 + `make check-swagger` 校验步骤 |
| 修改 | `docs/index.md`, `docs/reference/admin-api.md` | 加入 API 控制台入口链接 |

Closes #632