### PR TITLE
docs(patrol): 2026-06-07 文档维护

### DIFF
--- a/docs/explanation/agent-config-system.md
+++ b/docs/explanation/agent-config-system.md
@@ -55,12 +55,12 @@ HotPlex 将所有配置分为两个通道，使用 XML 嵌套表达结构性优�
 每个配置文件通过 3 级 fallback 独立查找：
 
 ```
-1. dir/{platform}/{botID}/{file}   -- Bot 级（最高优先级）
+1. dir/{platform}/{botName}/{file} -- Bot 级（最高优先级）
 2. dir/{platform}/{file}           -- 平台级
 3. dir/{file}                      -- 全局级
 ```
 
-找到文件就停止，**不会合并多个层级**。
+找到文件就停止，**不会合并多个层级**。`botName` 是 YAML 配置中的 `bots[].name` 字段（如 `"my-bot"`），而非平台运行时 ID。单 Bot 模式下 `botName` 为空，Bot 级查找被跳过，直接从平台级开始解析。
 
 **为什么不用继承（合并所有层级）？**
 
@@ -89,13 +89,13 @@ META-COGNITION 定义了 Worker 的**身份边界**——明确告知 Agent "你
 
 ### 配置加载流程
 
-`Load(dir, platform, botID, injectExclude...)` 的完整执行路径：
+`Load(dir, platform, botName, injectExclude...)` 的完整执行路径：
 
 ```
-1. 路径安全检查：filepath.Base(botID) == botID（防止路径穿越）
+1. 路径安全检查：ValidateBotName(botName)（防止路径穿越）
 2. 逐文件加载（SOUL → AGENTS → SKILLS → USER → MEMORY）：
    a. 检查 injectExclude：如文件名在排除列表中，跳过加载
-   b. 调用 resolveFile(dir, platform, botID, fileName)
+   b. 调用 resolveFile(dir, platform, botName, fileName)
    c. 按三级 fallback 查找文件
    d. 读取文件内容，剥离 YAML frontmatter
    e. 检查单文件大小限制（MaxFileChars = 8000 字符）

--- a/docs/explanation/session-lifecycle.md
+++ b/docs/explanation/session-lifecycle.md
@@ -243,7 +243,7 @@ if ms.info.State == RUNNING && ms.worker != nil {
 ### 并发安全边界
 
 - **锁顺序必须严格遵守**：`Manager.mu -> managedSession.mu`，违反此顺序会死锁。
-- **Worker.Terminate() 在 ms.mu 持有时调用**：这是安全的，因为 Terminate 只使用 syscall.Kill，不获取任何 Session Manager 锁。
+- **Worker.Terminate() 必须在 ms.mu 释放后调用**：`transitionState` 返回需要终止的 Worker 引用，由调用方在锁外执行 Terminate。这是为了避免 Terminate 阻塞（进程优雅关闭可能耗时数秒）期间锁住所有并发读操作（Get、GetWorker），导致 Session 永久无响应（#655）。
 - **callback 调用（OnTerminate、StateNotifier）在独立 goroutine 中执行**：防止用户回调阻塞 GC 循环。
 
 ## 参考

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -363,7 +363,7 @@ Agent B/C 通道配置加载器。
 
 **C 通道**（`<context>`）：`USER.md` + `MEMORY.md`
 
-**三级 fallback**：全局 → 平台（slack/） → Bot（slack/U12345/），每文件独立解析，命中即终止。
+**三级 fallback**：全局 → 平台（slack/） → Bot（slack/{botName}/），每文件独立解析，命中即终止。Bot 级目录名使用 YAML 配置中 `bots[].name` 的值。
 
 ---
 
@@ -545,7 +545,7 @@ Yuanxin 是基于 Apache Pulsar 的企业消息平台适配器。
 | `stt_*` | — | 覆盖 STT 配置 |
 | `tts_*` | — | 覆盖 TTS 配置 |
 
-**向后兼容**：`normalizeSlackBots()`/`normalizeFeishuBots()` 自动将单 bot 顶层凭证归一化为 `bots: [{name: "default"}]`。`bots[]` 非空时忽略顶层凭证。
+**向后兼容**：`normalizeSlackBots()`/`normalizeFeishuBots()` 自动将单 bot 顶层凭证归一化为 `bots: [{name: ""}]`（空名称，表示单 Bot 模式）。`bots[]` 非空时忽略顶层凭证。
 
 **限制**：每平台最多 10 个 bot。配置变更需重启生效。
 

--- a/docs/tutorials/agent-personality.md
+++ b/docs/tutorials/agent-personality.md
@@ -149,21 +149,31 @@ HotPlex 支持**三级 fallback**，每个文件独立解析，命中即终止�
 ```
 全局级：~/.hotplex/agent-configs/SOUL.md
 平台级：~/.hotplex/agent-configs/slack/SOUL.md
-Bot 级：~/.hotplex/agent-configs/slack/U12345/SOUL.md
+Bot 级：~/.hotplex/agent-configs/slack/my-bot/SOUL.md
 ```
 
-解析顺序：Bot 级 → 平台级 → 全局级，第一个非空文件生效。
+Bot 级目录名使用 YAML 配置中 `bots[].name` 的值（如 `"my-bot"`），而非平台运行时 ID。单 Bot 模式无 Bot 级目录，直接使用平台级。解析顺序：Bot 级 → 平台级 → 全局级，第一个非空文件生效。
 
-### 示例：为特定 Slack Bot 定制人格
+### 示例：为特定 Bot 定制人格
 
-假设 Slack Bot ID 为 `U88888`，给它一个不同的角色：
+假设 YAML 配置中定义了一个名为 `dev-bot` 的 Bot：
+
+```yaml
+messaging:
+  slack:
+    bots:
+      - name: "dev-bot"
+        bot_token: "xoxb-..."
+```
+
+给它一个不同的人格：
 
 ```bash
-mkdir -p ~/.hotplex/agent-configs/slack/U88888
+mkdir -p ~/.hotplex/agent-configs/slack/dev-bot
 ```
 
 ```markdown
-<!-- ~/.hotplex/agent-configs/slack/U88888/SOUL.md -->
+<!-- ~/.hotplex/agent-configs/slack/dev-bot/SOUL.md -->
 
 # 人格
 
@@ -176,12 +186,12 @@ mkdir -p ~/.hotplex/agent-configs/slack/U88888
 - 故障排查时按排查树逐步推进
 ```
 
-此时 `U88888` 使用 DevOps 人格，其他 Bot 仍使用全局 `SOUL.md`。`AGENTS.md`、`USER.md` 等文件同理，各自独立 fallback。
+此时 `dev-bot` 使用 DevOps 人格，其他 Bot 仍使用全局 `SOUL.md`。`AGENTS.md`、`USER.md` 等文件同理，各自独立 fallback。
 
 > **重要**：Bot 级文件存在时（即使是空文件），该 Bot **不会**读取平台级和全局级的同名文件。如需基于全局修改，先复制再编辑：
 >
 > ```bash
-> cp ~/.hotplex/agent-configs/SOUL.md ~/.hotplex/agent-configs/slack/U88888/SOUL.md
+> cp ~/.hotplex/agent-configs/SOUL.md ~/.hotplex/agent-configs/slack/dev-bot/SOUL.md
 > # 然后编辑 Bot 级文件
 > ```
 


### PR DESCRIPTION
## Summary

- **agent-config-system.md**: botID→botName 路径解析迁移，更新 Load 签名、fallback 路径描述、ValidateBotName
- **agent-personality.md**: 示例从 Slack UserID 改为 YAML 配置名，补充单 Bot 模式说明
- **configuration.md**: agent_config 三级 fallback 使用 botName，单 bot 归一化 name="default"→name=""
- **session-lifecycle.md**: Worker.Terminate() 已移至 mutex 外部（#655），修正并发安全边界描述

## 变更窗口

自 950251e 以来 16 个提交，关键变更：PR #678/#679 config name 迁移、PR #656 Terminate mutex 修复。

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)