### PR TITLE
fix(config): expand ~ in watcher path to fix fsnotify no such file

### DIFF
--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -105,6 +105,10 @@ func NewWatcher(log *slog.Logger, path string, store *ConfigStore, onChange func
 	if log == nil {
 		log = slog.Default()
 	}
+	// Expand ~ and make absolute so fsnotify can resolve the directory.
+	if expanded, err := ExpandAndAbs(path); err == nil {
+		path = expanded
+	}
 	return &Watcher{
 		log:           log,
 		path:          path,


### PR DESCRIPTION
## Summary

Config watcher 使用 `~` 前缀路径时，fsnotify 无法解析目录导致 `no such file or directory` 错误。

## Changes

- `internal/config/watcher.go`: `NewWatcher` 入口处调用 `ExpandAndAbs` 展开 `~` 并转为绝对路径

## Testing

- 全量测试通过 (pre-push gate)
- lint / vet / build 均通过