### PR TITLE
fix: batch fix for issues #667, #670, #671

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -651,58 +651,64 @@ func cleanupStaleTempFiles(log *slog.Logger) {
 		}
 	}
 
-	// Clean media directory: remove files older than 24h (aligns with Slack TTL).
-	if entries, err := os.ReadDir(mediaDir); err == nil {
-		cutoff := time.Now().Add(-24 * time.Hour)
-		for _, e := range entries {
-			if e.IsDir() {
-				continue
-			}
-			info, err := e.Info()
-			if err != nil {
-				continue
-			}
-			if info.ModTime().Before(cutoff) {
-				p := filepath.Join(mediaDir, e.Name())
-				if err := os.Remove(p); err == nil {
-					cleaned++
-				}
+	// Clean media directory: recursive walk to remove files older than 24h.
+	// Adapter-owned subdirectories (e.g., "slack/") are also cleaned here at
+	// startup; the adapters' periodic goroutines handle ongoing maintenance.
+	cutoff := time.Now().Add(-24 * time.Hour)
+	_ = filepath.Walk(mediaDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() && info.ModTime().Before(cutoff) {
+			if removeErr := os.Remove(path); removeErr == nil {
+				cleaned++
 			}
 		}
-	}
+		return nil
+	})
 
 	// Also scan legacy temp files scattered in os.TempDir() root (pre-unification).
-	cleaned += cleanupLegacyTempFiles(log)
+	cleaned += cleanupLegacyTempFiles()
 
 	if cleaned > 0 {
 		log.Info("gateway: cleaned stale temp files", "count", cleaned)
 	}
 }
 
-// cleanupLegacyTempFiles scans the system temp dir root for hotplex temp files
-// from before the unified worker/ subdirectory was introduced.
-func cleanupLegacyTempFiles(_ *slog.Logger) int {
-	tmpDir := os.TempDir()
+// cleanupLegacyTempFiles scans for hotplex temp files from before the unified
+// worker/ subdirectory was introduced. Searches both /tmp (hardcoded path used
+// by the old TempBaseDir) and os.TempDir() (in case TMPDIR was overridden).
+func cleanupLegacyTempFiles() int {
+	// Pre-unification files were created by os.CreateTemp("", ...) which uses
+	// os.TempDir(). On stock Linux this is /tmp, but TMPDIR overrides change it.
+	// Search both /tmp and os.TempDir() to cover all cases.
+	searchDirs := []string{"/tmp"}
+	if td := os.TempDir(); td != "/tmp" {
+		searchDirs = append(searchDirs, td)
+	}
 	patterns := []string{
 		"hotplex-append-system-prompt-*",
 		"hotplex-mcp-config-*",
 		"hotplex-system-prompt-*",
+		"hotplex-update-*",
 	}
 	cutoff := time.Now().Add(-2 * time.Hour)
 	cleaned := 0
-	for _, pattern := range patterns {
-		matches, err := filepath.Glob(filepath.Join(tmpDir, pattern))
-		if err != nil {
-			continue
-		}
-		for _, p := range matches {
-			info, err := os.Stat(p)
+	for _, dir := range searchDirs {
+		for _, pattern := range patterns {
+			matches, err := filepath.Glob(filepath.Join(dir, pattern))
 			if err != nil {
 				continue
 			}
-			if info.ModTime().Before(cutoff) {
-				if err := os.Remove(p); err == nil {
-					cleaned++
+			for _, p := range matches {
+				info, err := os.Stat(p)
+				if err != nil {
+					continue
+				}
+				if info.ModTime().Before(cutoff) {
+					if err := os.Remove(p); err == nil {
+						cleaned++
+					}
 				}
 			}
 		}

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -115,6 +115,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 
 	log, cfgStore, levelVar := initLogging(cfg)
 	pidTracker, cleanupWG := initOrphanCleanup(ctx, cfg, log)
+	cleanupStaleTempFiles(log)
 
 	obsCfg := observability.DefaultConfig()
 	obsCfg.ServiceVersion = versionString()
@@ -619,6 +620,94 @@ func initLogging(cfg *config.Config) (*slog.Logger, *config.ConfigStore, *slog.L
 	slog.SetDefault(log)
 
 	return log, cfgStore, levelVar
+}
+
+// cleanupStaleTempFiles removes orphaned temp files from previous gateway runs.
+// Files younger than 2 hours are preserved (may be in active use by a worker
+// from a previous process that hasn't terminated yet).
+func cleanupStaleTempFiles(log *slog.Logger) {
+	baseDir := config.TempBaseDir()
+	workerDir := filepath.Join(baseDir, "worker")
+	mediaDir := filepath.Join(baseDir, "media")
+
+	// Clean worker temp directory: remove files older than 2h.
+	cleaned := 0
+	if entries, err := os.ReadDir(workerDir); err == nil {
+		cutoff := time.Now().Add(-2 * time.Hour)
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			if info.ModTime().Before(cutoff) {
+				p := filepath.Join(workerDir, e.Name())
+				if err := os.Remove(p); err == nil {
+					cleaned++
+				}
+			}
+		}
+	}
+
+	// Clean media directory: remove files older than 24h (aligns with Slack TTL).
+	if entries, err := os.ReadDir(mediaDir); err == nil {
+		cutoff := time.Now().Add(-24 * time.Hour)
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			if info.ModTime().Before(cutoff) {
+				p := filepath.Join(mediaDir, e.Name())
+				if err := os.Remove(p); err == nil {
+					cleaned++
+				}
+			}
+		}
+	}
+
+	// Also scan legacy temp files scattered in os.TempDir() root (pre-unification).
+	cleaned += cleanupLegacyTempFiles(log)
+
+	if cleaned > 0 {
+		log.Info("gateway: cleaned stale temp files", "count", cleaned)
+	}
+}
+
+// cleanupLegacyTempFiles scans the system temp dir root for hotplex temp files
+// from before the unified worker/ subdirectory was introduced.
+func cleanupLegacyTempFiles(_ *slog.Logger) int {
+	tmpDir := os.TempDir()
+	patterns := []string{
+		"hotplex-append-system-prompt-*",
+		"hotplex-mcp-config-*",
+		"hotplex-system-prompt-*",
+	}
+	cutoff := time.Now().Add(-2 * time.Hour)
+	cleaned := 0
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Join(tmpDir, pattern))
+		if err != nil {
+			continue
+		}
+		for _, p := range matches {
+			info, err := os.Stat(p)
+			if err != nil {
+				continue
+			}
+			if info.ModTime().Before(cutoff) {
+				if err := os.Remove(p); err == nil {
+					cleaned++
+				}
+			}
+		}
+	}
+	return cleaned
 }
 
 func initOrphanCleanup(ctx context.Context, cfg *config.Config, log *slog.Logger) (*proc.Tracker, *sync.WaitGroup) {

--- a/internal/cli/checkers/config.go
+++ b/internal/cli/checkers/config.go
@@ -167,19 +167,53 @@ func (c configRequiredChecker) Check(ctx context.Context) cli.Diagnostic {
 	var missing []string
 
 	if cfg.Messaging.Slack.Enabled {
-		if cfg.Messaging.Slack.BotToken == "" {
-			missing = append(missing, "messaging.slack.bot_token")
-		}
-		if cfg.Messaging.Slack.AppToken == "" {
-			missing = append(missing, "messaging.slack.app_token")
+		if len(cfg.Messaging.Slack.Bots) > 0 {
+			// Multi-bot mode: check each bot's credentials.
+			for i, bot := range cfg.Messaging.Slack.Bots {
+				prefix := fmt.Sprintf("messaging.slack.bots[%d]", i)
+				if bot.Name != "" {
+					prefix = fmt.Sprintf("messaging.slack.bots[%q]", bot.Name)
+				}
+				if bot.BotToken == "" {
+					missing = append(missing, prefix+".bot_token")
+				}
+				if bot.AppToken == "" {
+					missing = append(missing, prefix+".app_token")
+				}
+			}
+		} else {
+			// Single-bot mode: check top-level credentials.
+			if cfg.Messaging.Slack.BotToken == "" {
+				missing = append(missing, "messaging.slack.bot_token")
+			}
+			if cfg.Messaging.Slack.AppToken == "" {
+				missing = append(missing, "messaging.slack.app_token")
+			}
 		}
 	}
 	if cfg.Messaging.Feishu.Enabled {
-		if cfg.Messaging.Feishu.AppID == "" {
-			missing = append(missing, "messaging.feishu.app_id")
-		}
-		if cfg.Messaging.Feishu.AppSecret == "" {
-			missing = append(missing, "messaging.feishu.app_secret")
+		if len(cfg.Messaging.Feishu.Bots) > 0 {
+			// Multi-bot mode: check each bot's credentials.
+			for i, bot := range cfg.Messaging.Feishu.Bots {
+				prefix := fmt.Sprintf("messaging.feishu.bots[%d]", i)
+				if bot.Name != "" {
+					prefix = fmt.Sprintf("messaging.feishu.bots[%q]", bot.Name)
+				}
+				if bot.AppID == "" {
+					missing = append(missing, prefix+".app_id")
+				}
+				if bot.AppSecret == "" {
+					missing = append(missing, prefix+".app_secret")
+				}
+			}
+		} else {
+			// Single-bot mode: check top-level credentials.
+			if cfg.Messaging.Feishu.AppID == "" {
+				missing = append(missing, "messaging.feishu.app_id")
+			}
+			if cfg.Messaging.Feishu.AppSecret == "" {
+				missing = append(missing, "messaging.feishu.app_secret")
+			}
 		}
 	}
 	if !cfg.Messaging.Slack.Enabled && !cfg.Messaging.Feishu.Enabled {

--- a/internal/cli/checkers/config_test.go
+++ b/internal/cli/checkers/config_test.go
@@ -318,3 +318,91 @@ func TestConfigRequired_EmptyPath(t *testing.T) {
 
 	require.Equal(t, cli.StatusFail, d.Status)
 }
+
+func TestConfigRequired_FeishuMultiBotAllPresent(t *testing.T) {
+	// t.Setenv — cannot use t.Parallel.
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	dbDir := filepath.Join(dir, "data")
+	require.NoError(t, os.MkdirAll(dbDir, 0o755))
+	t.Setenv("HOTPLEX_MESSAGING_FEISHU_APP_SECRET", "")
+	t.Setenv("BOT1_SECRET", "secret1")
+	t.Setenv("BOT2_SECRET", "secret2")
+	content := "gateway:\n  addr: \":8888\"\nadmin:\n  addr: \":9999\"\n  enabled: true\ndb:\n  path: \"" + filepath.Join(dbDir, "test.db") + "\"\nmessaging:\n  feishu:\n    enabled: true\n    bots:\n      - name: hephaestus\n        app_id: \"cli_a954eab23678dbb5\"\n        app_secret: \"${BOT1_SECRET}\"\n      - name: bailaoban\n        app_id: \"cli_a934ebe1a2b81bb3\"\n        app_secret: \"${BOT2_SECRET}\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	defer resetConfigPath()
+	SetConfigPath(path)
+
+	c := configRequiredChecker{}
+	d := c.Check(context.Background())
+
+	require.Equal(t, cli.StatusPass, d.Status, "multi-bot feishu with all credentials should pass, got: %s", d.Detail)
+}
+
+func TestConfigRequired_FeishuMultiBotMissingCredential(t *testing.T) {
+	// t.Setenv — cannot use t.Parallel.
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	dbDir := filepath.Join(dir, "data")
+	require.NoError(t, os.MkdirAll(dbDir, 0o755))
+	// bot1 has app_id but no app_secret; bot2 is complete.
+	content := "gateway:\n  addr: \":8888\"\nadmin:\n  addr: \":9999\"\n  enabled: true\ndb:\n  path: \"" + filepath.Join(dbDir, "test.db") + "\"\nmessaging:\n  feishu:\n    enabled: true\n    bots:\n      - name: hephaestus\n        app_id: \"cli_a954eab23678dbb5\"\n      - name: bailaoban\n        app_id: \"cli_a934ebe1a2b81bb3\"\n        app_secret: \"secret2\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	defer resetConfigPath()
+	SetConfigPath(path)
+
+	c := configRequiredChecker{}
+	d := c.Check(context.Background())
+
+	require.Equal(t, cli.StatusFail, d.Status)
+	require.Contains(t, d.Detail, `bots["hephaestus"].app_secret`)
+}
+
+func TestConfigRequired_SlackMultiBotAllPresent(t *testing.T) {
+	// t.Setenv — cannot use t.Parallel.
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	dbDir := filepath.Join(dir, "data")
+	require.NoError(t, os.MkdirAll(dbDir, 0o755))
+	t.Setenv("SLACK_BOT1_TOKEN", "xoxb-1")
+	t.Setenv("SLACK_BOT1_APP", "xapp-1")
+	t.Setenv("SLACK_BOT2_TOKEN", "xoxb-2")
+	t.Setenv("SLACK_BOT2_APP", "xapp-2")
+	content := "gateway:\n  addr: \":8888\"\nadmin:\n  addr: \":9999\"\n  enabled: true\ndb:\n  path: \"" + filepath.Join(dbDir, "test.db") + "\"\nmessaging:\n  slack:\n    enabled: true\n    bots:\n      - name: primary\n        bot_token: \"${SLACK_BOT1_TOKEN}\"\n        app_token: \"${SLACK_BOT1_APP}\"\n      - name: secondary\n        bot_token: \"${SLACK_BOT2_TOKEN}\"\n        app_token: \"${SLACK_BOT2_APP}\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	defer resetConfigPath()
+	SetConfigPath(path)
+
+	c := configRequiredChecker{}
+	d := c.Check(context.Background())
+
+	require.Equal(t, cli.StatusPass, d.Status, "multi-bot slack with all credentials should pass, got: %s", d.Detail)
+}
+
+func TestConfigRequired_SlackMultiBotMissingCredential(t *testing.T) {
+	// t.Setenv — cannot use t.Parallel.
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	dbDir := filepath.Join(dir, "data")
+	require.NoError(t, os.MkdirAll(dbDir, 0o755))
+	// bot1 missing app_token.
+	t.Setenv("SLACK_BOT1_TOKEN", "xoxb-1")
+	content := "gateway:\n  addr: \":8888\"\nadmin:\n  addr: \":9999\"\n  enabled: true\ndb:\n  path: \"" + filepath.Join(dbDir, "test.db") + "\"\nmessaging:\n  slack:\n    enabled: true\n    bots:\n      - name: primary\n        bot_token: \"${SLACK_BOT1_TOKEN}\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	defer resetConfigPath()
+	SetConfigPath(path)
+
+	c := configRequiredChecker{}
+	d := c.Check(context.Background())
+
+	require.Equal(t, cli.StatusFail, d.Status)
+	require.Contains(t, d.Detail, `bots["primary"].app_token`)
+}

--- a/internal/config/paths_unix.go
+++ b/internal/config/paths_unix.go
@@ -2,5 +2,11 @@
 
 package config
 
+import (
+	"os"
+	"path/filepath"
+)
+
 // TempBaseDir returns the base directory for temporary HotPlex files.
-func TempBaseDir() string { return "/tmp/hotplex" }
+// Uses os.TempDir() to respect TMPDIR overrides instead of hardcoding /tmp.
+func TempBaseDir() string { return filepath.Join(os.TempDir(), "hotplex") }

--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -93,6 +93,11 @@ func (e *Executor) Execute(ctx context.Context, job *CronJob, timeout time.Durat
 
 	err := e.waitForCompletion(ctx, sessionKey, timeout)
 
+	if err != nil {
+		e.log.Error("cron executor: session execution failed",
+			"session_id", sessionKey, "timeout", timeout, "err", err)
+	}
+
 	// Explicitly terminate the session to ensure the worker process exits immediately.
 	// We use context.Background() with a short timeout to ensure termination happens
 	// even if the original context is canceled.

--- a/internal/cron/timer.go
+++ b/internal/cron/timer.go
@@ -293,9 +293,12 @@ func (s *Scheduler) finishExecution(job *CronJob, startedAtMs int64, err error, 
 
 	if err != nil {
 		s.log.Error("cron: job execution failed",
-			"job_id", job.ID, "name", job.Name, "err", err)
+			"job_id", job.ID, "name", job.Name, "error_type", errType, "err", err)
 		job.State.LastStatus = StatusFailed
 		job.State.ConsecutiveErrs++
+		s.log.Info("cron: error state recorded",
+			"job_id", job.ID, "name", job.Name,
+			"last_status", job.State.LastStatus, "consecutive_errors", job.State.ConsecutiveErrs)
 		observability.CronErrors().Add(s.ctx, 1, metric.WithAttributes(attribute.String("job_name", job.Name), attribute.String("error_type", errType)))
 
 		if job.State.ConsecutiveErrs >= maxConsecutiveErrors {

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -6,6 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -13,6 +16,7 @@ import (
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	"github.com/larksuite/oapi-sdk-go/v3/ws"
 
+	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/messaging/phrases"
 	"github.com/hrygo/hotplex/internal/messaging/stt"
@@ -131,6 +135,7 @@ func (a *Adapter) Start(ctx context.Context) error {
 
 	a.Log.Info("feishu: starting WebSocket connection")
 	go a.runWebSocket(ctx)
+	go a.cleanupMedia(ctx)
 
 	return nil
 }
@@ -372,4 +377,45 @@ func extractTextFromContent(content string) string {
 		return ""
 	}
 	return tc.Text
+}
+
+const (
+	feishuMediaCleanupInterval = 6 * time.Hour
+	feishuMediaTTL             = 24 * time.Hour
+)
+
+// cleanupMedia periodically removes old media files downloaded from Feishu.
+// This aligns with the Slack adapter's media cleanup behavior.
+func (a *Adapter) cleanupMedia(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			a.Log.Error("feishu: panic in cleanupMedia", "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
+	ticker := time.NewTicker(feishuMediaCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			a.cleanupMediaInDir(filepath.Join(config.TempBaseDir(), "media"))
+		}
+	}
+}
+
+func (a *Adapter) cleanupMediaInDir(dir string) {
+	a.Log.Debug("feishu: cleaning up media files", "dir", dir)
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() && time.Since(info.ModTime()) > feishuMediaTTL {
+			if err := os.Remove(path); err != nil {
+				a.Log.Warn("feishu: failed to remove old media file", "path", path, "err", err)
+			}
+		}
+		return nil
+	})
 }

--- a/internal/messaging/feishu/adapter.go
+++ b/internal/messaging/feishu/adapter.go
@@ -384,14 +384,22 @@ const (
 	feishuMediaTTL             = 24 * time.Hour
 )
 
+// feishuMediaSubdirs lists the media subdirectories owned by the Feishu adapter.
+// This excludes adapter-owned subdirectories like "slack/" to prevent cross-adapter cleanup.
+var feishuMediaSubdirs = []string{"images", "files", "audios", "videos", "stickers"}
+
 // cleanupMedia periodically removes old media files downloaded from Feishu.
-// This aligns with the Slack adapter's media cleanup behavior.
+// Only cleans Feishu-owned subdirectories to avoid interfering with the Slack adapter's cleanup.
 func (a *Adapter) cleanupMedia(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
 			a.Log.Error("feishu: panic in cleanupMedia", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
+
+	// Run immediate cleanup on startup to handle stale files from previous runs.
+	a.doCleanupMedia()
+
 	ticker := time.NewTicker(feishuMediaCleanupInterval)
 	defer ticker.Stop()
 
@@ -400,8 +408,15 @@ func (a *Adapter) cleanupMedia(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			a.cleanupMediaInDir(filepath.Join(config.TempBaseDir(), "media"))
+			a.doCleanupMedia()
 		}
+	}
+}
+
+func (a *Adapter) doCleanupMedia() {
+	mediaBase := filepath.Join(config.TempBaseDir(), "media")
+	for _, sub := range feishuMediaSubdirs {
+		a.cleanupMediaInDir(filepath.Join(mediaBase, sub))
 	}
 }
 

--- a/internal/worker/claudecode/worker.go
+++ b/internal/worker/claudecode/worker.go
@@ -952,12 +952,17 @@ func (w *Worker) nextSeq() int64 {
 // writeTempFile writes content to a temp file and tracks it for cleanup.
 // Returns the absolute path to the file. The file is deleted in cleanupTempFiles
 // which is called from Terminate.
+// Files are created under config.TempBaseDir()/worker/ for unified cleanup.
 func (w *Worker) writeTempFile(prefix, content string) (string, error) {
 	ext := ".txt"
 	if prefix == "mcp-config" {
 		ext = ".json"
 	}
-	f, err := os.CreateTemp("", "hotplex-"+prefix+"-*"+ext)
+	dir := filepath.Join(config.TempBaseDir(), "worker")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create worker temp dir: %w", err)
+	}
+	f, err := os.CreateTemp(dir, "hotplex-"+prefix+"-*"+ext)
 	if err != nil {
 		return "", fmt.Errorf("create temp file: %w", err)
 	}


### PR DESCRIPTION
## Summary

Batch fix for three issues discovered during production operation.

### Fix #671: doctor config.required 多 bot 误报

`config.required` checker now recognizes `bots[]` multi-bot configurations. When bots array is present, credentials are checked per-bot instead of top-level fields. Applies to both Slack and Feishu platforms.

### Fix #667: cron timeout 未记录到 job state

Enhanced timeout error observability:
- Added explicit error logging in `executor.Execute` when `waitForCompletion` returns timeout
- Added `error_type` field and state confirmation logging in `finishExecution` for easier diagnosis

### Fix #670: 孤儿临时文件清理 + 统一临时目录

Three improvements:
- **`paths_unix.go`**: Use `os.TempDir()` instead of hardcoded `/tmp` (respects `TMPDIR` override)
- **`writeTempFile`**: Worker temp files now created under `$TMPDIR/hotplex/worker/` subdirectory
- **`cleanupStaleTempFiles`**: Gateway startup scans and removes orphaned temp files (>2h for worker, >24h for media)
- **Feishu adapter**: Added periodic media cleanup goroutine (24h TTL, 6h scan interval) aligned with Slack adapter behavior

## Files Changed (8 files, +289/-13)

| File | Change |
|------|--------|
| `internal/cli/checkers/config.go` | Multi-bot credential validation |
| `internal/cli/checkers/config_test.go` | 4 new test cases for multi-bot |
| `internal/config/paths_unix.go` | `os.TempDir()` replaces hardcoded `/tmp` |
| `internal/cron/executor.go` | Timeout error logging |
| `internal/cron/timer.go` | Error state observability |
| `internal/worker/claudecode/worker.go` | Unified temp dir (`$TMPDIR/hotplex/worker/`) |
| `cmd/hotplex/gateway_run.go` | Startup orphan cleanup |
| `internal/messaging/feishu/adapter.go` | Media cleanup goroutine |

## Verification

- `make check` — all quality gates passed (lint + test + build)
- Pre-push hooks — formatting, lint, vet, build, tests all green

Closes #667, Closes #670, Closes #671