### PR TITLE
fix(acp): drain pending notifications before sending Done

### DIFF
--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -210,6 +210,7 @@ func TestWatcher_isRelevant(t *testing.T) {
 
 	tmpFile := createTempConfigFile(t)
 	w := NewWatcher(slog.Default(), tmpFile, nil, nil, nil)
+	differentPath := filepath.Join(t.TempDir(), "other.yaml")
 
 	tests := []struct {
 		name     string
@@ -233,7 +234,7 @@ func TestWatcher_isRelevant(t *testing.T) {
 		},
 		{
 			name:     "Write event for different path",
-			event:    fsnotify.Event{Name: "/tmp/other.yaml", Op: fsnotify.Write},
+			event:    fsnotify.Event{Name: differentPath, Op: fsnotify.Write},
 			expected: false,
 		},
 		{

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -337,5 +337,9 @@ func createTempConfigFile(t *testing.T) string {
 	err := os.WriteFile(tmpFile, []byte(content), 0644)
 	require.NoError(t, err)
 
-	return tmpFile
+	// Resolve symlinks so the path matches what NewWatcher stores internally
+	// (NewWatcher calls ExpandAndAbs which runs EvalSymlinks).
+	resolved, err := filepath.EvalSymlinks(tmpFile)
+	require.NoError(t, err)
+	return resolved
 }

--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/hrygo/hotplex/internal/session"
@@ -73,7 +75,7 @@ func (e *Executor) Execute(ctx context.Context, job *CronJob, timeout time.Durat
 		BotName:      job.BotName,
 		WorkerType:   wt,
 		AllowedTools: job.Payload.AllowedTools,
-		WorkDir:      job.WorkDir,
+		WorkDir:      e.resolveWorkDir(job),
 		Platform:     job.Platform,
 		PlatformKey:  platformKey,
 		Title:        title,
@@ -116,6 +118,18 @@ func (e *Executor) Execute(ctx context.Context, job *CronJob, timeout time.Durat
 	}
 
 	return sessionKey, err
+}
+
+// resolveWorkDir computes the working directory for a cron job execution.
+// Webhook-triggered PR reviews get a per-PR directory under the OS temp dir;
+// all other executions (cron fallback, etc.) use the job's static WorkDir.
+func (e *Executor) resolveWorkDir(job *CronJob) string {
+	prNum := job.PlatformKey["pr_number"]
+	if prNum != "" && job.PlatformKey["trigger"] == "webhook" {
+		return filepath.Join(os.TempDir(),
+			fmt.Sprintf("pr-review-%s/pr-%s", time.Now().Format("20060102"), prNum))
+	}
+	return job.WorkDir
 }
 
 func (e *Executor) waitForCompletion(ctx context.Context, sessionID string, timeout time.Duration) error {

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -135,6 +135,15 @@ func (b *Bridge) StartSession(ctx context.Context, p worker.SessionStartParams) 
 		return fmt.Errorf("bridge: rejecting new session during shutdown")
 	}
 
+	// Validate and expand workDir for all callers.
+	if p.WorkDir != "" {
+		expanded, err := validateAndExpandWorkDir(p.WorkDir)
+		if err != nil {
+			return fmt.Errorf("bridge: invalid work dir: %w", err)
+		}
+		p.WorkDir = expanded
+	}
+
 	observability.SessionStartAttempts().Add(ctx, 1, metric.WithAttributes(attribute.String("worker_type", string(p.WorkerType))))
 	start := time.Now()
 	defer func() {

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -225,6 +225,16 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 		return fmt.Errorf("bridge: rejecting resume during shutdown")
 	}
 
+	// Validate workDir for consistency with StartSession.
+	if workDir != "" {
+		expanded, err := validateAndExpandWorkDir(workDir)
+		if err != nil {
+			return fmt.Errorf("bridge: invalid resume work dir: %w", err)
+		}
+		workDir = expanded
+		opts.workDir = expanded
+	}
+
 	si, err := b.sm.Get(ctx, id)
 	if err != nil {
 		return err

--- a/internal/gateway/webhook.go
+++ b/internal/gateway/webhook.go
@@ -62,7 +62,7 @@ type JobTrigger interface {
 const maxConcurrentTriggers = 5
 
 // triggerDedupCooldown prevents duplicate triggers for the same PR within this window.
-const triggerDedupCooldown = 60 * time.Second
+const triggerDedupCooldown = 300 * time.Second
 
 // WebhookHandler handles incoming GitHub webhook requests.
 type WebhookHandler struct {
@@ -197,16 +197,17 @@ func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	jobName := h.cfg.TargetJobName
 	repo := event.Repository.FullName
 	for _, prNum := range prNumbers {
-		// Dedup: skip if the same PR was triggered within the cooldown window.
-		// Key includes repo to avoid cross-repo collision when AllowedRepos is empty.
+		// Dedup: atomically check and mark to prevent TOCTOU race when
+		// check_suite and check_run arrive near-simultaneously.
 		prKey := repo + "#" + strconv.Itoa(prNum)
-		if last, ok := h.dedup.Load(prKey); ok {
-			if t, _ := last.(time.Time); time.Since(t) < triggerDedupCooldown {
+		now := time.Now()
+		if actual, loaded := h.dedup.LoadOrStore(prKey, now); loaded {
+			if t, _ := actual.(time.Time); now.Sub(t) < triggerDedupCooldown {
 				h.log.Info("webhook: skipping duplicate trigger", "pr", prNum)
 				continue
 			}
+			h.dedup.Store(prKey, now)
 		}
-		h.dedup.Store(prKey, time.Now())
 
 		select {
 		case h.sem <- struct{}{}:
@@ -259,41 +260,33 @@ func (h *WebhookHandler) verifySignature(payload []byte, sig string) bool {
 }
 
 // extractPRs returns PR numbers that need review based on event type and action.
+// Only check_suite and check_run events are handled — pull_request events are
+// ignored to prevent triggering before CI completes (issue #662).
 func (h *WebhookHandler) extractPRs(eventType string, e *GitHubEvent) []int {
 	switch eventType {
-	case "pull_request":
-		if e.PullRequest == nil || e.PullRequest.State != "open" || e.PullRequest.Draft {
-			return nil
-		}
-		switch e.Action {
-		case "opened", "synchronize", "reopened", "ready_for_review":
-			return []int{e.PullRequest.Number}
-		}
-
 	case "check_suite":
 		if e.CheckSuite == nil || e.CheckSuite.Conclusion != "success" {
 			return nil
 		}
-		// NOTE: check_suite/check_run PullRequests may include draft or already-merged
-		// PRs (GitHub associates suites with commits, not PR state). We intentionally
-		// don't filter here — the downstream agent's CI gate will skip irrelevant PRs.
-		prs := make([]int, 0, len(e.CheckSuite.PullRequests))
-		for _, pr := range e.CheckSuite.PullRequests {
-			prs = append(prs, pr.Number)
-		}
-		return prs
-
+		return extractPRNumbers(e.CheckSuite.PullRequests)
 	case "check_run":
 		if e.CheckRun == nil || e.CheckRun.Conclusion != "success" || e.CheckRun.CheckSuite == nil {
 			return nil
 		}
-		prs := make([]int, 0, len(e.CheckRun.CheckSuite.PullRequests))
-		for _, pr := range e.CheckRun.CheckSuite.PullRequests {
-			prs = append(prs, pr.Number)
-		}
-		return prs
+		return extractPRNumbers(e.CheckRun.CheckSuite.PullRequests)
 	}
 	return nil
+}
+
+// extractPRNumbers extracts PR numbers from the inline PullRequests structs.
+func extractPRNumbers(prs []struct {
+	Number int `json:"number"`
+}) []int {
+	numbers := make([]int, 0, len(prs))
+	for _, pr := range prs {
+		numbers = append(numbers, pr.Number)
+	}
+	return numbers
 }
 
 // extractRepoFromPing attempts to extract the repository full name from a ping payload.

--- a/internal/gateway/webhook.go
+++ b/internal/gateway/webhook.go
@@ -23,6 +23,8 @@ import (
 )
 
 // GitHubEvent represents the common fields of GitHub webhook payloads.
+// PullRequest fields are retained for JSON deserialization even though
+// extractPRs no longer handles pull_request events (CI-only trigger, #662).
 type GitHubEvent struct {
 	Action     string `json:"action"`
 	Repository struct {

--- a/internal/gateway/webhook_test.go
+++ b/internal/gateway/webhook_test.go
@@ -25,16 +25,6 @@ import (
 
 const testSecret = "test-webhook-secret"
 
-// prDetail is a typed alias for the PullRequest inner struct to avoid repetition.
-type prDetail = struct {
-	Number int    `json:"number"`
-	State  string `json:"state"`
-	Draft  bool   `json:"draft"`
-	Head   struct {
-		SHA string `json:"sha"`
-	} `json:"head"`
-}
-
 // checkSuiteDetail is a typed alias for the CheckSuite inner struct.
 type checkSuiteDetail = struct {
 	Conclusion   string `json:"conclusion"`
@@ -164,54 +154,21 @@ func TestWebhookHandler_ExtractPRs(t *testing.T) {
 
 	h := &WebhookHandler{cfg: config.WebhookConfig{MaxBodySize: 1 << 20}}
 
-	t.Run("draft PR ignored", func(t *testing.T) {
+	t.Run("pull_request ignored (CI-only trigger, #662)", func(t *testing.T) {
 		t.Parallel()
 		e := &GitHubEvent{
-			Action:      "opened",
-			PullRequest: &prDetail{Number: 42, State: "open", Draft: true},
+			Action: "opened",
+			PullRequest: &struct {
+				Number int    `json:"number"`
+				State  string `json:"state"`
+				Draft  bool   `json:"draft"`
+				Head   struct {
+					SHA string `json:"sha"`
+				} `json:"head"`
+			}{Number: 42, State: "open"},
 		}
 		prs := h.extractPRs("pull_request", e)
-		require.Empty(t, prs)
-	})
-
-	t.Run("closed PR ignored", func(t *testing.T) {
-		t.Parallel()
-		e := &GitHubEvent{
-			Action:      "closed",
-			PullRequest: &prDetail{Number: 42, State: "closed"},
-		}
-		prs := h.extractPRs("pull_request", e)
-		require.Empty(t, prs)
-	})
-
-	t.Run("opened triggers review", func(t *testing.T) {
-		t.Parallel()
-		e := &GitHubEvent{
-			Action:      "opened",
-			PullRequest: &prDetail{Number: 42, State: "open"},
-		}
-		prs := h.extractPRs("pull_request", e)
-		require.Equal(t, []int{42}, prs)
-	})
-
-	t.Run("synchronize triggers review", func(t *testing.T) {
-		t.Parallel()
-		e := &GitHubEvent{
-			Action:      "synchronize",
-			PullRequest: &prDetail{Number: 42, State: "open"},
-		}
-		prs := h.extractPRs("pull_request", e)
-		require.Equal(t, []int{42}, prs)
-	})
-
-	t.Run("ready_for_review triggers", func(t *testing.T) {
-		t.Parallel()
-		e := &GitHubEvent{
-			Action:      "ready_for_review",
-			PullRequest: &prDetail{Number: 42, State: "open"},
-		}
-		prs := h.extractPRs("pull_request", e)
-		require.Equal(t, []int{42}, prs)
+		require.Empty(t, prs, "pull_request events should be ignored after #662")
 	})
 
 	t.Run("check_suite success triggers PRs", func(t *testing.T) {
@@ -299,16 +256,6 @@ func TestWebhookHandler_ExtractPRs(t *testing.T) {
 		prs := h.extractPRs("push", &GitHubEvent{})
 		require.Empty(t, prs)
 	})
-
-	t.Run("unknown PR action returns nil", func(t *testing.T) {
-		t.Parallel()
-		e := &GitHubEvent{
-			Action:      "labeled",
-			PullRequest: &prDetail{Number: 42, State: "open"},
-		}
-		prs := h.extractPRs("pull_request", e)
-		require.Empty(t, prs)
-	})
 }
 
 // --- ServeHTTP integration tests ---
@@ -375,14 +322,41 @@ func TestWebhookHandler_ServeHTTP(t *testing.T) {
 		require.Equal(t, 0, trigger.count())
 	})
 
-	t.Run("wrong repo returns 200 without trigger", func(t *testing.T) {
+	t.Run("pull_request ignored (CI-only trigger, #662)", func(t *testing.T) {
 		t.Parallel()
 		h, trigger := newIsolatedHandler(t)
 		w := postWebhook(h, "pull_request", &GitHubEvent{
 			Action: "opened",
 			Repository: struct {
 				FullName string `json:"full_name"`
+			}{FullName: "hrygo/hotplex"},
+			PullRequest: &struct {
+				Number int    `json:"number"`
+				State  string `json:"state"`
+				Draft  bool   `json:"draft"`
+				Head   struct {
+					SHA string `json:"sha"`
+				} `json:"head"`
+			}{Number: 99, State: "open"},
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, 0, trigger.count(), "pull_request events should not trigger review")
+	})
+
+	t.Run("wrong repo returns 200 without trigger", func(t *testing.T) {
+		t.Parallel()
+		h, trigger := newIsolatedHandler(t)
+		w := postWebhook(h, "check_suite", &GitHubEvent{
+			Action: "completed",
+			Repository: struct {
+				FullName string `json:"full_name"`
 			}{FullName: "other/repo"},
+			CheckSuite: &checkSuiteDetail{
+				Conclusion: "success",
+				PullRequests: []struct {
+					Number int `json:"number"`
+				}{{Number: 42}},
+			},
 		})
 		require.Equal(t, http.StatusOK, w.Code)
 		require.Equal(t, 0, trigger.count())
@@ -392,70 +366,40 @@ func TestWebhookHandler_ServeHTTP(t *testing.T) {
 		t.Parallel()
 		trigger := &mockTrigger{}
 		cfg := testWebhookConfig()
-		cfg.AllowedRepos = nil // no filter
+		cfg.AllowedRepos = nil
 		h := NewWebhookHandler(context.Background(), cfg, trigger, noopLogger())
 		t.Cleanup(func() { h.Close() })
-		w := postWebhook(h, "pull_request", &GitHubEvent{
-			Action: "opened",
+		w := postWebhook(h, "check_suite", &GitHubEvent{
+			Action: "completed",
 			Repository: struct {
 				FullName string `json:"full_name"`
 			}{FullName: "any/repo"},
-			PullRequest: &prDetail{Number: 10, State: "open"},
+			CheckSuite: &checkSuiteDetail{
+				Conclusion: "success",
+				PullRequests: []struct {
+					Number int `json:"number"`
+				}{{Number: 10}},
+			},
 		})
 		require.Equal(t, http.StatusAccepted, w.Code)
 		require.Eventually(t, func() bool { return trigger.count() >= 1 }, 2*time.Second, 50*time.Millisecond)
-	})
-
-	t.Run("valid PR opened triggers review", func(t *testing.T) {
-		t.Parallel()
-		h, trigger := newIsolatedHandler(t)
-		w := postWebhook(h, "pull_request", &GitHubEvent{
-			Action: "opened",
-			Repository: struct {
-				FullName string `json:"full_name"`
-			}{
-				FullName: "hrygo/hotplex",
-			},
-			PullRequest: &prDetail{Number: 99, State: "open"},
-		})
-		require.Equal(t, http.StatusAccepted, w.Code)
-
-		require.Eventually(t, func() bool { return trigger.count() >= 1 }, 2*time.Second, 50*time.Millisecond)
-		require.Equal(t, "webhook", trigger.getLastExtra()["trigger"])
-		require.Equal(t, "99", trigger.getLastExtra()["pr_number"])
-	})
-
-	t.Run("draft PR does not trigger", func(t *testing.T) {
-		t.Parallel()
-		h, trigger := newIsolatedHandler(t)
-		w := postWebhook(h, "pull_request", &GitHubEvent{
-			Action: "opened",
-			Repository: struct {
-				FullName string `json:"full_name"`
-			}{
-				FullName: "hrygo/hotplex",
-			},
-			PullRequest: &prDetail{Number: 50, State: "open", Draft: true},
-		})
-		require.Equal(t, http.StatusOK, w.Code) // no PRs extracted → 200
-		require.Equal(t, 0, trigger.count())
 	})
 
 	t.Run("malformed JSON returns 400", func(t *testing.T) {
 		t.Parallel()
 		h, _ := newIsolatedHandler(t)
-		w := postWebhook(h, "pull_request", []byte(`{invalid json`))
+		w := postWebhook(h, "check_suite", []byte(`{invalid json`))
 		require.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
 	t.Run("oversized payload returns 413", func(t *testing.T) {
 		t.Parallel()
 		h, _ := newIsolatedHandler(t)
-		bigPayload := make([]byte, 1<<20+100) // > 1MB
+		bigPayload := make([]byte, 1<<20+100)
 		for i := range bigPayload {
 			bigPayload[i] = 'a'
 		}
-		w := postWebhook(h, "pull_request", bigPayload)
+		w := postWebhook(h, "check_suite", bigPayload)
 		require.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
 	})
 
@@ -466,9 +410,7 @@ func TestWebhookHandler_ServeHTTP(t *testing.T) {
 			Action: "completed",
 			Repository: struct {
 				FullName string `json:"full_name"`
-			}{
-				FullName: "hrygo/hotplex",
-			},
+			}{FullName: "hrygo/hotplex"},
 			CheckSuite: &checkSuiteDetail{
 				Conclusion: "success",
 				HeadSHA:    "abc123",
@@ -489,9 +431,7 @@ func TestWebhookHandler_ServeHTTP(t *testing.T) {
 			Action: "completed",
 			Repository: struct {
 				FullName string `json:"full_name"`
-			}{
-				FullName: "hrygo/hotplex",
-			},
+			}{FullName: "hrygo/hotplex"},
 			CheckRun: &checkRunDetail{
 				Conclusion: "success",
 				CheckSuite: &struct {
@@ -517,9 +457,7 @@ func TestWebhookHandler_ServeHTTP(t *testing.T) {
 			Action: "completed",
 			Repository: struct {
 				FullName string `json:"full_name"`
-			}{
-				FullName: "hrygo/hotplex",
-			},
+			}{FullName: "hrygo/hotplex"},
 			CheckSuite: &checkSuiteDetail{
 				Conclusion: "failure",
 				HeadSHA:    "abc123",
@@ -538,12 +476,77 @@ func TestWebhookHandler_ServeHTTP(t *testing.T) {
 		w := postWebhook(h, "push", &GitHubEvent{
 			Repository: struct {
 				FullName string `json:"full_name"`
-			}{
-				FullName: "hrygo/hotplex",
-			},
+			}{FullName: "hrygo/hotplex"},
 		})
 		require.Equal(t, http.StatusOK, w.Code)
 		require.Equal(t, 0, trigger.count())
+	})
+}
+
+// --- Dedup tests ---
+
+func TestWebhookHandler_Dedup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("concurrent check_suite and check_run trigger once", func(t *testing.T) {
+		t.Parallel()
+		trigger := &mockTrigger{}
+		cfg := testWebhookConfig()
+		cfg.AllowedRepos = nil
+		h := NewWebhookHandler(context.Background(), cfg, trigger, noopLogger())
+		t.Cleanup(func() { h.Close() })
+
+		csPayload := &GitHubEvent{
+			Action: "completed",
+			Repository: struct {
+				FullName string `json:"full_name"`
+			}{FullName: "hrygo/hotplex"},
+			CheckSuite: &checkSuiteDetail{
+				Conclusion: "success",
+				PullRequests: []struct {
+					Number int `json:"number"`
+				}{{Number: 42}},
+			},
+		}
+		crPayload := &GitHubEvent{
+			Action: "completed",
+			Repository: struct {
+				FullName string `json:"full_name"`
+			}{FullName: "hrygo/hotplex"},
+			CheckRun: &checkRunDetail{
+				Conclusion: "success",
+				CheckSuite: &struct {
+					PullRequests []struct {
+						Number int `json:"number"`
+					} `json:"pull_requests"`
+				}{
+					PullRequests: []struct {
+						Number int `json:"number"`
+					}{{Number: 42}},
+				},
+			},
+		}
+
+		// Send both concurrently to stress the dedup atomicity.
+		var wg sync.WaitGroup
+		for range 5 {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				postWebhook(h, "check_suite", csPayload)
+			}()
+			go func() {
+				defer wg.Done()
+				postWebhook(h, "check_run", crPayload)
+			}()
+		}
+		wg.Wait()
+
+		require.Eventually(t, func() bool { return trigger.count() >= 1 }, 3*time.Second, 50*time.Millisecond)
+		// With atomic LoadOrStore dedup, we should see at most 2 triggers
+		// (one from the first LoadOrStore winner, possibly one more from cooldown expiry race).
+		// Without the fix, 10 concurrent requests could trigger 10 times.
+		require.LessOrEqual(t, trigger.count(), 3, "dedup should prevent most duplicate triggers")
 	})
 }
 
@@ -554,7 +557,6 @@ func TestWebhookHandler_RateLimiting(t *testing.T) {
 
 	h, _ := newIsolatedHandler(t)
 
-	// Exhaust burst (10 tokens)
 	var limited int
 	for range 20 {
 		payload := []byte(`{}`)
@@ -583,16 +585,18 @@ func TestWebhookHandler_TriggerError(t *testing.T) {
 	h := NewWebhookHandler(context.Background(), testWebhookConfig(), &errorTrigger{}, noopLogger())
 	t.Cleanup(func() { h.Close() })
 
-	w := postWebhook(h, "pull_request", &GitHubEvent{
-		Action: "opened",
+	w := postWebhook(h, "check_suite", &GitHubEvent{
+		Action: "completed",
 		Repository: struct {
 			FullName string `json:"full_name"`
-		}{
-			FullName: "hrygo/hotplex",
+		}{FullName: "hrygo/hotplex"},
+		CheckSuite: &checkSuiteDetail{
+			Conclusion: "success",
+			PullRequests: []struct {
+				Number int `json:"number"`
+			}{{Number: 1}},
 		},
-		PullRequest: &prDetail{Number: 1, State: "open"},
 	})
-	// HTTP response is 202 even if trigger fails (async)
 	require.Equal(t, http.StatusAccepted, w.Code)
 }
 

--- a/internal/gateway/webhook_test.go
+++ b/internal/gateway/webhook_test.go
@@ -543,9 +543,9 @@ func TestWebhookHandler_Dedup(t *testing.T) {
 		wg.Wait()
 
 		require.Eventually(t, func() bool { return trigger.count() >= 1 }, 3*time.Second, 50*time.Millisecond)
-		// With atomic LoadOrStore dedup, we should see at most 2 triggers
-		// (one from the first LoadOrStore winner, possibly one more from cooldown expiry race).
-		// Without the fix, 10 concurrent requests could trigger 10 times.
+		// With atomic LoadOrStore dedup, concurrent requests for the same PR
+		// should produce at most 1 trigger (the first LoadOrStore winner).
+		// Allow up to 3 for rare races between expired-entry Store and new LoadOrStore.
 		require.LessOrEqual(t, trigger.count(), 3, "dedup should prevent most duplicate triggers")
 	})
 }

--- a/internal/worker/acp/client.go
+++ b/internal/worker/acp/client.go
@@ -245,6 +245,8 @@ func (c *ACPClient) readLoop(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			default:
+				c.log.Warn("acp client: notification channel full, dropping",
+					"method", m.Method, "channel_cap", cap(c.NotificationCh))
 			}
 		case *JSONRPCRequest:
 			select {

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -163,6 +163,12 @@ type Worker struct {
 	conn   *acpConn
 	cancel context.CancelFunc
 
+	// drainCh signals readLoop to drain all buffered notifications from NotificationCh.
+	// drainDoneCh signals back when the drain is complete.
+	// readLoop is the sole consumer of NotificationCh — Input() must not read it directly.
+	drainCh     chan struct{}
+	drainDoneCh chan struct{}
+
 	// pendingPerm stores the permission mapping for in-flight permission requests.
 	pendingPerm sync.Map // requestID (string) → *PermissionMapResult
 
@@ -428,6 +434,9 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 	w.SetConnLocked(nil) // base.Conn not used; acpConn is returned via Conn() override.
 	w.Mu.Unlock()
 
+	w.drainCh = make(chan struct{})
+	w.drainDoneCh = make(chan struct{}, 1)
+
 	// Start worker read loop.
 	go w.readLoop(childCtx)
 
@@ -501,22 +510,18 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 	}
 
 	// Drain pending notifications before sending Done.
-	// Prompt() returns after the JSON-RPC response arrives, but the
-	// readLoop goroutine may still have agent_message_chunk notifications
-	// buffered in NotificationCh. Without draining, Done reaches the
-	// bridge before MessageDelta, resulting in text_len=0.
-	drainTimer := time.NewTimer(200 * time.Millisecond)
-	defer drainTimer.Stop()
-drainLoop:
-	for {
+	// Signal readLoop (the sole consumer of NotificationCh) to flush
+	// any buffered notifications. This avoids a race between Input()
+	// and readLoop competing for NotificationCh.
+	drainCtx, drainCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer drainCancel()
+	select {
+	case w.drainCh <- struct{}{}:
 		select {
-		case n := <-w.client.NotificationCh:
-			w.processNotification(ctx, n, conn)
-		case <-drainTimer.C:
-			break drainLoop
-		default:
-			break drainLoop
+		case <-w.drainDoneCh:
+		case <-drainCtx.Done():
 		}
+	case <-drainCtx.Done():
 	}
 
 	// Emit done sequence.
@@ -894,6 +899,24 @@ func (w *Worker) processNotification(ctx context.Context, notif *JSONRPCNotifica
 	}
 }
 
+// drainNotificationCh empties all buffered notifications from NotificationCh.
+// Called by readLoop in response to a drain signal from Input().
+func (w *Worker) drainNotificationCh(ctx context.Context, conn *acpConn) {
+	for {
+		select {
+		case n, ok := <-w.client.NotificationCh:
+			if !ok {
+				return
+			}
+			w.processNotification(ctx, n, conn)
+		case <-ctx.Done():
+			return
+		default:
+			return
+		}
+	}
+}
+
 func (w *Worker) readLoop(ctx context.Context) {
 	// Capture conn under lock for consistent access pattern.
 	w.Mu.Lock()
@@ -922,6 +945,12 @@ func (w *Worker) readLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-w.drainCh:
+			w.drainNotificationCh(ctx, conn)
+			select {
+			case w.drainDoneCh <- struct{}{}:
+			case <-ctx.Done():
+			}
 		case notif, ok := <-w.client.NotificationCh:
 			if !ok {
 				return

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -500,6 +500,25 @@ func (w *Worker) Input(ctx context.Context, content string, metadata map[string]
 		return fmt.Errorf("acp: prompt: %w", promptErr)
 	}
 
+	// Drain pending notifications before sending Done.
+	// Prompt() returns after the JSON-RPC response arrives, but the
+	// readLoop goroutine may still have agent_message_chunk notifications
+	// buffered in NotificationCh. Without draining, Done reaches the
+	// bridge before MessageDelta, resulting in text_len=0.
+	drainTimer := time.NewTimer(200 * time.Millisecond)
+	defer drainTimer.Stop()
+drainLoop:
+	for {
+		select {
+		case n := <-w.client.NotificationCh:
+			w.processNotification(ctx, n, conn)
+		case <-drainTimer.C:
+			break drainLoop
+		default:
+			break drainLoop
+		}
+	}
+
 	// Emit done sequence.
 	envs := w.mapper.MapPromptResponse(result)
 	for _, env := range envs {

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -902,7 +902,8 @@ func (w *Worker) processNotification(ctx context.Context, notif *JSONRPCNotifica
 // drainNotificationCh empties all buffered notifications from NotificationCh.
 // Called by readLoop in response to a drain signal from Input().
 func (w *Worker) drainNotificationCh(ctx context.Context, conn *acpConn) {
-	for {
+	const maxDrain = 256
+	for i := 0; i < maxDrain; i++ {
 		select {
 		case n, ok := <-w.client.NotificationCh:
 			if !ok {
@@ -949,7 +950,7 @@ func (w *Worker) readLoop(ctx context.Context) {
 			w.drainNotificationCh(ctx, conn)
 			select {
 			case w.drainDoneCh <- struct{}{}:
-			case <-ctx.Done():
+			default: // already consumed or buffered
 			}
 		case notif, ok := <-w.client.NotificationCh:
 			if !ok {


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### Fix 1: ACP Worker notification drain (Issue #684)
- Fix race condition where `Done` reaches bridge before `MessageDelta`, causing `text_len=0`
- Add drain loop in `Input()` to process pending notifications before sending Done
- Add Warn log when ACP client notification channel drops events (previously silent)

### Fix 2: PR Review Webhook CI-Only Trigger (Issue #662)
- Remove `pull_request` event handling — only `check_suite`/`check_run` trigger reviews
- Fix dedup TOCTOU race: `sync.Map` Load+Store → atomic `LoadOrStore`
- Increase dedup cooldown 60s → 300s to handle long CI pipelines
- Dynamic workDir for webhook-triggered PR reviews: `/tmp/pr-review-YYYYMMDD/pr-N`
- Add `validateAndExpandWorkDir` in `StartSession` (fixes pre-existing security gap)

### Bonus: Pre-existing test fix
- Fix `TestWatcher_isRelevant` on macOS (symlink path resolution)
- Use cross-platform path in test (replace hardcoded `/tmp`)

## Changes

| File | Change |
|------|--------|
| `internal/worker/acp/worker.go` | Drain notifications before Done + channel handshake |
| `internal/worker/acp/client.go` | Warn log on notification drop |
| `internal/gateway/webhook.go` | Remove pull_request, fix dedup, 300s cooldown |
| `internal/gateway/webhook_test.go` | Remove pull_request tests, add dedup atomicity test |
| `internal/gateway/bridge.go` | workDir validation in StartSession |
| `internal/cron/executor.go` | Dynamic workDir for webhook PR reviews |
| `internal/config/watcher_test.go` | Fix symlink + cross-platform path |

## Test Plan

- [x] `make test-short` — all tests pass
- [x] `make lint` — 0 issues
- [x] Pre-push quality gates — all pass
- [x] Webhook dedup: concurrent check_suite + check_run trigger ≤3 times (vs 10 without fix)
- [x] pull_request events ignored (CI-only trigger)
- [ ] Manual: ACP worker returns text content
- [ ] Manual: Webhook triggers review only after CI passes

Closes #662, Closes #684