### PR TITLE
fix(config): expand ~ in watcher path to fix fsnotify failure

### DIFF
--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -105,6 +105,10 @@ func NewWatcher(log *slog.Logger, path string, store *ConfigStore, onChange func
 	if log == nil {
 		log = slog.Default()
 	}
+	// Expand ~ and make absolute so fsnotify can resolve the directory.
+	if expanded, err := ExpandAndAbs(path); err == nil {
+		path = expanded
+	}
 	return &Watcher{
 		log:           log,
 		path:          path,


### PR DESCRIPTION
## 问题

`hotplex gateway start` 启动时日志报：

```
WARN config: watcher start failed — no such file or directory
```

## 根因

`NewWatcher` 收到 `~/.hotplex/config.yaml`（含未展开的 `~`），`fsnotify.Add` 不认识波浪号，导致 watcher 无法启动，配置热重载静默失效。

## 修复

在 `NewWatcher` 构造时调用 `ExpandAndAbs` 将路径展开为绝对路径，与 `loadConfig` 的行为保持一致。

**修复前**：`path = "~/.hotplex/config.yaml"` → fsnotify 报错
**修复后**：`path = "/home/user/.hotplex/config.yaml"` → watcher 正常启动

## 验证

```
INFO config: watcher started  path=/home/hotplex/.hotplex/config.yaml
```