### PR TITLE
feat(worker): reload agent config on /reset via SystemPromptUpdater

### DIFF
--- a/internal/agentconfig/META-COGNITION.md
+++ b/internal/agentconfig/META-COGNITION.md
@@ -80,8 +80,8 @@ HotPlex 配置加载 **完全没有继承关系**，遵循**命中即终止 (Hit
 
 ## 5. 工程限制与安全边界
 
-*   **规模限制**：单文件最大 **8KB**，单会话总加载最大 **40KB**。YAML frontmatter 在网关层自动剔除（不占 Token），但修改时须保持格式正确。
-*   **热加载限制**：配置仅在会话初始化（或 `/reset`）时载入。运行中修改不会立即生效，须等待 Session 重启或手动 `/reset`。
+*   **规模限制**：单文件最大 **8000 字符**，单会话总加载最大 **40000 字符**。YAML frontmatter 在网关层自动剔除（不占 Token），但修改时须保持格式正确。
+*   **热加载限制**：配置仅在会话初始化（或 `/reset`）时载入。运行中修改不会立即生效，须等待 Session 重启或手动 `/reset`（注：OCS Worker 暂不支持，见 #664）。
 *   **XML 注入安全 (XML Sanitizer)**：
     配置装载层强制开启 XML Sanitizer，所有保留标签（包含 `agent-configuration`, `directives`, `context`, `persona`, `rules`, `skills`, `user`, `memory`, `hotplex`, `notice`）在装配拼入系统提示词时均会被自动转义。请勿在回复或配置文件中试图通过拼凑这些标签来篡改系统行为。
 

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -436,6 +436,20 @@ func (b *Bridge) ResetSession(ctx context.Context, sessionID string) error {
 		rg.IncResetGeneration()
 	}
 
+	// Reload agent config so the worker's next session picks up file changes.
+	if si, err := b.sm.Get(ctx, sessionID); err == nil {
+		if su, ok := w.(worker.SystemPromptUpdater); ok {
+			info := &worker.SessionInfo{SystemPrompt: ""}
+			b.injectAgentConfig(info, si.Platform, si.BotID, nil)
+			if info.SystemPrompt != "" {
+				su.UpdateSystemPrompt(info.SystemPrompt)
+				b.log.Info("bridge: reset reloaded agent config",
+					"session_id", sessionID, "platform", si.Platform, "bot_id", si.BotID,
+					"prompt_len", len(info.SystemPrompt))
+			}
+		}
+	}
+
 	// Worker-level reset: Terminate → delete session files → Start fresh.
 	if err := w.ResetContext(ctx); err != nil {
 		if !errors.Is(err, worker.ErrNotImplemented) {

--- a/internal/gateway/bridge_test.go
+++ b/internal/gateway/bridge_test.go
@@ -667,3 +667,81 @@ func TestBuildWorkerInfo_MCPInjection(t *testing.T) {
 		})
 	}
 }
+
+// ─── Test ResetSession Reloads Agent Config ──────────────────────────────────
+
+// mockPromptUpdater is a mockBridgeWorker that also implements SystemPromptUpdater.
+type mockPromptUpdater struct {
+	mockBridgeWorker
+	updatedPrompt string
+}
+
+func (m *mockPromptUpdater) UpdateSystemPrompt(prompt string) {
+	m.updatedPrompt = prompt
+}
+
+var _ worker.SystemPromptUpdater = (*mockPromptUpdater)(nil)
+
+func TestResetSession_ReloadsAgentConfig(t *testing.T) {
+	t.Parallel()
+
+	// Set up agent config dir with a SOUL.md
+	dir := t.TempDir()
+	writeAgentConfigFile(t, dir, "SOUL.md", "Updated persona v2.")
+
+	hub := newTestHub(t)
+	sm := new(mockBridgeSM)
+	b := NewBridge(BridgeDeps{
+		Log:            slog.Default(),
+		Hub:            hub,
+		SM:             sm,
+		AgentConfigDir: dir,
+	})
+
+	sid := "test-reset-reload-session"
+	mw := &mockPromptUpdater{}
+
+	sm.On("GetWorker", sid).Return(mw)
+	sm.On("Get", sid).Return(&session.SessionInfo{
+		ID:       sid,
+		Platform: "webchat",
+		BotID:    "bot-1",
+	}, nil)
+
+	err := b.ResetSession(context.Background(), sid)
+	require.NoError(t, err)
+
+	assert.Contains(t, mw.updatedPrompt, "Updated persona v2.")
+	sm.AssertExpectations(t)
+}
+
+func TestResetSession_NoUpdater_NoReload(t *testing.T) {
+	t.Parallel()
+
+	// Set up agent config dir so we can verify it's NOT used when worker lacks SystemPromptUpdater.
+	dir := t.TempDir()
+	writeAgentConfigFile(t, dir, "SOUL.md", "Should not appear.")
+
+	hub := newTestHub(t)
+	sm := new(mockBridgeSM)
+	b := NewBridge(BridgeDeps{
+		Log:            slog.Default(),
+		Hub:            hub,
+		SM:             sm,
+		AgentConfigDir: dir,
+	})
+
+	sid := "test-no-updater"
+	mw := &mockBridgeWorker{} // does NOT implement SystemPromptUpdater
+
+	sm.On("GetWorker", sid).Return(mw)
+	sm.On("Get", sid).Return(&session.SessionInfo{
+		ID:       sid,
+		Platform: "webchat",
+	}, nil)
+
+	err := b.ResetSession(context.Background(), sid)
+	require.NoError(t, err)
+	// No crash, no panic — worker without SystemPromptUpdater is silently skipped.
+	sm.AssertExpectations(t)
+}

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -634,6 +634,17 @@ func (w *Worker) supportsCapability(name string) bool {
 	return true
 }
 
+// ─── UpdateSystemPrompt ──────────────────────────────────────────────────
+
+// UpdateSystemPrompt replaces the stored system prompt and resets the injection
+// flag so the next user input in the new ACP session carries the reloaded config.
+func (w *Worker) UpdateSystemPrompt(prompt string) {
+	w.Mu.Lock()
+	w.systemPrompt = prompt
+	w.Mu.Unlock()
+	w.systemPromptInjected.Store(false)
+}
+
 // ─── ResetContext ────────────────────────────────────────────────────────────
 
 func (w *Worker) ResetContext(ctx context.Context) error {

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -492,6 +492,14 @@ func (w *Worker) SendControlRequest(ctx context.Context, subtype string, body ma
 	return ctrl.SendControlRequest(ctx, subtype, body)
 }
 
+// UpdateSystemPrompt updates the stored origSession.SystemPrompt so that
+// the next ResetContext uses the reloaded agent config.
+func (w *Worker) UpdateSystemPrompt(prompt string) {
+	w.Mu.Lock()
+	w.origSession.SystemPrompt = prompt
+	w.Mu.Unlock()
+}
+
 func (w *Worker) LastIO() time.Time {
 	return w.BaseWorker.LastIO()
 }

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -854,6 +854,14 @@ func (w *AppServerWorker) Health() worker.WorkerHealth {
 	return w.BaseWorker.Health(worker.TypeCodexCLI)
 }
 
+// UpdateSystemPrompt updates the stored origSession.SystemPrompt so that
+// the next ResetContext uses the reloaded agent config.
+func (w *AppServerWorker) UpdateSystemPrompt(prompt string) {
+	w.mu.Lock()
+	w.origSession.SystemPrompt = prompt
+	w.mu.Unlock()
+}
+
 func (w *AppServerWorker) LastIO() time.Time {
 	return w.BaseWorker.LastIO()
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -172,6 +172,16 @@ type WorkerSessionIDHandler interface {
 	GetWorkerSessionID() string
 }
 
+// SystemPromptUpdater is an optional interface for workers that support
+// updating their stored system prompt at runtime (e.g. during /reset).
+// Workers that do not implement this interface will continue using the
+// system prompt from their initial Start() call.
+// Bridge detects implementations via type assertion and calls this before
+// ResetContext so the worker's next session uses the reloaded agent config.
+type SystemPromptUpdater interface {
+	UpdateSystemPrompt(prompt string)
+}
+
 // SessionInfo contains metadata about a session needed by the worker to start/resume.
 type SessionInfo struct {
 	SessionID    string


### PR DESCRIPTION
## Problem

`/reset` 只清对话历史，不重新加载 `~/.hotplex/agent-configs/` 下的配置文件。用户修改 SOUL.md 等后必须等 session 超时回收才能生效。

## Solution

新增 `worker.SystemPromptUpdater` 可选接口，`Bridge.ResetSession` 在调 `ResetContext` 前重载 agent config 并通过该接口传递新 prompt。

### 改动

| 文件 | 说明 |
|------|------|
| `worker/worker.go` | +`SystemPromptUpdater` 接口 |
| `worker/claudecode/worker.go` | +`UpdateSystemPrompt()` — 更新 `origSession.SystemPrompt` |
| `worker/codexcli/worker.go` | +`UpdateSystemPrompt()` — 更新 `origSession.SystemPrompt` |
| `worker/acp/worker.go` | +`UpdateSystemPrompt()` — 更新 `w.systemPrompt` + 重置注入 flag |
| `gateway/bridge.go` | `ResetSession` 中重载配置 + type assertion |
| `gateway/bridge_test.go` | +2 测试覆盖 |
| `agentconfig/META-COGNITION.md` | 8KB → 8000 字符（精度修正）|

### OCS 不在此 PR

OCS 的 `/session/{id}/reset` API 不接受 system prompt 参数，需扩展 OCS API 或走 Terminate+Start fallback。跟踪在 #664。

## Test

```
make quality  # fmt + lint + test -race 全量通过
```