### PR TITLE
fix(events,cli): ToInt64/ToFloat64 handle int32 + botName text migration

### DIFF
--- a/.agents/skills/hotplex-setup/SKILL.md
+++ b/.agents/skills/hotplex-setup/SKILL.md
@@ -218,7 +218,7 @@ bots[].worker_type → <platform>.worker_type → HOTPLEX_MESSAGING_<PLATFORM>_W
 3. 调整 SOUL.md 仅改用户明确要求的部分
 4. 展示 diff 确认后写入
 
-规则：幂等、最小变更、不覆盖已个性化内容。配置层级：全局 → 平台（slack/）→ Bot（slack/U12345/）。
+规则：幂等、最小变更、不覆盖已个性化内容。配置层级：全局 → 平台（slack/）→ Bot（slack/<botName>/）。
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ configs/   - 配置文件
 - **C 通道**（`<context>`，可被 B 通道覆盖）：
   - `<user>` = `USER.md`
   - `<memory>` = `MEMORY.md`
-- 三级 fallback：全局 → 平台（slack/）→ Bot（slack/U12345/），每文件独立解析，命中即终止
+- 三级 fallback：全局 → 平台（slack/）→ Bot（slack/<botName>/），每文件独立解析，命中即终止
 - 配置热更新：仅在 session 初始化或 `/reset` 时加载，运行中修改不立即生效
 
 ### 配置陷阱（高发反直觉点）

--- a/cmd/hotplex/onboard.go
+++ b/cmd/hotplex/onboard.go
@@ -188,6 +188,6 @@ func displayAgentConfigPanel(created []string) {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintf(os.Stderr, "  %s\n", output.Dim("根据需要编辑这些文件来定制 Agent 行为。"))
 	fmt.Fprintf(os.Stderr, "  %s\n", output.Dim("修改后对新会话生效（下次创建 session 时加载）。"))
-	fmt.Fprintf(os.Stderr, "  %s\n\n", output.Dim("支持平台和 Bot 级覆盖：slack/SOUL.md、slack/U12345/SOUL.md"))
+	fmt.Fprintf(os.Stderr, "  %s\n\n", output.Dim("支持平台和 Bot 级覆盖：slack/SOUL.md、slack/<botName>/SOUL.md"))
 	fmt.Fprintf(os.Stderr, "  %s\n", output.Dim("使用 hotplex-setup skill 交互式定制 Agent 人格和偏好。"))
 }

--- a/configs/README.md
+++ b/configs/README.md
@@ -201,7 +201,7 @@ Worker 进程启动时的工作目录遵循以下优先级覆盖逻辑：
 | 字段 | 类型 | 默认值 | 热重载 | 说明 |
 |:-----|:-----|:-------|:------:|:-----|
 | `enabled` | bool | `true` | — | 是否启用 Agent 配置注入。关闭后 Agent 将仅使用代码内建的通用提示词。 |
-| `config_dir` | string | `~/.hotplex/agent-configs` | — | 配置文件根目录。支持 **per-bot 3 级目录 fallback**，按文件独立解析：`<config_dir>/<platform>/<botID>/<file>` → `<config_dir>/<platform>/<file>` → `<config_dir>/<file>`，命中第一个非空文件即停止。有效平台值：`slack`、`feishu`、`webchat`、`""`（仅全局级） |
+| `config_dir` | string | `~/.hotplex/agent-configs` | — | 配置文件根目录。支持 **per-bot 3 级目录 fallback**，按文件独立解析：`<config_dir>/<platform>/<botName>/<file>` → `<config_dir>/<platform>/<file>` → `<config_dir>/<file>`，命中第一个非空文件即停止。有效平台值：`slack`、`feishu`、`webchat`、`""`（仅全局级） |
 
 ### skills — 技能管理
 

--- a/internal/cli/checkers/agentconfig.go
+++ b/internal/cli/checkers/agentconfig.go
@@ -223,6 +223,6 @@ func (c agentConfigGlobalFilesChecker) Check(_ context.Context) cli.Diagnostic {
 		Status:   cli.StatusWarn,
 		Message:  fmt.Sprintf("Global config files apply to all bots: %s", strings.Join(global, ", ")),
 		Detail:   dir,
-		FixHint:  fmt.Sprintf("Move to per-bot directory for isolation:\n  mkdir -p %s/slack/<BOT_ID>\n  mv %s %s/slack/<BOT_ID>/", dir, filepath.Join(dir, global[0]), dir),
+		FixHint:  fmt.Sprintf("Move to per-bot directory for isolation:\n  mkdir -p %s/slack/<botName>\n  mv %s %s/slack/<botName>/", dir, filepath.Join(dir, global[0]), dir),
 	}
 }

--- a/internal/cli/onboard/templates/AGENTS.md
+++ b/internal/cli/onboard/templates/AGENTS.md
@@ -42,6 +42,6 @@ description: "Workspace rules for HotPlex non-interactive agent"
 此文件支持 3 级 fallback，高优先级完整替换低优先级：
 - 全局级：~/.hotplex/agent-configs/AGENTS.md（本文件）
 - 平台级：~/.hotplex/agent-configs/slack/AGENTS.md
-- Bot 级：~/.hotplex/agent-configs/slack/U12345/AGENTS.md
+- Bot 级：~/.hotplex/agent-configs/slack/<botName>/AGENTS.md
 
 使用 `hotplex-setup` skill 进行交互式个性化配置。修改后对新会话生效。

--- a/internal/cli/onboard/templates/MEMORY.md
+++ b/internal/cli/onboard/templates/MEMORY.md
@@ -13,7 +13,7 @@ description: "Cross-session context memory"
 此文件支持 3 级 fallback，高优先级完整替换低优先级：
 - 全局级：~/.hotplex/agent-configs/MEMORY.md（本文件）
 - 平台级：~/.hotplex/agent-configs/slack/MEMORY.md
-- Bot 级：~/.hotplex/agent-configs/slack/U12345/MEMORY.md
+- Bot 级：~/.hotplex/agent-configs/slack/<botName>/MEMORY.md
 
 使用 `hotplex-setup` skill 进行交互式个性化配置。修改后对新会话生效。
 

--- a/internal/cli/onboard/templates/SKILLS.md
+++ b/internal/cli/onboard/templates/SKILLS.md
@@ -63,6 +63,6 @@ STT 自动转写语音为文本，等同文本处理。TTS 支持语音合成输
 此文件支持 3 级 fallback，高优先级完整替换低优先级：
 - 全局级：~/.hotplex/agent-configs/SKILLS.md（本文件）
 - 平台级：~/.hotplex/agent-configs/slack/SKILLS.md
-- Bot 级：~/.hotplex/agent-configs/slack/U12345/SKILLS.md
+- Bot 级：~/.hotplex/agent-configs/slack/<botName>/SKILLS.md
 
 使用 `hotplex-setup` skill 进行交互式个性化配置。修改后对新会话生效。

--- a/internal/cli/onboard/templates/SOUL.md
+++ b/internal/cli/onboard/templates/SOUL.md
@@ -34,6 +34,6 @@ description: "Agent persona for HotPlex non-interactive mode"
 此文件支持 3 级 fallback，高优先级完整替换低优先级：
 - 全局级：~/.hotplex/agent-configs/SOUL.md（本文件）
 - 平台级：~/.hotplex/agent-configs/slack/SOUL.md
-- Bot 级：~/.hotplex/agent-configs/slack/U12345/SOUL.md
+- Bot 级：~/.hotplex/agent-configs/slack/<botName>/SOUL.md
 
 使用 `hotplex-setup` skill 进行交互式个性化配置。修改后对新会话生效。

--- a/internal/cli/onboard/templates/USER.md
+++ b/internal/cli/onboard/templates/USER.md
@@ -31,6 +31,6 @@ description: "User profile and preferences"
 此文件支持 3 级 fallback，高优先级完整替换低优先级：
 - 全局级：~/.hotplex/agent-configs/USER.md（本文件）
 - 平台级：~/.hotplex/agent-configs/slack/USER.md
-- Bot 级：~/.hotplex/agent-configs/slack/U12345/USER.md
+- Bot 级：~/.hotplex/agent-configs/slack/<botName>/USER.md
 
 使用 `hotplex-setup` skill 进行交互式个性化配置。修改后对新会话生效。

--- a/internal/cli/onboard/wizard.go
+++ b/internal/cli/onboard/wizard.go
@@ -1182,7 +1182,7 @@ func stepAgentConfig() (StepResult, []string) {
 	return StepResult{
 		Name:   "agent_config",
 		Status: "pass",
-		Detail: fmt.Sprintf("%s (%s) — per-bot: %s/<platform>/<botID>/SOUL.md", dir, strings.Join(created, ", "), dir),
+		Detail: fmt.Sprintf("%s (%s) — per-bot: %s/<platform>/<botName>/SOUL.md", dir, strings.Join(created, ", "), dir),
 	}, created
 }
 

--- a/internal/messaging/phrases/phrases.md
+++ b/internal/messaging/phrases/phrases.md
@@ -13,7 +13,7 @@
 │       └── PHRASES.md        # 特定 bot（权重 4，最高优先）
 └── slack/
     ├── PHRASES.md
-    └── U12345/
+    └── <botName>/
         └── PHRASES.md
 ```
 

--- a/pkg/events/helpers.go
+++ b/pkg/events/helpers.go
@@ -8,12 +8,14 @@ func IntFloat(v any) int {
 }
 
 // ToInt64 converts any numeric value to int64.
-// Handles float64, int, int64, and json.Number.
+// Handles float64, int, int32, int64, and json.Number.
 func ToInt64(v any) int64 {
 	switch n := v.(type) {
 	case float64:
 		return int64(n)
 	case int:
+		return int64(n)
+	case int32:
 		return int64(n)
 	case int64:
 		return n
@@ -26,12 +28,14 @@ func ToInt64(v any) int64 {
 }
 
 // ToFloat64 converts any numeric value to float64.
-// Handles float64, int, int64, and json.Number.
+// Handles float64, int, int32, int64, and json.Number.
 func ToFloat64(v any) float64 {
 	switch n := v.(type) {
 	case float64:
 		return n
 	case int:
+		return float64(n)
+	case int32:
 		return float64(n)
 	case int64:
 		return float64(n)


### PR DESCRIPTION
## Changes

Batch fix for #686 and #687.

### #686 — Turn Summary 丢失 toolcall 信息 + 飞书卡片 turn number 不稳定

**根因**: `sessionAccumulator` 使用 `atomic.Int32` 存储 `TurnCount`/`ToolCallCount`，经过 struct path（无 JSON round-trip）传入 `ExtractTurnSummary` → `ToInt64()`。PR #364 将 `events.Clone` 从 JSON round-trip 改为 shallow struct copy 后，int32 值不再经过 JSON float64 转换，直接以 int32 类型到达 `ToInt64()`，触发 default 分支返回 0。

**修复**: `pkg/events/helpers.go` — `ToInt64()` 和 `ToFloat64()` 新增 `case int32` 处理。

### #687 — botName 文案迁移

PR #679 将 agent config 路径从 `{platform}/{botID}/` 改为 `{platform}/{botName}/`，但 4 处用户可见文案未同步更新。

**修复**: 4 个文件中的过时 `botID`/`U12345`/`<BOT_ID>` 文案 → `<botName>`。

## Files Changed

| File | Change |
|------|--------|
| `pkg/events/helpers.go` | +int32 case to ToInt64/ToFloat64 |
| `cmd/hotplex/onboard.go` | U12345 → \<botName\> |
| `internal/cli/onboard/wizard.go` | \<botID\> → \<botName\> |
| `internal/cli/checkers/agentconfig.go` | \<BOT_ID\> → \<botName\> |
| `.agents/skills/hotplex-setup/SKILL.md` | U12345 → \<botName\> |

Closes #686
Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)