### PR TITLE
🔒 fix(security): configurable CORS origins, tighten docs CSP, add security.txt

### DIFF
--- a/cmd/hotplex/routes.go
+++ b/cmd/hotplex/routes.go
@@ -36,32 +36,28 @@ func setupRoutes(
 
 	gatewayAPI := gateway.NewGatewayAPI(log, auth, sm, bridge, deps.ConfigStore, deps.EventStore, deps.EventStore)
 
-	// withCORS wraps a handler to inject CORS headers.
-	withCORS := func(h http.HandlerFunc) http.HandlerFunc {
-		return func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Access-Control-Allow-Origin", "*")
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Api-Key")
-			if r.Method == http.MethodOptions {
-				w.WriteHeader(http.StatusOK)
-				return
-			}
-			h(w, r)
-		}
+	// CORS middleware reads allowed origins from config (supports hot-reload).
+	corsOriginsFn := func() []string {
+		return deps.ConfigStore.Load().Security.AllowedOrigins
+	}
+	corsMw := security.CORSMiddleware(corsOriginsFn)
+
+	if slices.Contains(cfg.Security.AllowedOrigins, "*") {
+		log.Warn("cors: allowed_origins contains '*' — all origins permitted; set security.allowed_origins in production")
 	}
 
-	mux.HandleFunc("GET /api/sessions", withCORS(gatewayAPI.ListSessions))
-	mux.HandleFunc("POST /api/sessions", withCORS(gatewayAPI.CreateSession))
-	mux.HandleFunc("GET /api/sessions/{id}", withCORS(gatewayAPI.GetSession))
-	mux.HandleFunc("DELETE /api/sessions/{id}", withCORS(gatewayAPI.DeleteSession))
-	mux.HandleFunc("POST /api/sessions/{id}/cd", withCORS(gatewayAPI.SwitchWorkDir))
-	mux.HandleFunc("GET /api/sessions/{id}/history", withCORS(gatewayAPI.GetHistory))
-	mux.HandleFunc("GET /api/sessions/{id}/events", withCORS(gatewayAPI.GetEvents))
-	mux.HandleFunc("OPTIONS /api/sessions", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
-	mux.HandleFunc("OPTIONS /api/sessions/", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
-	mux.HandleFunc("OPTIONS /api/sessions/{id}", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
-	mux.HandleFunc("OPTIONS /api/sessions/{id}/history", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
-	mux.HandleFunc("OPTIONS /api/sessions/{id}/events", withCORS(func(w http.ResponseWriter, r *http.Request) {}))
+	mux.Handle("GET /api/sessions", corsMw(http.HandlerFunc(gatewayAPI.ListSessions)))
+	mux.Handle("POST /api/sessions", corsMw(http.HandlerFunc(gatewayAPI.CreateSession)))
+	mux.Handle("GET /api/sessions/{id}", corsMw(http.HandlerFunc(gatewayAPI.GetSession)))
+	mux.Handle("DELETE /api/sessions/{id}", corsMw(http.HandlerFunc(gatewayAPI.DeleteSession)))
+	mux.Handle("POST /api/sessions/{id}/cd", corsMw(http.HandlerFunc(gatewayAPI.SwitchWorkDir)))
+	mux.Handle("GET /api/sessions/{id}/history", corsMw(http.HandlerFunc(gatewayAPI.GetHistory)))
+	mux.Handle("GET /api/sessions/{id}/events", corsMw(http.HandlerFunc(gatewayAPI.GetEvents)))
+	mux.Handle("OPTIONS /api/sessions", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+	mux.Handle("OPTIONS /api/sessions/", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+	mux.Handle("OPTIONS /api/sessions/{id}", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+	mux.Handle("OPTIONS /api/sessions/{id}/history", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+	mux.Handle("OPTIONS /api/sessions/{id}/events", corsMw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
 
 	mux.Handle("GET /ws", hub.HandleHTTP(auth, handler, bridge, deps.CookieAuth))
 
@@ -78,18 +74,19 @@ func setupRoutes(
 	}
 
 	adminAPI := admin.New(admin.Deps{
-		Log:           log,
-		Config:        configAdapter,
-		SessionMgr:    sessionAdapter,
-		TurnStats:     turnsAdapter,
-		Hub:           hubAdapter,
-		Bridge:        bridgeAdapter,
-		ConfigWatcher: configWatcherAdapter,
-		Cron:          cronProvider,
-		BotLister:     &botListerAdapter{registry: messaging.DefaultBotRegistry()},
-		BotConfig:     newBotConfigAdapter(deps.ConfigStore, cfg.AgentConfig.ConfigDir, ""),
-		Version:       versionString,
-		NewSessionID:  newSessionID,
+		Log:              log,
+		Config:           configAdapter,
+		SessionMgr:       sessionAdapter,
+		TurnStats:        turnsAdapter,
+		Hub:              hubAdapter,
+		Bridge:           bridgeAdapter,
+		ConfigWatcher:    configWatcherAdapter,
+		Cron:             cronProvider,
+		BotLister:        &botListerAdapter{registry: messaging.DefaultBotRegistry()},
+		BotConfig:        newBotConfigAdapter(deps.ConfigStore, cfg.AgentConfig.ConfigDir, ""),
+		Version:          versionString,
+		NewSessionID:     newSessionID,
+		AllowedOriginsFn: corsOriginsFn,
 		Restart: func() error {
 			inst, err := findRunningGateway()
 			if err != nil {
@@ -206,6 +203,11 @@ func setupRoutes(
 	mux.HandleFunc("GET /favicon.ico", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/docs/assets/logo.png", http.StatusMovedPermanently)
 	})
+
+	// security.txt (RFC 9116) — contact info from config, no hardcoded domains.
+	mux.Handle("GET /.well-known/security.txt", security.SecurityTxtHandler(
+		func() string { return deps.ConfigStore.Load().Security.SecurityContact },
+	))
 
 	// Webchat SPA is NOT registered on the mux directly.
 	// Instead, the caller wraps the mux with a fallback handler below.

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -113,6 +113,15 @@ security:
   tls_enabled: false
   tls_cert_file: "/etc/hotplex/tls/server.crt"
   tls_key_file: "/etc/hotplex/tls/server.key"
+  # Allowed CORS origins for gateway API, admin API, and WebSocket connections.
+  # Default: ["*"] (allows all origins — suitable for development).
+  # Production: pin to specific origins to prevent cross-origin attacks, e.g.:
+  #   allowed_origins:
+  #     - "https://app.example.com"
+  #     - "https://admin.example.com"
+  # Can be overridden at runtime by HOTPLEX_SECURITY_ALLOWED_ORIGINS env var
+  # (comma-separated list, e.g. "https://app.example.com,https://admin.example.com").
+  # A startup WARN log fires when wildcard "*" is in effect.
   allowed_origins:
     - "*"
   # Content-Security-Policy header served with the embedded webchat SPA and
@@ -126,6 +135,11 @@ security:
   #   csp: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' http://192.168.1.100:9999 ws://192.168.1.100:9999 wss://*; img-src 'self' data: blob:; font-src 'self' data:"
   # Can be overridden at runtime by HOTPLEX_SECURITY_CSP env var.
   csp: ""
+  # Contact URI for /.well-known/security.txt (RFC 9116).
+  # When set, the security.txt endpoint is enabled. Empty = disabled.
+  # Examples: "mailto:security@example.com", "https://example.com/security-policy"
+  # Can be overridden at runtime by HOTPLEX_SECURITY_SECURITY_CONTACT env var.
+  security_contact: ""
 
   # Work directory security settings (convention + configuration)
   # Program defaults (convention over configuration):

--- a/configs/env.example
+++ b/configs/env.example
@@ -29,6 +29,14 @@ ADMIN_TOKEN=
 # the deployment host(s) are known, e.g.:
 #   HOTPLEX_SECURITY_CSP="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' http://YOUR-HOST:9999 ws://YOUR-HOST:9999 wss://*; img-src 'self' data: blob:; font-src 'self' data:"
 
+# Allowed CORS origins for gateway and admin APIs (comma-separated).
+# Default: "*" (all origins). Production: pin to specific origins.
+# HOTPLEX_SECURITY_ALLOWED_ORIGINS="https://app.example.com,https://admin.example.com"
+
+# Contact URI for /.well-known/security.txt (RFC 9116).
+# When set, enables the security.txt endpoint. Empty = disabled.
+# HOTPLEX_SECURITY_SECURITY_CONTACT="mailto:security@example.com"
+
 # ── Core Overrides ────────────────────────────────────────────────────────────
 
 # Log level: debug, info, warn, error (default: info)

--- a/docs/explanation/cron-design.md
+++ b/docs/explanation/cron-design.md
@@ -353,6 +353,113 @@ Dispatch(job):
 
 ---
 
+## 案例：自动化 PR Review Prompt
+
+以下为 `pr-review-hotplex` cron job 的完整 Prompt，展示了一个生产级 AI-native 定时任务的 Prompt 设计模式。
+
+### 设计要点
+
+| 特征 | 实现方式 | 目的 |
+|------|---------|------|
+| 身份验证 | §0 `gh api user` 确认 hotplex-ai | 防止错误身份提交 review |
+| 去重 | §1 比较 commit date vs last review date | 避免重复审查同一 commit |
+| CI 门控 | §1 `gh pr checks` 检测 pending/fail | CI 未通过不审查 |
+| 隔离检出 | §1.5 `/tmp/pr-review-YYYYMMDD/pr-$PR` | 隔离工作区，防路径穿越 |
+| 预读共享 | §2 主进程读取 diff + CLAUDE.md | 消除 agent 间重复读取 |
+| 双维度并行 | §3 Agent A(正确性) + B(架构) | 覆盖安全/并发/性能/文档 |
+| 置信度过滤 | §4 <75 丢弃 | 减少误报 |
+| 结果投递 | §5 `gh api` 提交 review | 无需人工干预 |
+
+### Prompt 模式
+
+Prompt 采用**分段门控**模式：每个 § 是一个阶段，前一阶段的输出决定是否继续。这避免了 LLM 跳过关键步骤（如 CI 门控）直接进入 review。
+
+```
+§0 身份验证 → §1 去重+CI门控 → §1.5 检出 → §2 预读 → §3 并行Review → §4 过滤 → §5 提交
+     ↓               ↓                            ↓
+  失败→退出     SKIP→exit                    发现→汇总→提交
+```
+
+### 完整 Prompt
+
+```
+你是 hrygo/hotplex 的自动化 PR Review 系统。身份: hotplex-ai。
+
+## 铁律
+1. §1 去重+CI门控是硬性门控,必须先输出结果再决定是否继续
+2. 一个 PR 每次最多提交一条 review
+3. 无 P0/P1 必须 APPROVE
+4. 不确定标记 [UNCERTAIN],不凑数
+5. §1.5 检出是强制步骤,agent 只能从 $PR_DIR 读源文件
+
+## §0 身份
+export GH_TOKEN=$(cat ~/.hotplex/secrets/github-hotplex-ai-token)
+gh api user --jq ".login"  # 必须 hotplex-ai
+
+## §1 去重 + CI 门控(强制首步)
+echo $TARGET_PR  # 非空=webhook仅该PR,空=cron枚举所有open PR
+for PR in ${TARGET_PR:-$(gh pr list --repo hrygo/hotplex --state open --json number --jq '.[].number')}; do
+  HEAD=$(gh pr view $PR --repo hrygo/hotplex --json headRefOid --jq '.headRefOid')
+  COMMIT_DATE=$(gh api "repos/hrygo/hotplex/commits/$HEAD" --jq '.commit.committer.date')
+  LAST_REVIEW=$(gh api "repos/hrygo/hotplex/pulls/$PR/reviews?per_page=100" --jq "[.[]|select(.user.login==\"hotplex-ai\")|select(.state!=\"DISMISSED\")]|max_by(.submitted_at).submitted_at//\"\"")
+  NEED=false; [ -z "$LAST_REVIEW" ] && NEED=true
+  [ "$NEED" = false ] && [[ "$COMMIT_DATE" > "$LAST_REVIEW" ]] && NEED=true
+  [ "$NEED" = false ] && { echo "SKIP PR#$PR (reviewed)"; continue; }
+  CI=$(gh pr checks $PR --repo hrygo/hotplex 2>&1 || true)
+  [ -z "$CI" ] && { echo "SKIP PR#$PR (no CI)"; continue; }
+  echo "$CI" | grep -qiE "pending|queued|in progress" && { echo "SKIP PR#$PR (CI run)"; continue; }
+  echo "$CI" | grep -qiE "fail|neutral|timed.out" && { echo "SKIP PR#$PR (CI fail)"; continue; }
+  echo "REVIEW PR#$PR"; TARGET=$PR
+done
+[ -z "$TARGET" ] && { echo "All reviewed."; exit; }; PR=$TARGET
+
+## §1.5 检出 PR 分支(强制)
+RB="/tmp/pr-review-$(date +%Y%m%d)" && mkdir -p "$RB"
+PD="$RB/pr-$PR"
+if [ -d "$PD/.git" ]; then cd "$PD" && git fetch origin "+pull/$PR/head:review" && git reset --hard review
+else gh repo clone hrygo/hotplex "$PD" -- --no-checkout && cd "$PD" && git fetch origin "pull/$PR/head:review" && git checkout review
+fi
+find /tmp -maxdepth 1 -name "pr-review-*" ! -name "$(basename $RB)" -exec rm -rf {} + 2>/dev/null || true
+echo "PR_DIR=$PD"
+
+## §2 预读(主进程,共享给 agent)
+DIFF=$(gh pr diff $PR --repo hrygo/hotplex)
+CM=$(cat $PD/CLAUDE.md)
+[ $(echo "$DIFF" | wc -l) -gt 8000 ] && DIFF=$(echo "$DIFF" | tail -8000)
+SHARED_CTX="## PR#$PR Diff\n$DIFF\n\n## CLAUDE.md\n$CM\n\n## SRC_ROOT=$PD\n⚠️ 读源文件必须用 $PD/xxx,禁读 /home/hotplex/"
+
+## §3 并行 Review(2 agent,SHARED_CTX完整嵌入每个agent)
+A-正确性/安全/并发: nil、竞态、逻辑错误、错误处理、goroutine泄漏、锁序(mu→ms)、持锁IO、ctx未传播、WG不配对。Mutex嵌入/传指针、math/rand加密、shell执行、硬编码路径、Err+%w、slog。DRY、命名一致性。忽略linter能抓的。
+B-历史/架构/性能/文档: blame上下文、API破坏下游、migration、配置兼容。SRP/OCP/DIP。N+1、不必要分配、大锁粒度(热路径)。注释不一致、过期TODO、注释掉代码。
+返回: [SEVERITY] 简述 (file:line) — 原因
+⚠️ 源文件用 $PD/ 绝对路径,禁 /home/hotplex/
+
+## §4 过滤
+<75丢弃。P0>P1>P2>P3。误报:预存问题、linter能抓、风格、缺测试(通用)、功能变更、跨包DRY需新抽象、非热路径性能。
+
+## §5 提交
+重跑§1确认。已review→跳过输出"SKIP:reviewed"。
+P0/P1→REQUEST_CHANGES,仅P2/P3→COMMENT+APPROVE,全PASS→APPROVE。
+body不可为空→跳过"SKIP:空body"。
+格式: ## Code Review — hotplex-ai\nVerdict: ... | P0:X P1:X P2:X P3:X
+
+## §6 约束
+Go 1.26+ | tab | Mutex显式mu | Err哨兵+%w | slog | testify/require | filepath.Join
+```
+
+### 与系统特性的配合
+
+| 系统特性 | Prompt 中的利用 |
+|---------|----------------|
+| `buildWebhookPrefix` | webhook 触发时注入 `⚠️ WEBHOOK 触发：仅审查 PR #N` + `TARGET_PR` 环境变量 |
+| `Silent` 模式 | `silent: true` 跳过飞书投递，review 结果通过 GitHub API 直接提交 |
+| `WorkDir` | executor 设置 `/tmp/hotplex`，prompt §1.5 切换到隔离检出目录 |
+| `PlatformKey` | webhook 注入 `trigger`/`pr_number`，executor 注入 `cron_job_id` |
+| `job.Timeout` | 1000s 超时，覆盖 clone + 2-agent 并行 + review 提交全流程 |
+| `AllowedTools` | 可限制 Worker 仅使用 Bash 和 Read，防止意外修改 |
+
+---
+
 ## 相关实践
 
 - [Cron 自动化指南](../guides/developer/cron-automation.md) — 三种调度模式的配置与使用

--- a/docs/specs/pr-review-ci-only-trigger-spec.md
+++ b/docs/specs/pr-review-ci-only-trigger-spec.md
@@ -1,0 +1,241 @@
+# PR Review Webhook 优化：CI-Only 触发 + 动态 WorkDir
+
+**版本**: v2.0 · **日期**: 2026-06-05 · **状态**: Draft  
+**Issue**: #662
+
+---
+
+## 1. 目标
+
+两项优化：
+
+1. **CI-Only 触发**：webhook 仅在 CI 通过后触发 review，消除无效 SKIP session
+2. **动态 WorkDir**：webhook 触发时 executor 计算 PR 专属工作目录，Worker 直接在目标目录启动
+
+## 2. 当前行为与问题
+
+### 2.1 事件订阅
+
+GitHub Webhook 订阅 3 类事件：
+
+| 事件 | Action | 触发条件 |
+|------|--------|---------|
+| `pull_request` | opened, synchronize, reopened, ready_for_review | 非 draft、state=open |
+| `check_suite` | completed | conclusion=success |
+| `check_run` | completed | conclusion=success |
+
+### 2.2 问题 A：`pull_request` 事件触发过早
+
+PR opened/pushed 时 CI 未完成 → worker 启动 → §1 CI 门控检测 pending → SKIP。
+
+每次 SKIP 消耗 ~$0.20（冷启动 + system prompt 加载），典型 PR 浪费 1-2 次。实证：PR #659、#661 均出现 CI pending SKIP。
+
+### 2.3 问题 B：WorkDir 静态 + Prompt 层 cd
+
+当前数据流：
+
+```
+executor.go:70    job.WorkDir = "/tmp/hotplex" (静态)
+    ↓
+bridge.go:701     SessionInfo{ProjectDir: workDir}
+bridge.go:775     env["GATEWAY_WORK_DIR"] = workDir
+    ↓
+worker.go:200     Proc.Start(..., session.ProjectDir)
+    ↓
+manager.go:115    cmd.Dir = dir
+manager.go:124    os.MkdirAll(dir, 0o755)  ← 自动创建目录
+    ↓
+Worker 启动 cwd=/tmp/hotplex
+    ↓
+prompt §1.5: cd /tmp/pr-review-YYYYMMDD/pr-$PR  ← LLM 执行 shell cd
+```
+
+Worker 启动在 `/tmp/hotplex`，prompt §1.5 通过 `gh repo clone + cd` 切换到实际工作目录。这依赖 LLM 正确执行 cd（实测未失败，但冗余）。
+
+### 2.4 关键发现
+
+**`manager.go:124` 已有 `os.MkdirAll(dir, 0o755)`**。executor 只需设置 `workDir` 路径，目录创建由 proc manager 自动完成。executor 零额外代码。
+
+---
+
+## 3. 方案
+
+### 3.1 CI-Only 触发
+
+#### GitHub Webhook 订阅调整
+
+| 事件 | 保留 | 理由 |
+|------|:---:|------|
+| `pull_request` | ❌ 移除 | CI 未完成时触发无意义 |
+| `check_suite` | ✅ 保留 | CI 通过主信号 |
+| `check_run` | ✅ 保留 | 细粒度 check 完成信号 |
+
+#### 三层过滤
+
+| 层级 | 位置 | 过滤逻辑 | 作用 |
+|------|------|---------|------|
+| L1: 订阅 | GitHub Webhook Settings | 仅勾选 `check_suite` + `check_run` | 消除 `pull_request` 事件 |
+| L2: Handler | `webhook.go extractPRs` | `completed` + `conclusion=success` | 过滤 CI 失败 |
+| L3: Worker | prompt §1 CI 门控 | 保留作为防御性校验 | 防止极端情况（CI 后又 push） |
+
+#### `extractPRs` 简化
+
+```go
+// 移除 pull_request 分支
+func (h *WebhookHandler) extractPRs(eventType string, e *GitHubEvent) []int {
+    switch eventType {
+    case "check_suite":
+        if e.CheckSuite == nil || e.CheckSuite.Conclusion != "success" {
+            return nil
+        }
+        return extractPRNumbers(e.CheckSuite.PullRequests)
+    case "check_run":
+        if e.CheckRun == nil || e.CheckRun.Conclusion != "success" || e.CheckRun.CheckSuite == nil {
+            return nil
+        }
+        return extractPRNumbers(e.CheckRun.CheckSuite.PullRequests)
+    }
+    return nil
+}
+```
+
+#### Prompt §1 简化
+
+CI 门控降级为防御性校验。移除 `pending|queued|in progress` 检查（不应再出现）：
+
+```bash
+CI=$(gh pr checks $PR --repo hrygo/hotplex 2>&1 || true)
+echo "$CI" | grep -qiE "fail|neutral|timed.out" && { echo "SKIP PR#$PR (CI failed)"; continue; }
+```
+
+### 3.2 动态 WorkDir
+
+#### 核心思路
+
+Webhook 触发时 `PlatformKey["pr_number"]` 已注入（`webhook.go` → `TriggerByName` → `executor.go`）。Executor 在 `StartSession` 前计算动态路径，作为 `workDir` 参数传入。
+
+**无需创建目录**：`manager.go:124` 的 `os.MkdirAll` 自动处理。
+
+#### Executor 改动
+
+```go
+// executor.go — Execute 方法内，StartSession 之前
+workDir := job.WorkDir // 静态值: /tmp/hotplex
+
+// Webhook 触发：计算 PR 专属工作目录
+if prNum := job.PlatformKey["pr_number"]; prNum != "" && job.PlatformKey["trigger"] == "webhook" {
+    workDir = filepath.Join(os.TempDir(),
+        fmt.Sprintf("pr-review-%s/pr-%s", time.Now().Format("20060102"), prNum))
+}
+
+if err := e.bridge.StartSession(ctx, sessionKey, job.OwnerID, job.BotID,
+    wt, job.Payload.AllowedTools, workDir, // 使用动态 workDir
+    job.Platform, platformKey, title, "",
+); err != nil {
+```
+
+#### 数据流（Webhook 触发）
+
+```
+executor.go         workDir = /tmp/pr-review-20260605/pr-662
+    ↓
+bridge.go:701       SessionInfo{ProjectDir: "/tmp/pr-review-20260605/pr-662"}
+bridge.go:775       env["GATEWAY_WORK_DIR"] = "/tmp/pr-review-20260605/pr-662"
+    ↓
+manager.go:115      cmd.Dir = "/tmp/pr-review-20260605/pr-662"
+manager.go:124      os.MkdirAll("/tmp/pr-review-20260605/pr-662", 0o755)  ← 自动创建
+    ↓
+Worker 启动 cwd=/tmp/pr-review-20260605/pr-662  ← 已在目标目录
+    ↓
+prompt §0: export GH_TOKEN=$(cat ~/.hotplex/secrets/github-hotplex-ai-token)
+prompt §1.5: git init && git remote add origin ... && git fetch + checkout
+              （不再需要 gh repo clone 和 cd）
+```
+
+#### 数据流（Cron Fallback）
+
+Cron fallback 无 `PlatformKey["pr_number"]`，`workDir` 保持静态值 `/tmp/hotplex`，prompt §1.5 维持原逻辑（`gh repo clone + cd`）。
+
+#### Prompt §1.5 修改
+
+需区分 Worker 当前目录是否为目标目录：
+
+```bash
+## §1.5 检出 PR 分支(强制)
+RB="/tmp/pr-review-$(date +%Y%m%d)" && mkdir -p "$RB"
+PD="$RB/pr-$PR"
+
+if [ "$(pwd)" = "$PD" ]; then
+  # Webhook 触发：executor 已设置 cwd 为目标目录
+  git init
+  git remote add origin https://github.com/hrygo/hotplex.git
+  git fetch origin "+pull/$PR/head:review"
+  git checkout review
+elif [ -d "$PD/.git" ]; then
+  cd "$PD" && git fetch origin "+pull/$PR/head:review" && git reset --hard review
+else
+  gh repo clone hrygo/hotplex "$PD" -- --no-checkout
+  cd "$PD" && git fetch origin "pull/$PR/head:review" && git checkout review
+fi
+```
+
+---
+
+## 4. Cron Fallback 不变
+
+Cron fallback（`every:30m`）无 `PlatformKey["pr_number"]`，所有行为保持现状：
+
+- `workDir` = `/tmp/hotplex`（静态）
+- prompt §0-§1.5 完整执行
+- §1.5 走 `gh repo clone + cd` 路径
+
+---
+
+## 5. 涉及文件
+
+| 文件 | 类型 | 说明 |
+|------|------|------|
+| GitHub Webhook Settings | 配置 | 取消 `pull_request` 事件订阅 |
+| `internal/gateway/webhook.go` | 修改 | `extractPRs` 移除 `pull_request` 分支 |
+| `internal/gateway/webhook_test.go` | 修改 | 更新 pull_request 相关测试 |
+| `internal/cron/executor.go` | 修改 | 动态 WorkDir 计算（~6 行） |
+| cron prompt | 修改 | §1 简化 + §1.5 新增 webhook 路径 |
+
+---
+
+## 6. 验收标准
+
+### CI-Only 触发
+
+| ID | 条件 | 验证方法 |
+|----|------|---------|
+| AC-1 | PR opened 不触发 review | 创建 PR → gateway 日志无 trigger |
+| AC-2 | PR push 不触发 review | push commit → gateway 日志无 trigger |
+| AC-3 | CI 通过触发 review | CI 绿勾 → 日志 `trigger pr-review-hotplex pr=N` |
+| AC-4 | CI 失败不触发 review | CI 红叉 → 日志无 trigger |
+| AC-5 | 24h 内 webhook SKIP = 0 | webhook 触发 session 无 CI pending SKIP |
+
+### 动态 WorkDir
+
+| ID | 条件 | 验证方法 |
+|----|------|---------|
+| AC-6 | Webhook 触发：Worker cwd = `/tmp/pr-review-YYYYMMDD/pr-N` | §1.5 首条输出 `pwd` |
+| AC-7 | Webhook 触发：§1.5 走 `git init` 路径 | session 日志无 `gh repo clone` |
+| AC-8 | Cron 触发：行为不变 | `hotplex cron trigger` → 走 `gh repo clone` 路径 |
+| AC-9 | 重复 webhook：同一 PR 目录复用 | 第二次触发走 `git fetch + reset` 路径 |
+
+---
+
+## 7. 回滚
+
+```bash
+# 1. GitHub Webhook Settings 重新勾选 pull_request 事件
+# 2. redeploy webhook.go + executor.go（恢复 pull_request 分支，移除动态 WorkDir）
+# 3. 恢复 prompt §1 完整 CI 门控 + §1.5 原 gh repo clone 逻辑
+```
+
+---
+
+## 8. R2-R4 备注
+
+R2-R4 为用户已同意的改进项，原始提案待确认。在 issue #662 中标记为 checklist。

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/eventstore"
+	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/sqlutil"
 	"github.com/hrygo/hotplex/internal/worker"
 	"github.com/hrygo/hotplex/pkg/events"
@@ -94,47 +95,49 @@ func (r *statusRecorder) Write(b []byte) (int, error) {
 }
 
 type AdminAPI struct {
-	log           *slog.Logger
-	cfg           ConfigProvider
-	sm            SessionManagerProvider
-	turnStore     TurnStatsProvider
-	hub           HubProvider
-	bridge        BridgeProvider
-	configWatcher ConfigWatcherProvider
-	cron          CronSchedulerProvider
-	botLister     BotListerProvider
-	botConfig     BotConfigProvider
-	logCollector  LogCollector
-	akStore       APIKeyUserStorer // nil when DB resolver not enabled
-	keyValidator  KeyValidator     // nil when not injected
-	rateLimiter   atomic.Value     // *simpleRateLimiter
-	allowedCIDRs  atomic.Value     // []string
-	version       func() string
-	newSessionID  func() string
-	restart       func() error
-	startedAt     time.Time
+	log              *slog.Logger
+	cfg              ConfigProvider
+	sm               SessionManagerProvider
+	turnStore        TurnStatsProvider
+	hub              HubProvider
+	bridge           BridgeProvider
+	configWatcher    ConfigWatcherProvider
+	cron             CronSchedulerProvider
+	botLister        BotListerProvider
+	botConfig        BotConfigProvider
+	logCollector     LogCollector
+	akStore          APIKeyUserStorer // nil when DB resolver not enabled
+	keyValidator     KeyValidator     // nil when not injected
+	rateLimiter      atomic.Value     // *simpleRateLimiter
+	allowedCIDRs     atomic.Value     // []string
+	allowedOriginsFn func() []string  // returns allowed CORS origins from config
+	version          func() string
+	newSessionID     func() string
+	restart          func() error
+	startedAt        time.Time
 }
 
 type Deps struct {
-	Log           *slog.Logger
-	Config        ConfigProvider
-	SessionMgr    SessionManagerProvider
-	TurnStats     TurnStatsProvider
-	Hub           HubProvider
-	Bridge        BridgeProvider
-	ConfigWatcher ConfigWatcherProvider
-	Cron          CronSchedulerProvider
-	BotLister     BotListerProvider
-	BotConfig     BotConfigProvider
-	LogCollector  LogCollector
-	Version       func() string
-	NewSessionID  func() string
-	Restart       func() error
-	DB            DBExecutor       // Optional: enables API key user CRUD + DB resolver
-	DBResolver    cacheInvalidator // Optional: invalidates DBResolver cache after CUD
-	WriteMu       *sqlutil.WriteMu // Optional: serializes SQLite writes; nil-safe, PG-safe
-	APIKeyStore   APIKeyUserStorer // Optional: pre-built store (e.g. PG); overrides DB-based creation
-	KeyValidator  KeyValidator     // Optional: syncs DB keys into auth layer for Phase 1 validation
+	Log              *slog.Logger
+	Config           ConfigProvider
+	SessionMgr       SessionManagerProvider
+	TurnStats        TurnStatsProvider
+	Hub              HubProvider
+	Bridge           BridgeProvider
+	ConfigWatcher    ConfigWatcherProvider
+	Cron             CronSchedulerProvider
+	BotLister        BotListerProvider
+	BotConfig        BotConfigProvider
+	LogCollector     LogCollector
+	Version          func() string
+	NewSessionID     func() string
+	Restart          func() error
+	AllowedOriginsFn func() []string  // Optional: returns allowed CORS origins; defaults to ["*"] when nil
+	DB               DBExecutor       // Optional: enables API key user CRUD + DB resolver
+	DBResolver       cacheInvalidator // Optional: invalidates DBResolver cache after CUD
+	WriteMu          *sqlutil.WriteMu // Optional: serializes SQLite writes; nil-safe, PG-safe
+	APIKeyStore      APIKeyUserStorer // Optional: pre-built store (e.g. PG); overrides DB-based creation
+	KeyValidator     KeyValidator     // Optional: syncs DB keys into auth layer for Phase 1 validation
 }
 
 func New(deps Deps) *AdminAPI {
@@ -165,6 +168,12 @@ func New(deps Deps) *AdminAPI {
 		newSessionID: deps.NewSessionID,
 		restart:      deps.Restart,
 		startedAt:    time.Now(),
+		allowedOriginsFn: func() []string {
+			if deps.AllowedOriginsFn != nil {
+				return deps.AllowedOriginsFn()
+			}
+			return []string{"*"}
+		},
 	}
 	return a
 }
@@ -188,7 +197,7 @@ func (a *AdminAPI) Middleware(next http.Handler) http.Handler {
 			)
 		}()
 
-		addCORSHeaders(sw)
+		security.SetCORSHeaders(sw, a.allowedOriginsFn(), r.Header.Get("Origin"))
 		if r.Method == http.MethodOptions {
 			sw.WriteHeader(http.StatusOK)
 			return

--- a/internal/admin/handlers_test.go
+++ b/internal/admin/handlers_test.go
@@ -459,15 +459,57 @@ func TestMiddleware_IPWhitelist(t *testing.T) {
 }
 
 func TestMiddleware_CORS(t *testing.T) {
-	api := newTestAPI()
-	handler := api.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodOptions, "/", nil)
+	t.Parallel()
 
-	handler.ServeHTTP(w, r)
+	t.Run("default wildcard allows all origins", func(t *testing.T) {
+		t.Parallel()
+		api := newTestAPI()
+		handler := api.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodOptions, "/", nil)
 
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+		handler.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("specific origin matches request", func(t *testing.T) {
+		t.Parallel()
+		api := newTestAPI(func(d *Deps) {
+			d.AllowedOriginsFn = func() []string {
+				return []string{"https://admin.example.com"}
+			}
+		})
+		handler := api.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodOptions, "/", nil)
+		r.Header.Set("Origin", "https://admin.example.com")
+
+		handler.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "https://admin.example.com", w.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, "Origin", w.Header().Get("Vary"))
+	})
+
+	t.Run("non-matching origin gets no CORS headers", func(t *testing.T) {
+		t.Parallel()
+		api := newTestAPI(func(d *Deps) {
+			d.AllowedOriginsFn = func() []string {
+				return []string{"https://admin.example.com"}
+			}
+		})
+		handler := api.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodOptions, "/", nil)
+		r.Header.Set("Origin", "https://evil.com")
+
+		handler.ServeHTTP(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+	})
 }
 
 func TestMiddleware_PanicRecovery(t *testing.T) {

--- a/internal/admin/sessions.go
+++ b/internal/admin/sessions.go
@@ -8,12 +8,6 @@ import (
 	"github.com/hrygo/hotplex/pkg/events"
 )
 
-func addCORSHeaders(w http.ResponseWriter) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Api-Key")
-}
-
 // CreateSession creates a new session.
 //
 // @Summary      Create session

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -685,6 +685,11 @@ type SecurityConfig struct {
 	// (localhost-friendly). Set this when serving from a remote host — the
 	// browser blocks fetch/ws/connect calls that do not match a directive in CSP.
 	CSP string `mapstructure:"csp"`
+
+	// SecurityContact enables /.well-known/security.txt (RFC 9116) when non-empty.
+	// Examples: "mailto:security@example.com", "https://example.com/security".
+	// Overridable via HOTPLEX_SECURITY_SECURITY_CONTACT env var.
+	SecurityContact string `mapstructure:"security_contact"`
 }
 
 // SessionConfig holds session lifecycle settings.
@@ -817,11 +822,12 @@ func Default() *Config {
 			},
 		},
 		Security: SecurityConfig{
-			APIKeyHeader:   "X-API-Key",
-			APIKeys:        nil,
-			TLSEnabled:     false,
-			AllowedOrigins: []string{"*"},
-			CSP:            "", // empty → webchat/docs use package-level default
+			APIKeyHeader:    "X-API-Key",
+			APIKeys:         nil,
+			TLSEnabled:      false,
+			AllowedOrigins:  []string{"*"},
+			CSP:             "", // empty → webchat/docs use package-level default
+			SecurityContact: "",
 		},
 		Session: SessionConfig{
 			RetentionPeriod:   7 * 24 * time.Hour,
@@ -1074,6 +1080,8 @@ func Load(filePath string) (*Config, error) {
 	_ = v.BindEnv("worker.opencode_server.password")
 	_ = v.BindEnv("security.api_key_header")
 	_ = v.BindEnv("security.csp")
+	_ = v.BindEnv("security.allowed_origins")
+	_ = v.BindEnv("security.security_contact")
 	_ = v.BindEnv("agent_config.enabled")
 	_ = v.BindEnv("agent_config.config_dir")
 	_ = v.BindEnv("skills.cache_ttl")

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -16,20 +16,21 @@ import (
 // without requiring a restart. All other fields are treated as static.
 // Format: "TopLevel.NestedField" (matches mapstructure tags).
 var hotReloadableFields = map[string]bool{
-	"log.level":                true,
-	"session.gc_scan_interval": true,
-	"pool.max_size":            true,
-	"pool.max_idle_per_user":   true,
-	"security.api_keys":        true,
-	"security.allowed_origins": true,
-	"worker.max_lifetime":      true,
-	"worker.idle_timeout":      true,
-	"worker.execution_timeout": true,
-	"worker.auto_retry":        true,
-	"admin.requests_per_sec":   true,
-	"admin.burst":              true,
-	"admin.tokens":             true,
-	"admin.allowed_cidrs":      true,
+	"log.level":                 true,
+	"session.gc_scan_interval":  true,
+	"pool.max_size":             true,
+	"pool.max_idle_per_user":    true,
+	"security.api_keys":         true,
+	"security.allowed_origins":  true,
+	"security.security_contact": true,
+	"worker.max_lifetime":       true,
+	"worker.idle_timeout":       true,
+	"worker.execution_timeout":  true,
+	"worker.auto_retry":         true,
+	"admin.requests_per_sec":    true,
+	"admin.burst":               true,
+	"admin.tokens":              true,
+	"admin.allowed_cidrs":       true,
 }
 
 // staticFields are config fields that require a restart to take effect.

--- a/internal/security/cors.go
+++ b/internal/security/cors.go
@@ -29,7 +29,7 @@ func ResolveOrigin(requestOrigin string, allowedOrigins []string) string {
 //   - Access-Control-Allow-Origin: the matched origin (or "*" for wildcard)
 //   - Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS
 //   - Access-Control-Allow-Headers: Content-Type, Authorization, X-Api-Key
-//   - Vary: Origin (prevents cache poisoning when origin-specific)
+//   - Vary: Origin (prevents cache poisoning when origin-specific; omitted for wildcard)
 //
 // OPTIONS requests receive a 200 response without calling the next handler.
 func CORSMiddleware(originsFn func() []string) func(http.Handler) http.Handler {
@@ -64,9 +64,15 @@ func SetCORSHeaders(w http.ResponseWriter, allowedOrigins []string, requestOrigi
 
 // writeCORSHeaders writes the standard CORS response headers for the given
 // resolved origin value.
+//
+// Vary: Origin is only set in echo-back mode (origin != "*") to avoid
+// degrading CDN cache efficiency in wildcard mode where the response is
+// identical for all origins.
 func writeCORSHeaders(w http.ResponseWriter, origin string) {
 	w.Header().Set("Access-Control-Allow-Origin", origin)
 	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Api-Key")
-	w.Header().Set("Vary", "Origin")
+	if origin != "*" {
+		w.Header().Set("Vary", "Origin")
+	}
 }

--- a/internal/security/cors.go
+++ b/internal/security/cors.go
@@ -1,0 +1,72 @@
+package security
+
+import "net/http"
+
+// ResolveOrigin determines the Access-Control-Allow-Origin header value
+// based on the request's Origin and the configured allowed origins list.
+//
+//   - If the list contains "*", returns "*" (backward-compatible wildcard mode).
+//   - If the request Origin exactly matches an entry, returns that Origin
+//     (echo-back mode for production with specific domains).
+//   - Otherwise returns "" (no CORS headers → browser blocks the request).
+func ResolveOrigin(requestOrigin string, allowedOrigins []string) string {
+	for _, o := range allowedOrigins {
+		if o == "*" {
+			return "*"
+		}
+		if o == requestOrigin {
+			return requestOrigin
+		}
+	}
+	return ""
+}
+
+// CORSMiddleware returns an HTTP middleware that injects CORS response headers
+// and handles OPTIONS preflight requests. The originsFn function is called on
+// every request so that config hot-reload takes effect immediately.
+//
+// When the resolved origin is non-empty, the following headers are set:
+//   - Access-Control-Allow-Origin: the matched origin (or "*" for wildcard)
+//   - Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS
+//   - Access-Control-Allow-Headers: Content-Type, Authorization, X-Api-Key
+//   - Vary: Origin (prevents cache poisoning when origin-specific)
+//
+// OPTIONS requests receive a 200 response without calling the next handler.
+func CORSMiddleware(originsFn func() []string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			allowed := ResolveOrigin(origin, originsFn())
+			if allowed != "" {
+				writeCORSHeaders(w, allowed)
+			}
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// SetCORSHeaders sets CORS response headers without handling OPTIONS.
+// Use this in middleware chains that have their own OPTIONS handling
+// (e.g. the admin API middleware).
+//
+// When allowedOrigins contains "*" or the request Origin matches an entry,
+// the CORS headers are written. Otherwise no headers are set.
+func SetCORSHeaders(w http.ResponseWriter, allowedOrigins []string, requestOrigin string) {
+	allowed := ResolveOrigin(requestOrigin, allowedOrigins)
+	if allowed != "" {
+		writeCORSHeaders(w, allowed)
+	}
+}
+
+// writeCORSHeaders writes the standard CORS response headers for the given
+// resolved origin value.
+func writeCORSHeaders(w http.ResponseWriter, origin string) {
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Api-Key")
+	w.Header().Set("Vary", "Origin")
+}

--- a/internal/security/cors_test.go
+++ b/internal/security/cors_test.go
@@ -99,7 +99,7 @@ func TestCORSMiddleware(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, rec.Code)
 		require.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
-		require.Equal(t, "Origin", rec.Header().Get("Vary"))
+		require.Empty(t, rec.Header().Get("Vary"), "wildcard should not set Vary: Origin")
 		require.Equal(t, "GET, POST, PUT, PATCH, DELETE, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
 		require.Equal(t, "Content-Type, Authorization, X-Api-Key", rec.Header().Get("Access-Control-Allow-Headers"))
 	})
@@ -197,21 +197,22 @@ func TestCORSMiddleware(t *testing.T) {
 func TestSetCORSHeaders(t *testing.T) {
 	t.Parallel()
 
-	t.Run("wildcard sets all headers", func(t *testing.T) {
+	t.Run("wildcard sets headers without Vary", func(t *testing.T) {
 		t.Parallel()
 		rec := httptest.NewRecorder()
 		SetCORSHeaders(rec, []string{"*"}, "https://any.com")
 
 		require.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
-		require.Equal(t, "Origin", rec.Header().Get("Vary"))
+		require.Empty(t, rec.Header().Get("Vary"), "wildcard should not set Vary: Origin")
 	})
 
-	t.Run("matching origin sets headers", func(t *testing.T) {
+	t.Run("matching origin sets headers with Vary", func(t *testing.T) {
 		t.Parallel()
 		rec := httptest.NewRecorder()
 		SetCORSHeaders(rec, []string{"https://app.example.com"}, "https://app.example.com")
 
 		require.Equal(t, "https://app.example.com", rec.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, "Origin", rec.Header().Get("Vary"), "echo-back mode must set Vary: Origin")
 	})
 
 	t.Run("non-matching origin sets no headers", func(t *testing.T) {

--- a/internal/security/cors_test.go
+++ b/internal/security/cors_test.go
@@ -1,0 +1,232 @@
+package security
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveOrigin(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		requestOrigin string
+		allowed       []string
+		want          string
+	}{
+		{
+			name:          "wildcard allows any origin",
+			requestOrigin: "https://evil.com",
+			allowed:       []string{"*"},
+			want:          "*",
+		},
+		{
+			name:          "exact match echoes origin",
+			requestOrigin: "https://app.example.com",
+			allowed:       []string{"https://app.example.com"},
+			want:          "https://app.example.com",
+		},
+		{
+			name:          "no match returns empty",
+			requestOrigin: "https://evil.com",
+			allowed:       []string{"https://app.example.com"},
+			want:          "",
+		},
+		{
+			name:          "empty allowed list returns empty",
+			requestOrigin: "https://app.example.com",
+			allowed:       nil,
+			want:          "",
+		},
+		{
+			name:          "wildcard in mixed list wins",
+			requestOrigin: "https://random.com",
+			allowed:       []string{"https://ok.com", "*"},
+			want:          "*",
+		},
+		{
+			name:          "empty request origin no match",
+			requestOrigin: "",
+			allowed:       []string{"https://app.example.com"},
+			want:          "",
+		},
+		{
+			name:          "empty request origin with wildcard",
+			requestOrigin: "",
+			allowed:       []string{"*"},
+			want:          "*",
+		},
+		{
+			name:          "multiple origins exact match",
+			requestOrigin: "https://admin.example.com",
+			allowed:       []string{"https://app.example.com", "https://admin.example.com"},
+			want:          "https://admin.example.com",
+		},
+		{
+			name:          "multiple origins no match",
+			requestOrigin: "https://evil.com",
+			allowed:       []string{"https://app.example.com", "https://admin.example.com"},
+			want:          "",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveOrigin(tt.requestOrigin, tt.allowed)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCORSMiddleware(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wildcard preserves backward compat", func(t *testing.T) {
+		t.Parallel()
+		mw := CORSMiddleware(func() []string { return []string{"*"} })
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+		req.Header.Set("Origin", "https://any.com")
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, "Origin", rec.Header().Get("Vary"))
+		require.Equal(t, "GET, POST, PUT, PATCH, DELETE, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
+		require.Equal(t, "Content-Type, Authorization, X-Api-Key", rec.Header().Get("Access-Control-Allow-Headers"))
+	})
+
+	t.Run("matching origin echoes back with Vary", func(t *testing.T) {
+		t.Parallel()
+		mw := CORSMiddleware(func() []string {
+			return []string{"https://app.example.com", "https://admin.example.com"}
+		})
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+		req.Header.Set("Origin", "https://admin.example.com")
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "https://admin.example.com", rec.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, "Origin", rec.Header().Get("Vary"))
+	})
+
+	t.Run("non-matching origin gets no CORS headers", func(t *testing.T) {
+		t.Parallel()
+		mw := CORSMiddleware(func() []string {
+			return []string{"https://app.example.com"}
+		})
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+		req.Header.Set("Origin", "https://evil.com")
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("OPTIONS returns 200 without calling next", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		mw := CORSMiddleware(func() []string { return []string{"*"} })
+		inner := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		})
+		req := httptest.NewRequest(http.MethodOptions, "/api/sessions", nil)
+		req.Header.Set("Origin", "https://any.com")
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.False(t, called, "OPTIONS should not call next handler")
+		require.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("empty origins list gets no CORS headers", func(t *testing.T) {
+		t.Parallel()
+		mw := CORSMiddleware(func() []string { return nil })
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+		req.Header.Set("Origin", "https://any.com")
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("no Origin header gets no CORS headers for specific origins", func(t *testing.T) {
+		t.Parallel()
+		mw := CORSMiddleware(func() []string {
+			return []string{"https://app.example.com"}
+		})
+		inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+		// No Origin header set
+		rec := httptest.NewRecorder()
+
+		mw(inner).ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+}
+
+func TestSetCORSHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wildcard sets all headers", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		SetCORSHeaders(rec, []string{"*"}, "https://any.com")
+
+		require.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, "Origin", rec.Header().Get("Vary"))
+	})
+
+	t.Run("matching origin sets headers", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		SetCORSHeaders(rec, []string{"https://app.example.com"}, "https://app.example.com")
+
+		require.Equal(t, "https://app.example.com", rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("non-matching origin sets no headers", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		SetCORSHeaders(rec, []string{"https://app.example.com"}, "https://evil.com")
+
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("empty origins sets no headers", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		SetCORSHeaders(rec, nil, "https://any.com")
+
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+}

--- a/internal/security/csp.go
+++ b/internal/security/csp.go
@@ -19,14 +19,16 @@ const DefaultWebChatCSP = "default-src 'self'; " +
 	"img-src 'self' data: blob:; " +
 	"font-src 'self' data:"
 
-// DefaultDocsCSP is the fallback CSP for the self-hosted docs portal. It is
-// the same scheme-wide-open connect-src as the webchat default, plus jsDelivr
-// for scripts. Scalar API Reference loads web fonts from fonts.scalar.com.
-// Google Fonts have been localized (served from 'self').
+// DefaultDocsCSP is the fallback CSP for the self-hosted docs portal.
+// connect-src is restricted to 'self' only: the docs portal fetches the
+// OpenAPI spec and makes API Console "Try It" calls to the same origin.
+// Fonts loaded via CSS @font-face are governed by font-src, not connect-src.
+// Scripts loaded via <script> are governed by script-src, not connect-src.
+// Operators needing broader connectivity can override via security.csp.
 const DefaultDocsCSP = "default-src 'self'; " +
 	"script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; " +
 	"style-src 'self' 'unsafe-inline'; " +
-	"connect-src 'self' http: https: ws: wss: data: blob:; " +
+	"connect-src 'self'; " +
 	"img-src 'self' data: blob:; " +
 	"font-src 'self' data: https://cdn.jsdelivr.net https://fonts.scalar.com"
 

--- a/internal/security/headers_test.go
+++ b/internal/security/headers_test.go
@@ -110,3 +110,21 @@ func TestSecurityHeaders(t *testing.T) {
 		require.Equal(t, strict, rec.Header().Get("Content-Security-Policy"))
 	})
 }
+
+func TestDefaultDocsCSP_NotPermissive(t *testing.T) {
+	t.Parallel()
+	// After tightening, docs CSP should NOT contain permissive connect-src
+	// (no bare http:/https:/ws:/wss: scheme keywords).
+	require.False(t, IsPermissiveCSP(DefaultDocsCSP),
+		"DefaultDocsCSP connect-src should be restricted to 'self' only")
+	// Verify connect-src 'self' is present (not accidentally removed).
+	require.Contains(t, DefaultDocsCSP, "connect-src 'self';")
+}
+
+func TestDefaultWebChatCSP_IsPermissive(t *testing.T) {
+	t.Parallel()
+	// WebChat CSP intentionally keeps permissive connect-src for WebSocket
+	// connections to the gateway (ws:/wss: scheme keywords).
+	require.True(t, IsPermissiveCSP(DefaultWebChatCSP),
+		"DefaultWebChatCSP should remain permissive for zero-config remote deployments")
+}

--- a/internal/security/securitytxt.go
+++ b/internal/security/securitytxt.go
@@ -1,0 +1,35 @@
+package security
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// SecurityTxtHandler returns an HTTP handler for /.well-known/security.txt
+// (RFC 9116). The contactFn function is called on every request so that config
+// hot-reload takes effect immediately.
+//
+// When contactFn returns an empty string, the handler responds with 404
+// (security.txt is only advertised when explicitly configured).
+//
+// No domains or contact information is hardcoded — all values come from
+// the security.contact config field or HOTPLEX_SECURITY_SECURITY_CONTACT env var.
+func SecurityTxtHandler(contactFn func() string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		contact := contactFn()
+		if contact == "" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("Cache-Control", "public, max-age=86400")
+
+		_, _ = io.WriteString(w, "# HotPlex Security Policy\n")
+		_, _ = fmt.Fprintf(w, "Contact: %s\n", contact)
+		_, _ = io.WriteString(w, "Preferred-Languages: zh, en\n")
+		_, _ = fmt.Fprintf(w, "Expires: %s\n", time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
+	})
+}

--- a/internal/security/securitytxt_test.go
+++ b/internal/security/securitytxt_test.go
@@ -1,0 +1,80 @@
+package security
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecurityTxtHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns 404 when contact is empty", func(t *testing.T) {
+		t.Parallel()
+		handler := SecurityTxtHandler(func() string { return "" })
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/security.txt", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("returns security.txt with contact", func(t *testing.T) {
+		t.Parallel()
+		handler := SecurityTxtHandler(func() string { return "mailto:security@example.com" })
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/security.txt", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "text/plain; charset=utf-8", rec.Header().Get("Content-Type"))
+		body := rec.Body.String()
+		require.Contains(t, body, "Contact: mailto:security@example.com")
+		require.Contains(t, body, "Preferred-Languages: zh, en")
+		require.Contains(t, body, "Expires:")
+	})
+
+	t.Run("sets cache control for 24 hours", func(t *testing.T) {
+		t.Parallel()
+		handler := SecurityTxtHandler(func() string { return "mailto:sec@example.com" })
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/security.txt", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Header().Get("Cache-Control"), "max-age=86400")
+	})
+
+	t.Run("accepts URL contact", func(t *testing.T) {
+		t.Parallel()
+		handler := SecurityTxtHandler(func() string {
+			return "https://example.com/security-policy"
+		})
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/security.txt", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Body.String(), "Contact: https://example.com/security-policy")
+	})
+
+	t.Run("does not hardcode any domain", func(t *testing.T) {
+		t.Parallel()
+		handler := SecurityTxtHandler(func() string { return "mailto:custom@test.org" })
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/security.txt", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		body := rec.Body.String()
+		// No hardcoded domains should appear
+		require.False(t, strings.Contains(body, "hotplex.com") || strings.Contains(body, "hrygo.com"))
+	})
+}


### PR DESCRIPTION
## Summary

Three security hardening improvements for the gateway HTTP layer.

### 1. Configurable CORS Origins
- Replace hardcoded `Access-Control-Allow-Origin: *` with config-driven origin allowlist
- Support hot-reload via `security.allowed_origins` (YAML) or `HOTPLEX_SECURITY_ALLOWED_ORIGINS` (env)
- Production: pin specific domains; dev: wildcard `["*"]` (default, backward-compatible)
- Echo-back mode: matched origin returned with `Vary: Origin` to prevent cache poisoning
- Startup WARN log when wildcard is in effect

### 2. Tighten Docs Portal CSP
- Restrict `DefaultDocsCSP` `connect-src` from `http: https: ws: wss: data: blob:` → `self` only
- Docs portal only needs same-origin fetches (OpenAPI spec + API Console "Try It")
- Font/script loading unaffected (governed by `font-src`/`script-src`, not `connect-src`)

### 3. RFC 9116 security.txt
- Add `/.well-known/security.txt` endpoint, disabled by default
- Enabled when `security.security_contact` is set (YAML/env)
- No hardcoded domains — all contact info from config
- 24h cache, auto-generated expiry date

## Files Changed (14)

| File | Change |
|------|--------|
| `cmd/hotplex/routes.go` | CORS middleware integration + security.txt route |
| `configs/config.yaml` | `allowed_origins` + `security_contact` config + comments |
| `configs/env.example` | Env var documentation for new fields |
| `internal/admin/admin.go` | `AllowedOriginsFn` dep injection |
| `internal/admin/sessions.go` | Remove old `addCORSHeaders` helper |
| `internal/admin/handlers_test.go` | CORS middleware tests (wildcard/match/reject) |
| `internal/config/config.go` | `SecurityContact` field + env binding |
| `internal/config/watcher.go` | Hot-reload: `security.security_contact` |
| `internal/security/cors.go` | `ResolveOrigin` + `CORSMiddleware` + `SetCORSHeaders` |
| `internal/security/cors_test.go` | 232 lines: ResolveOrigin + middleware + header tests |
| `internal/security/csp.go` | Tighten `DefaultDocsCSP` connect-src |
| `internal/security/headers_test.go` | CSP permissiveness assertions |
| `internal/security/securitytxt.go` | RFC 9116 handler |
| `internal/security/securitytxt_test.go` | 80 lines: 404/contact/cache/url/no-hardcode tests |

## Test Plan

- [x] `make check` passes (fmt + lint + vet + build + test)
- [x] Table-driven tests for `ResolveOrigin` (9 cases)
- [x] `CORSMiddleware` integration tests (6 scenarios)
- [x] `SetCORSHeaders` unit tests (4 cases)
- [x] `SecurityTxtHandler` tests (5 cases including no-hardcode assertion)
- [x] CSP permissiveness regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #666

Refs #672