### PR TITLE
🔒 fix(security): configurable CORS origins, tighten docs CSP, add security.txt

### DIFF
--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -36,32 +36,28 @@ func setupRoutes(
 
 	gatewayAPI := gateway.NewGatewayAPI(log, auth, sm, bridge, deps.ConfigStore, deps.EventStore, deps.EventStore)
 
-	// withCORS wraps a handler to inject CORS headers.
-	withCORS := func(h http.HandlerFunc) http.HandlerFunc {
-		return func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Access-Control-Allow-Origin", "*")
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Api-Key")
-			if r.Method == http.MethodOptions {
-				w.WriteHeader(http.StatusOK)
-				return
-			}
-			h(w, r)
-		}
+	// CORS middleware reads allowed origins from config (supports hot-reload).
+	corsOriginsFn := func() []string {
+		return deps.ConfigStore.Load().Security.AllowedOrigins
+	}
+	corsMw := security.CORSMiddleware(corsOriginsFn)
+
+	if slices.Contains(cfg.Security.AllowedOrigins, "*") {
+		log.Warn("cors: allowed_origins contains '*' — all origins permitted; set security.allowed_origins in production")
 	}
 
-	mux.HandleFunc("GET /api/sessions", withCORS(gatewayAPI.ListSessions))
-	mux.HandleFunc("POST /api/sessions", withCORS(gatewayAPI.CreateSession))
-	mux.HandleFunc("GET /api/sessions/{id}", withCORS(gatewayAPI.GetSession))
-	mux.HandleFunc("DELETE /api/sessions/{id}", withCORS(gatewayAPI.DeleteSession))
-	mux.HandleFunc("POST /api/sessions/{id}/cd", withCORS(gatewayAPI.SwitchWorkDir))
-	mux.HandleFunc("GET /api/sessions/{id}/history", withCORS(gatewayAPI.GetHistory))
-	mux.HandleFunc("GET /api/sessions/{id}/events", withCORS(gatewayAPI.GetEvents))
-	mux.HandleFunc("OPTIONS /api/sessions", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
-	mux.HandleFunc("OPTIONS /api/sessions/", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
-	mux.HandleFunc("OPTIONS /api/sessions/{id}", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
-	mux.HandleFunc("OPTIONS /api/sessions/{id}/history", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
-	mux.HandleFunc("OPTIONS /api/sessions/{id}/events", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
+	mux.Handle("GET /api/sessions", corsMw(http.HandlerFunc(gatewayAPI.ListSessions)))
+	mux.Handle("POST /api/sessions", corsMw(http.HandlerFunc(gatewayAPI.CreateSession)))
+	mux.Handle("GET /api/sessions/{id}", corsMw(http.HandlerFunc(gatewayAPI.GetSession)))
+	mux.Handle("DELETE /api/sessions/{id}", corsMw(http.HandlerFunc(gatewayAPI.DeleteSession)))
+	mux.Handle("POST /api/sessions/{id}/cd", corsMw(http.HandlerFunc(gatewayAPI.SwitchWorkDir)))
+	mux.Handle("GET /api/sessions/{id}/history", corsMw(http.HandlerFunc(gatewayAPI.GetHistory)))
+	mux.Handle("GET /api/sessions/{id}/events", corsMw(http.HandlerFunc(gatewayAPI.GetEvents)))
+	mux.Handle("OPTIONS /api/sessions", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+	mux.Handle("OPTIONS /api/sessions/", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+	mux.Handle("OPTIONS /api/sessions/{id}", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+	mux.Handle("OPTIONS /api/sessions/{id}/history", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+	mux.Handle("OPTIONS /api/sessions/{id}/events", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
 
 	mux.Handle("GET /ws", hub.HandleHTTP(auth, handler, bridge, deps.CookieAuth))
 
@@ -78,18 +74,19 @@ func setupRoutes(
 	}
 
 	adminAPI := admin.New(admin.Deps{
-		Log:           log,
-		Config:        configAdapter,
-		SessionMgr:    sessionAdapter,
-		TurnStats:     turnsAdapter,
-		Hub:           hubAdapter,
-		Bridge:        bridgeAdapter,
-		ConfigWatcher: configWatcherAdapter,
-		Cron:          cronProvider,
-		BotLister:     &botListerAdapter{registry: messaging.DefaultBotRegistry()},
-		BotConfig:     newBotConfigAdapter(deps.ConfigStore, cfg.AgentConfig.ConfigDir, ""),
-		Version:       versionString,
-		NewSessionID:  newSessionID,
+		Log:              log,
+		Config:           configAdapter,
+		SessionMgr:       sessionAdapter,
+		TurnStats:        turnsAdapter,
+		Hub:              hubAdapter,
+		Bridge:           bridgeAdapter,
+		ConfigWatcher:    configWatcherAdapter,
+		Cron:             cronProvider,
+		BotLister:        &botListerAdapter{registry: messaging.DefaultBotRegistry()},
+		BotConfig:        newBotConfigAdapter(deps.ConfigStore, cfg.AgentConfig.ConfigDir, ""),
+		Version:          versionString,
+		NewSessionID:     newSessionID,
+		AllowedOriginsFn: corsOriginsFn,
 		Restart: func() error {
 			inst, err := findRunningGateway()
 			if err != nil {
@@ -206,6 +203,11 @@ func setupRoutes(
 	mux.HandleFunc("GET /favicon.ico", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/docs/assets/logo.png", http.StatusMovedPermanently)
 	})
+
+	// security.txt (RFC 9116) — contact info from config, no hardcoded domains.
+	mux.Handle("GET /.well-known/security.txt", security.SecurityTxtHandler(
+		func() string { return deps.ConfigStore.Load().Security.SecurityContact },
+	))
 
 	// Webchat SPA is NOT registered on the mux directly.
 	// Instead, the caller wraps the mux with a fallback handler below.

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -113,6 +113,15 @@ security:
   tls_enabled: false
   tls_cert_file: "/etc/hotplex/tls/server.crt"
   tls_key_file: "/etc/hotplex/tls/server.key"
+  # Allowed CORS origins for gateway API, admin API, and WebSocket connections.
+  # Default: ["*"] (allows all origins — suitable for development).
+  # Production: pin to specific origins to prevent cross-origin attacks, e.g.:
+  #   allowed_origins:
+  #     - "https://app.example.com"
+  #     - "https://admin.example.com"
+  # Can be overridden at runtime by HOTPLEX_SECURITY_ALLOWED_ORIGINS env var
+  # (comma-separated list, e.g. "https://app.example.com,https://admin.example.com").
+  # A startup WARN log fires when wildcard "*" is in effect.
   allowed_origins:
     - "*"
   # Content-Security-Policy header served with the embedded webchat SPA and
@@ -126,6 +135,11 @@ security:
   #   csp: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' http://192.168.1.100:9999 ws://192.168.1.100:9999 wss://*; img-src 'self' data: blob:; font-src 'self' data:"
   # Can be overridden at runtime by HOTPLEX_SECURITY_CSP env var.
   csp: ""
+  # Contact URI for /.well-known/security.txt (RFC 9116).
+  # When set, the security.txt endpoint is enabled. Empty = disabled.
+  # Examples: "mailto:security@example.com", "https://example.com/security-policy"
+  # Can be overridden at runtime by HOTPLEX_SECURITY_SECURITY_CONTACT env var.
+  security_contact: ""
 
   # Work directory security settings (convention + configuration)
   # Program defaults (convention over configuration):

--- a/configs/env.example
+++ b/configs/env.example
@@ -29,6 +29,14 @@ ADMIN_TOKEN=
 # the deployment host(s) are known, e.g.:
 #   HOTPLEX_SECURITY_CSP="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' http://YOUR-HOST:9999 ws://YOUR-HOST:9999 wss://*; img-src 'self' data: blob:; font-src 'self' data:"
 
+# Allowed CORS origins for gateway and admin APIs (comma-separated).
+# Default: "*" (all origins). Production: pin to specific origins.
+# HOTPLEX_SECURITY_ALLOWED_ORIGINS="https://app.example.com,https://admin.example.com"
+
+# Contact URI for /.well-known/security.txt (RFC 9116).
+# When set, enables the security.txt endpoint. Empty = disabled.
+# HOTPLEX_SECURITY_SECURITY_CONTACT="mailto:security@example.com"
+
 # ── Core Overrides ────────────────────────────────────────────────────────────
 
 # Log level: debug, info, warn, error (default: info)

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/eventstore"
+	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/events"
@@ -94,47 +95,49 @@ func (r *statusRecorder) Write(b []byte) (int, error) {
 }
 
 type AdminAPI struct {
-	log           *slog.Logger
-	cfg           ConfigProvider
-	sm            SessionManagerProvider
-	turnStore     TurnStatsProvider
-	hub           HubProvider
-	bridge        BridgeProvider
-	configWatcher ConfigWatcherProvider
-	cron          CronSchedulerProvider
-	botLister     BotListerProvider
-	botConfig     BotConfigProvider
-	logCollector  LogCollector
-	akStore       APIKeyUserStorer // nil when DB resolver not enabled
-	keyValidator  KeyValidator     // nil when not injected
-	rateLimiter   atomic.Value     // *simpleRateLimiter
-	allowedCIDRs  atomic.Value     // []string
-	version       func() string
-	newSessionID  func() string
-	restart       func() error
-	startedAt     time.Time
+	log              *slog.Logger
+	cfg              ConfigProvider
+	sm               SessionManagerProvider
+	turnStore        TurnStatsProvider
+	hub              HubProvider
+	bridge           BridgeProvider
+	configWatcher    ConfigWatcherProvider
+	cron             CronSchedulerProvider
+	botLister        BotListerProvider
+	botConfig        BotConfigProvider
+	logCollector     LogCollector
+	akStore          APIKeyUserStorer // nil when DB resolver not enabled
+	keyValidator     KeyValidator     // nil when not injected
+	rateLimiter      atomic.Value     // *simpleRateLimiter
+	allowedCIDRs     atomic.Value     // []string
+	allowedOriginsFn func() []string  // returns allowed CORS origins from config
+	version          func() string
+	newSessionID     func() string
+	restart          func() error
+	startedAt        time.Time
 }
 
 type Deps struct {
-	Log           *slog.Logger
-	Config        ConfigProvider
-	SessionMgr    SessionManagerProvider
-	TurnStats     TurnStatsProvider
-	Hub           HubProvider
-	Bridge        BridgeProvider
-	ConfigWatcher ConfigWatcherProvider
-	Cron          CronSchedulerProvider
-	BotLister     BotListerProvider
-	BotConfig     BotConfigProvider
-	LogCollector  LogCollector
-	Version       func() string
-	NewSessionID  func() string
-	Restart       func() error
-	DB            DBExecutor       // Optional: enables API key user CRUD + DB resolver
-	DBResolver    cacheInvalidator // Optional: invalidates DBResolver cache after CUD
-	WriteMu       *sqlutil.WriteMu // Optional: serializes SQLite writes; nil-safe, PG-safe
-	APIKeyStore   APIKeyUserStorer // Optional: pre-built store (e.g. PG); overrides DB-based creation
-	KeyValidator  KeyValidator     // Optional: syncs DB keys into auth layer for Phase 1 validation
+	Log              *slog.Logger
+	Config           ConfigProvider
+	SessionMgr       SessionManagerProvider
+	TurnStats        TurnStatsProvider
+	Hub              HubProvider
+	Bridge           BridgeProvider
+	ConfigWatcher    ConfigWatcherProvider
+	Cron             CronSchedulerProvider
+	BotLister        BotListerProvider
+	BotConfig        BotConfigProvider
+	LogCollector     LogCollector
+	Version          func() string
+	NewSessionID     func() string
+	Restart          func() error
+	AllowedOriginsFn func() []string  // Optional: returns allowed CORS origins; defaults to ["*"] when nil
+	DB               DBExecutor       // Optional: enables API key user CRUD + DB resolver
+	DBResolver       cacheInvalidator // Optional: invalidates DBResolver cache after CUD
+	WriteMu          *sqlutil.WriteMu // Optional: serializes SQLite writes; nil-safe, PG-safe
+	APIKeyStore      APIKeyUserStorer // Optional: pre-built store (e.g. PG); overrides DB-based creation
+	KeyValidator     KeyValidator     // Optional: syncs DB keys into auth layer for Phase 1 validation
 }
 
 func New(deps Deps) *AdminAPI {
@@ -165,6 +168,12 @@ func New(deps Deps) *AdminAPI {
 		newSessionID: deps.NewSessionID,
 		restart:      deps.Restart,
 		startedAt:    time.Now(),
+		allowedOriginsFn: func() []string {
+			if deps.AllowedOriginsFn != nil {
+				return deps.AllowedOriginsFn()
+			}
+			return []string{"*"}
+		},
 	}
 	return a
 }
@@ -188,7 +197,7 @@ func (a *AdminAPI) Middleware(next http.Handler) http.Handler {
 			)
 		}()
 
-		addCORSHeaders(sw)
+		security.SetCORSHeaders(sw, a.allowedOriginsFn(), r.Header.Get("Origin"))
 		if r.Method == http.MethodOptions {
 			sw.WriteHeader(http.StatusOK)
 			return

--- a/internal/admin/handlers_test.go
+++ b/internal/admin/handlers_test.go
@@ -459,15 +459,57 @@ func TestMiddleware_IPWhitelist(t *testing.T) {
 }
 
 func TestMiddleware_CORS(t *testing.T) {
-	api := newTestAPI()
-	handler := api.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodOptions, "/", nil)
+	t.Parallel()
 
-	handler.ServeHTTP(w, r)
+	t.Run("default wildcard allows all origins", func(t *testing.T) {
+		t.Parallel()
+		api := newTestAPI()
+		handler := api.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodOptions, "/", nil)
 
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+		handler.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("specific origin matches request", func(t *testing.T) {
+		t.Parallel()
+		api := newTestAPI(func(d *Deps) {
+			d.AllowedOriginsFn = func() []string {
+				return []string{"https://admin.example.com"}
+			}
+		})
+		handler := api.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodOptions, "/", nil)
+		r.Header.Set("Origin", "https://admin.example.com")
+
+		handler.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "https://admin.example.com", w.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, "Origin", w.Header().Get("Vary"))
+	})
+
+	t.Run("non-matching origin gets no CORS headers", func(t *testing.T) {
+		t.Parallel()
+		api := newTestAPI(func(d *Deps) {
+			d.AllowedOriginsFn = func() []string {
+				return []string{"https://admin.example.com"}
+			}
+		})
+		handler := api.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodOptions, "/", nil)
+		r.Header.Set("Origin", "https://evil.com")
+
+		handler.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+	})
 }
 
 func TestMiddleware_PanicRecovery(t *testing.T) {

--- a/internal/admin/sessions.go
+++ b/internal/admin/sessions.go
@@ -8,12 +8,6 @@ import (
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
-func addCORSHeaders(w http.ResponseWriter) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Api-Key")
-}
-
 // CreateSession creates a new session.
 //
 // @Summary      Create session

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -685,6 +685,11 @@ type SecurityConfig struct {
 	// (localhost-friendly). Set this when serving from a remote host — the
 	// browser blocks fetch/ws/connect calls that do not match a directive in CSP.
 	CSP string `mapstructure:"csp"`
+
+	// SecurityContact enables /.well-known/security.txt (RFC 9116) when non-empty.
+	// Examples: "mailto:security@example.com", "https://example.com/security".
+	// Overridable via HOTPLEX_SECURITY_SECURITY_CONTACT env var.
+	SecurityContact string `mapstructure:"security_contact"`
 }
 
 // SessionConfig holds session lifecycle settings.
@@ -817,11 +822,12 @@ func Default() *Config {
 			},
 		},
 		Security: SecurityConfig{
-			APIKeyHeader:   "X-API-Key",
-			APIKeys:        nil,
-			TLSEnabled:     false,
-			AllowedOrigins: []string{"*"},
-			CSP:            "", // empty → webchat/docs use package-level default
+			APIKeyHeader:    "X-API-Key",
+			APIKeys:         nil,
+			TLSEnabled:      false,
+			AllowedOrigins:  []string{"*"},
+			CSP:             "", // empty → webchat/docs use package-level default
+			SecurityContact: "",
 		},
 		Session: SessionConfig{
 			RetentionPeriod:   7 * 24 * time.Hour,
@@ -1074,6 +1080,8 @@ func Load(filePath string) (*Config, error) {
 	_ = v.BindEnv("worker.opencode_server.password")
 	_ = v.BindEnv("security.api_key_header")
 	_ = v.BindEnv("security.csp")
+	_ = v.BindEnv("security.allowed_origins")
+	_ = v.BindEnv("security.security_contact")
 	_ = v.BindEnv("agent_config.enabled")
 	_ = v.BindEnv("agent_config.config_dir")
 	_ = v.BindEnv("skills.cache_ttl")

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -16,20 +16,21 @@ import (
 // without requiring a restart. All other fields are treated as static.
 // Format: "TopLevel.NestedField" (matches mapstructure tags).
 var hotReloadableFields = map[string]bool{
-	"log.level":                true,
-	"session.gc_scan_interval": true,
-	"pool.max_size":            true,
-	"pool.max_idle_per_user":   true,
-	"security.api_keys":        true,
-	"security.allowed_origins": true,
-	"worker.max_lifetime":      true,
-	"worker.idle_timeout":      true,
-	"worker.execution_timeout": true,
-	"worker.auto_retry":        true,
-	"admin.requests_per_sec":   true,
-	"admin.burst":              true,
-	"admin.tokens":             true,
-	"admin.allowed_cidrs":      true,
+	"log.level":                 true,
+	"session.gc_scan_interval":  true,
+	"pool.max_size":             true,
+	"pool.max_idle_per_user":    true,
+	"security.api_keys":         true,
+	"security.allowed_origins":  true,
+	"security.security_contact": true,
+	"worker.max_lifetime":       true,
+	"worker.idle_timeout":       true,
+	"worker.execution_timeout":  true,
+	"worker.auto_retry":         true,
+	"admin.requests_per_sec":    true,
+	"admin.burst":               true,
+	"admin.tokens":              true,
+	"admin.allowed_cidrs":       true,
 }
 
 // staticFields are config fields that require a restart to take effect.

--- a/internal/security/cors.go
+++ b/internal/security/cors.go
@@ -1,0 +1,72 @@
+package security
+
+import "net/http"
+
+// ResolveOrigin determines the Access-Control-Allow-Origin header value
+// based on the request's Origin and the configured allowed origins list.
+//
+//   - If the list contains "*", returns "*" (backward-compatible wildcard mode).
+//   - If the request Origin exactly matches an entry, returns that Origin
+//     (echo-back mode for production with specific domains).
+//   - Otherwise returns "" (no CORS headers → browser blocks the request).
+func ResolveOrigin(requestOrigin string, allowedOrigins []string) string {
+	for _, o := range allowedOrigins {
+		if o == "*" {
+			return "*"
+		}
+		if o == requestOrigin {
+			return requestOrigin
+		}
+	}
+	return ""
+}
+
+// CORSMiddleware returns an HTTP middleware that injects CORS response headers
+// and handles OPTIONS preflight requests. The originsFn function is called on
+// every request so that config hot-reload takes effect immediately.
+//
+// When the resolved origin is non-empty, the following headers are set:
+//   - Access-Control-Allow-Origin: the matched origin (or "*" for wildcard)
+//   - Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS
+//   - Access-Control-Allow-Headers: Content-Type, Authorization, X-Api-Key
+//   - Vary: Origin (prevents cache poisoning when origin-specific)
+//
+// OPTIONS requests receive a 200 response without calling the next handler.
+func CORSMiddleware(originsFn func() []string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			allowed := ResolveOrigin(origin, originsFn())
+			if allowed != "" {
+				writeCORSHeaders(w, allowed)
+			}
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// SetCORSHeaders sets CORS response headers without handling OPTIONS.
+// Use this in middleware chains that have their own OPTIONS handling
+// (e.g. the admin API middleware).
+//
+// When allowedOrigins contains "*" or the request Origin matches an entry,
+// the CORS headers are written. Otherwise no headers are set.
+func SetCORSHeaders(w http.ResponseWriter, allowedOrigins []string, requestOrigin string) {
+	allowed := ResolveOrigin(requestOrigin, allowedOrigins)
+	if allowed != "" {
+		writeCORSHeaders(w, allowed)
+	}
+}
+
+// writeCORSHeaders writes the standard CORS response headers for the given
+// resolved origin value.
+func writeCORSHeaders(w http.ResponseWriter, origin string) {
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Api-Key")
+	w.Header().Set("Vary", "Origin")
+}

--- a/internal/security/cors_test.go
+++ b/internal/security/cors_test.go
@@ -1,0 +1,232 @@
+package security
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveOrigin(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		requestOrigin string
+		allowed       []string
+		want          string
+	}{
+		{
+			name:          "wildcard allows any origin",
+			requestOrigin: "https://evil.com",
+			allowed:       []string{"*"},
+			want:          "*",
+		},
+		{
+			name:          "exact match echoes origin",
+			requestOrigin: "https://app.example.com",
+			allowed:       []string{"https://app.example.com"},
+			want:          "https://app.example.com",
+		},
+		{
+			name:          "no match returns empty",
+			requestOrigin: "https://evil.com",
+			allowed:       []string{"https://app.example.com"},
+			want:          "",
+		},
+		{
+			name:          "empty allowed list returns empty",
+			requestOrigin: "https://app.example.com",
+			allowed:       nil,
+			want:          "",
+		},
+		{
+			name:          "wildcard in mixed list wins",
+			requestOrigin: "https://random.com",
+			allowed:       []string{"https://ok.com", "*"},
+			want:          "*",
+		},
+		{
+			name:          "empty request origin no match",
+			requestOrigin: "",
+			allowed:       []string{"https://app.example.com"},
+			want:          "",
+		},
+		{
+			name:          "empty request origin with wildcard",
+			requestOrigin: "",
+			allowed:       []string{"*"},
+			want:          "*",
+		},
+		{
+			name:          "multiple origins exact match",
+			requestOrigin: "https://admin.example.com",
+			allowed:       []string{"https://app.example.com", "https://admin.example.com"},
+			want:          "https://admin.example.com",
+		},
+		{
+			name:          "multiple origins no match",
+			requestOrigin: "https://evil.com",
+			allowed:       []string{"https://app.example.com", "https://admin.example.com"},
+			want:          "",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveOrigin(tt.requestOrigin, tt.allowed)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCORSMiddleware(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wildcard preserves backward compat", func(t *testing.T) {
+		t.Parallel()
+		mw := CORSMiddleware(func() []string { return []string{"*"} })
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+		req.Header.Set("Origin", "https://any.com")
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, "Origin", rec.Header().Get("Vary"))
+		require.Equal(t, "GET, POST, PUT, PATCH, DELETE, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
+		require.Equal(t, "Content-Type, Authorization, X-Api-Key", rec.Header().Get("Access-Control-Allow-Headers"))
+	})
+
+	t.Run("matching origin echoes back with Vary", func(t *testing.T) {
+		t.Parallel()
+		mw := CORSMiddleware(func() []string {
+			return []string{"https://app.example.com", "https://admin.example.com"}
+		})
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+		req.Header.Set("Origin", "https://admin.example.com")
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "https://admin.example.com", rec.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, "Origin", rec.Header().Get("Vary"))
+	})
+
+	t.Run("non-matching origin gets no CORS headers", func(t *testing.T) {
+		t.Parallel()
+		mw := CORSMiddleware(func() []string {
+			return []string{"https://app.example.com"}
+		})
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+		req.Header.Set("Origin", "https://evil.com")
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("OPTIONS returns 200 without calling next", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		mw := CORSMiddleware(func() []string { return []string{"*"} })
+		inner := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		})
+		req := httptest.NewRequest(http.MethodOptions, "/api/sessions", nil)
+		req.Header.Set("Origin", "https://any.com")
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.False(t, called, "OPTIONS should not call next handler")
+		require.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("empty origins list gets no CORS headers", func(t *testing.T) {
+		t.Parallel()
+		mw := CORSMiddleware(func() []string { return nil })
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+		req.Header.Set("Origin", "https://any.com")
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("no Origin header gets no CORS headers for specific origins", func(t *testing.T) {
+		t.Parallel()
+		mw := CORSMiddleware(func() []string {
+			return []string{"https://app.example.com"}
+		})
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+		// No Origin header set
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+}
+
+func TestSetCORSHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wildcard sets all headers", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		SetCORSHeaders(rec, []string{"*"}, "https://any.com")
+
+		require.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, "Origin", rec.Header().Get("Vary"))
+	})
+
+	t.Run("matching origin sets headers", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		SetCORSHeaders(rec, []string{"https://app.example.com"}, "https://app.example.com")
+
+		require.Equal(t, "https://app.example.com", rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("non-matching origin sets no headers", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		SetCORSHeaders(rec, []string{"https://app.example.com"}, "https://evil.com")
+
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("empty origins sets no headers", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		SetCORSHeaders(rec, nil, "https://any.com")
+
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+}

--- a/internal/security/csp.go
+++ b/internal/security/csp.go
@@ -19,14 +19,16 @@ const DefaultWebChatCSP = "default-src 'self'; " +
 	"img-src 'self' data: blob:; " +
 	"font-src 'self' data:"
 
-// DefaultDocsCSP is the fallback CSP for the self-hosted docs portal. It is
-// the same scheme-wide-open connect-src as the webchat default, plus jsDelivr
-// for scripts. Scalar API Reference loads web fonts from fonts.scalar.com.
-// Google Fonts have been localized (served from 'self').
+// DefaultDocsCSP is the fallback CSP for the self-hosted docs portal.
+// connect-src is restricted to 'self' only: the docs portal fetches the
+// OpenAPI spec and makes API Console "Try It" calls to the same origin.
+// Fonts loaded via CSS @font-face are governed by font-src, not connect-src.
+// Scripts loaded via <script> are governed by script-src, not connect-src.
+// Operators needing broader connectivity can override via security.csp.
 const DefaultDocsCSP = "default-src 'self'; " +
 	"script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; " +
 	"style-src 'self' 'unsafe-inline'; " +
-	"connect-src 'self' http: https: ws: wss: data: blob:; " +
+	"connect-src 'self'; " +
 	"img-src 'self' data: blob:; " +
 	"font-src 'self' data: https://cdn.jsdelivr.net https://fonts.scalar.com"
 

--- a/internal/security/headers_test.go
+++ b/internal/security/headers_test.go
@@ -110,3 +110,21 @@ func TestSecurityHeaders(t *testing.T) {
 		require.Equal(t, strict, rec.Header().Get("Content-Security-Policy"))
 	})
 }
+
+func TestDefaultDocsCSP_NotPermissive(t *testing.T) {
+	t.Parallel()
+	// After tightening, docs CSP should NOT contain permissive connect-src
+	// (no bare http:/https:/ws:/wss: scheme keywords).
+	require.False(t, IsPermissiveCSP(DefaultDocsCSP),
+		"DefaultDocsCSP connect-src should be restricted to 'self' only")
+	// Verify connect-src 'self' is present (not accidentally removed).
+	require.Contains(t, DefaultDocsCSP, "connect-src 'self';")
+}
+
+func TestDefaultWebChatCSP_IsPermissive(t *testing.T) {
+	t.Parallel()
+	// WebChat CSP intentionally keeps permissive connect-src for WebSocket
+	// connections to the gateway (ws:/wss: scheme keywords).
+	require.True(t, IsPermissiveCSP(DefaultWebChatCSP),
+		"DefaultWebChatCSP should remain permissive for zero-config remote deployments")
+}

--- a/internal/security/securitytxt.go
+++ b/internal/security/securitytxt.go
@@ -1,0 +1,35 @@
+package security
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// SecurityTxtHandler returns an HTTP handler for /.well-known/security.txt
+// (RFC 9116). The contactFn function is called on every request so that config
+// hot-reload takes effect immediately.
+//
+// When contactFn returns an empty string, the handler responds with 404
+// (security.txt is only advertised when explicitly configured).
+//
+// No domains or contact information is hardcoded — all values come from
+// the security.contact config field or HOTPLEX_SECURITY_SECURITY_CONTACT env var.
+func SecurityTxtHandler(contactFn func() string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		contact := contactFn()
+		if contact == "" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("Cache-Control", "public, max-age=86400")
+
+		_, _ = io.WriteString(w, "# HotPlex Security Policy\n")
+		_, _ = fmt.Fprintf(w, "Contact: %s\n", contact)
+		_, _ = io.WriteString(w, "Preferred-Languages: zh, en\n")
+		_, _ = fmt.Fprintf(w, "Expires: %s\n", time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
+	})
+}

--- a/internal/security/securitytxt_test.go
+++ b/internal/security/securitytxt_test.go
@@ -1,0 +1,80 @@
+package security
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecurityTxtHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns 404 when contact is empty", func(t *testing.T) {
+		t.Parallel()
+		handler := SecurityTxtHandler(func() string { return "" })
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/security.txt", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("returns security.txt with contact", func(t *testing.T) {
+		t.Parallel()
+		handler := SecurityTxtHandler(func() string { return "mailto:security@example.com" })
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/security.txt", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "text/plain; charset=utf-8", rec.Header().Get("Content-Type"))
+		body := rec.Body.String()
+		require.Contains(t, body, "Contact: mailto:security@example.com")
+		require.Contains(t, body, "Preferred-Languages: zh, en")
+		require.Contains(t, body, "Expires:")
+	})
+
+	t.Run("sets cache control for 24 hours", func(t *testing.T) {
+		t.Parallel()
+		handler := SecurityTxtHandler(func() string { return "mailto:sec@example.com" })
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/security.txt", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Header().Get("Cache-Control"), "max-age=86400")
+	})
+
+	t.Run("accepts URL contact", func(t *testing.T) {
+		t.Parallel()
+		handler := SecurityTxtHandler(func() string {
+			return "https://example.com/security-policy"
+		})
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/security.txt", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Body.String(), "Contact: https://example.com/security-policy")
+	})
+
+	t.Run("does not hardcode any domain", func(t *testing.T) {
+		t.Parallel()
+		handler := SecurityTxtHandler(func() string { return "mailto:custom@test.org" })
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/security.txt", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		body := rec.Body.String()
+		// No hardcoded domains should appear
+		require.False(t, strings.Contains(body, "hotplex.com") || strings.Contains(body, "hrygo.com"))
+	})
+}


### PR DESCRIPTION
## Security Hardening — Assessment Fixes

Based on security assessment report (2026-06-05, target: B+ → A).

### MED-1: Configurable CORS Origins

**Before:** `Access-Control-Allow-Origin: *` hardcoded in 2 independent locations (`routes.go`, `admin/sessions.go`).

**After:** Shared `security.CORSMiddleware` reads from `security.allowed_origins` config.

| Scenario | Behavior |
|----------|----------|
| Default (`["*"]`) | Wildcard — backward compatible, dev-friendly |
| Specific origins | Origin echo-back + `Vary: Origin` header |
| No match | No CORS headers → browser blocks |

- Config: `security.allowed_origins` YAML / `HOTPLEX_SECURITY_ALLOWED_ORIGINS` env var
- Hot-reload: `originsFn` reads `ConfigStore.Load()` per-request
- Startup WARN when wildcard is active

### MED-2: Tighten Docs CSP `connect-src`

**Before:** `connect-src 'self' http: https: ws: wss: data: blob:` (any host)

**After:** `connect-src 'self'` (same-origin only)

Docs portal only needs same-origin fetch (swagger spec + API console "Try It"). Fonts/scripts governed by `font-src`/`script-src`. WebChat CSP unchanged.

### LOW-1: `/.well-known/security.txt` (RFC 9116)

- Contact from `security.contact` config / `HOTPLEX_SECURITY_SECURITY_CONTACT` env var
- No hardcoded domains — all configurable
- Disabled by default (404 when empty)
- Hot-reloadable, 24h cache

### Files Changed (14)

| File | Change |
|------|--------|
| `internal/security/cors.go` | **New** — shared CORS middleware |
| `internal/security/cors_test.go` | **New** — comprehensive tests |
| `internal/security/securitytxt.go` | **New** — RFC 9116 handler |
| `internal/security/securitytxt_test.go` | **New** — tests |
| `internal/security/csp.go` | Docs CSP `connect-src` tightened |
| `internal/security/headers_test.go` | CSP tightening assertions |
| `internal/admin/admin.go` | Deps + Middleware use config-driven CORS |
| `internal/admin/sessions.go` | Removed hardcoded `addCORSHeaders` |
| `internal/admin/handlers_test.go` | Enhanced CORS tests (3 sub-cases) |
| `internal/config/config.go` | `SecurityContact` field + `BindEnv` |
| `internal/config/watcher.go` | Hot-reload field |
| `cmd/hotplex/routes.go` | CORS middleware + security.txt route |
| `configs/config.yaml` | Documentation + new fields |
| `configs/env.example` | Env var documentation |

### Backward Compatibility

All changes are backward compatible — default config (`allowed_origins: ["*"]`, `security_contact: ""`) preserves existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)