### PR TITLE
Batch: DRY extractions for issues #504, #511, #508, #516

### DIFF
--- a/docs/explanation/cron-design.md
+++ b/docs/explanation/cron-design.md
@@ -206,6 +206,10 @@ else -> Gateway 投递（Delivery 模块通过 SDK 发送）
 if platform="" || platform="cron" -> 不投递
 ```
 
+**投递重试**：Gateway 投递失败时，临时性错误（429、timeout、5xx）会进入内存重试队列，最多重试 3 次，指数退避 30s → 1m → 2m（上限 5m）。永久性错误（403、404）立即丢弃并记录日志。重试队列容量 100 条目（FIFO 驱逐），后台 `retryLoop` 以 10s tick 间隔检查到期重试。优雅关闭时，队列中残留的重试被记录为永久丢失。
+
+**注意**：重试队列是内存中的，进程重启后未执行的重试会丢失。这适用于绝大多数场景——投递失败通常是临时性的（限流、网络抖动），在几秒到几分钟内重试即可恢复。
+
 **Silent 模式**：当 `job.Silent = true` 时，跳过所有投递逻辑。用于"静默检查"类型的任务——只执行不通知。
 
 ### Catch-up 机制：错过任务的补偿
@@ -335,7 +339,7 @@ Dispatch(job):
 
 4. **at 类型无持久重试队列**：`at` 类型的重试通过 `scheduleRetry` 在内存中调度。如果 Gateway 在重试等待期间重启，重试机会丢失。持久重试需要将重试状态写入 DB，当前未实现。
 
-5. **CLI 投递的可靠性**：CLI 投递依赖 Worker 执行 `hotplex slack send-message` 命令。如果 Worker 崩溃或忽略投递指令，结果会丢失。Gateway 投递（Delivery 模块）更可靠，但需要额外的基础设施支持（EventStore + SDK 回调）。
+5. **CLI 投递的可靠性**：CLI 投递依赖 Worker 执行 `hotplex slack send-message` 命令。如果 Worker 崩溃或忽略投递指令，结果会丢失。Gateway 投递（Delivery 模块）更可靠——内置临时错误重试（最多 3 次，指数退避），且通过 EventStore + SDK 回调独立于 Worker 生命周期。
 
 ## 参考
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -166,6 +166,7 @@ increase(hotplex_pool_release_errors_total[1h])
 | `hotplex.cron.errors` | Counter | 执行错误数，label: `job_name`, `error_type` |
 | `hotplex.cron.duration` | Histogram | 执行时长，label: `job_name` |
 | `hotplex.cron.attached` | Counter | Session-attached cron 投递次数 |
+| `hotplex.cron.delivery.result` | Counter | 投递结果，label: `status`（success / exhausted / permanent） |
 
 ### 常用查询
 

--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -268,11 +268,6 @@ func (m *mockStore) DeletePhysical(ctx context.Context, id string) error {
 	return args.Error(0)
 }
 
-func (m *mockStore) Compact(ctx context.Context, threshold float64) error {
-	args := m.Called(ctx, threshold)
-	return args.Error(0)
-}
-
 func (m *mockStore) GetSessionsByState(ctx context.Context, state events.SessionState) ([]string, error) {
 	args := m.Called(ctx, state)
 	return args.Get(0).([]string), args.Error(1)

--- a/internal/admin/apikey_handlers.go
+++ b/internal/admin/apikey_handlers.go
@@ -41,8 +41,8 @@ type apiKeyStoreBase struct {
 	db          DBExecutor
 	mu          sync.Mutex
 	invalidator cacheInvalidator
-	dialect     dbutil.Dialect     // DialectSQLite or DialectPostgres; controls placeholder style
-	writeMu     *sqlutil.WriteMu   // nil-safe; PG dialect = no-op
+	dialect     dbutil.Dialect   // DialectSQLite or DialectPostgres; controls placeholder style
+	writeMu     *sqlutil.WriteMu // nil-safe; PG dialect = no-op
 }
 
 // prepareQuery applies dialect placeholder rebind (e.g. ? → $1, $2).

--- a/internal/admin/apikey_handlers.go
+++ b/internal/admin/apikey_handlers.go
@@ -33,13 +33,103 @@ type APIKeyUser struct {
 	UpdatedAt   string `json:"updated_at,omitempty"`
 }
 
-// apiKeyUserStore implements APIKeyUserStorer backed by SQLite.
-// PG-backed callers use pgStore (apikey_pg_store.go) instead.
-type apiKeyUserStore struct {
+// apiKeyStoreBase provides shared CRUD logic for API key user stores.
+// Both SQLite (apiKeyUserStore) and PG (pgStore) embed this struct,
+// eliminating duplication of list/get/delete and invalidator methods.
+type apiKeyStoreBase struct {
 	db          DBExecutor
 	mu          sync.Mutex
 	invalidator cacheInvalidator
-	writeMu     *sqlutil.WriteMu // serializes writes for SQLite; nil/PG-safe
+	rebind      func(string) string      // nil for SQLite, dialect.Rebind for PG
+	withLock    func(func() error) error // writeMu.WithLock for SQLite, identity for PG
+}
+
+// prepareQuery applies dialect rebind if configured.
+func (b *apiKeyStoreBase) prepareQuery(q string) string {
+	if b.rebind != nil {
+		return b.rebind(q)
+	}
+	return q
+}
+
+// ensureAPIKey generates a random API key (hpk_ prefix) if not already set.
+func (b *apiKeyStoreBase) ensureAPIKey(u *APIKeyUser) error {
+	if u.APIKey != "" {
+		return nil
+	}
+	key := make([]byte, 24)
+	if _, err := rand.Read(key); err != nil {
+		return fmt.Errorf("admin: generate api key: %w", err)
+	}
+	u.APIKey = "hpk_" + hex.EncodeToString(key)
+	return nil
+}
+
+func (b *apiKeyStoreBase) Invalidator() cacheInvalidator {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.invalidator
+}
+
+func (b *apiKeyStoreBase) SetInvalidator(inv cacheInvalidator) {
+	b.mu.Lock()
+	b.invalidator = inv
+	b.mu.Unlock()
+}
+
+func (b *apiKeyStoreBase) list(ctx context.Context) ([]APIKeyUser, error) {
+	rows, err := b.db.QueryContext(ctx,
+		"SELECT id, api_key, user_id, description, created_at, updated_at FROM api_key_users ORDER BY created_at DESC")
+	if err != nil {
+		return nil, fmt.Errorf("admin: list api key users: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []APIKeyUser
+	for rows.Next() {
+		var u APIKeyUser
+		if err := rows.Scan(&u.ID, &u.APIKey, &u.UserID, &u.Description, &u.CreatedAt, &u.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("admin: scan api key user: %w", err)
+		}
+		result = append(result, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin: iterate api key users: %w", err)
+	}
+	return result, nil
+}
+
+func (b *apiKeyStoreBase) get(ctx context.Context, id int64) (*APIKeyUser, error) {
+	var u APIKeyUser
+	err := b.db.QueryRowContext(ctx,
+		b.prepareQuery("SELECT id, api_key, user_id, description, created_at, updated_at FROM api_key_users WHERE id = ?"), id,
+	).Scan(&u.ID, &u.APIKey, &u.UserID, &u.Description, &u.CreatedAt, &u.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("admin: get api key user: %w", err)
+	}
+	return &u, nil
+}
+
+func (b *apiKeyStoreBase) delete(ctx context.Context, id int64) error {
+	query := b.prepareQuery("DELETE FROM api_key_users WHERE id = ?")
+	return b.withLock(func() error {
+		res, err := b.db.ExecContext(ctx, query, id)
+		if err != nil {
+			return fmt.Errorf("admin: delete api key user: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			return fmt.Errorf("admin: api key user ID %d not found", id)
+		}
+		return nil
+	})
+}
+
+// apiKeyUserStore implements APIKeyUserStorer backed by SQLite.
+// PG-backed callers use pgStore (apikey_pg_store.go) instead.
+type apiKeyUserStore struct {
+	apiKeyStoreBase
+	writeMu *sqlutil.WriteMu
 }
 
 // APIKeyUserStorer defines CRUD operations for API key user records.
@@ -69,66 +159,25 @@ func newAPIKeyUserStoreWithInvalidator(db DBExecutor, inv cacheInvalidator, writ
 	if db == nil {
 		return nil
 	}
-	return &apiKeyUserStore{db: db, invalidator: inv, writeMu: writeMu}
+	return &apiKeyUserStore{
+		apiKeyStoreBase: apiKeyStoreBase{
+			db:          db,
+			invalidator: inv,
+			rebind:      nil,
+			withLock:    writeMu.WithLock,
+		},
+		writeMu: writeMu,
+	}
 }
 
 var _ APIKeyUserStorer = (*apiKeyUserStore)(nil)
 
-func (s *apiKeyUserStore) Invalidator() cacheInvalidator {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.invalidator
-}
-
-func (s *apiKeyUserStore) SetInvalidator(inv cacheInvalidator) {
-	s.mu.Lock()
-	s.invalidator = inv
-	s.mu.Unlock()
-}
-
-func (s *apiKeyUserStore) list(ctx context.Context) ([]APIKeyUser, error) {
-	rows, err := s.db.QueryContext(ctx,
-		"SELECT id, api_key, user_id, description, created_at, updated_at FROM api_key_users ORDER BY created_at DESC")
-	if err != nil {
-		return nil, fmt.Errorf("admin: list api key users: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var result []APIKeyUser
-	for rows.Next() {
-		var u APIKeyUser
-		if err := rows.Scan(&u.ID, &u.APIKey, &u.UserID, &u.Description, &u.CreatedAt, &u.UpdatedAt); err != nil {
-			return nil, fmt.Errorf("admin: scan api key user: %w", err)
-		}
-		result = append(result, u)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("admin: iterate api key users: %w", err)
-	}
-	return result, nil
-}
-
-func (s *apiKeyUserStore) get(ctx context.Context, id int64) (*APIKeyUser, error) {
-	var u APIKeyUser
-	err := s.db.QueryRowContext(ctx,
-		"SELECT id, api_key, user_id, description, created_at, updated_at FROM api_key_users WHERE id = ?", id,
-	).Scan(&u.ID, &u.APIKey, &u.UserID, &u.Description, &u.CreatedAt, &u.UpdatedAt)
-	if err != nil {
-		return nil, fmt.Errorf("admin: get api key user: %w", err)
-	}
-	return &u, nil
-}
-
 func (s *apiKeyUserStore) create(ctx context.Context, u *APIKeyUser) error {
-	if u.APIKey == "" {
-		key := make([]byte, 24)
-		if _, err := rand.Read(key); err != nil {
-			return fmt.Errorf("admin: generate api key: %w", err)
-		}
-		u.APIKey = "hpk_" + hex.EncodeToString(key)
+	if err := s.ensureAPIKey(u); err != nil {
+		return err
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
-	return s.writeMu.WithLock(func() error {
+	return s.withLock(func() error {
 		res, err := s.db.ExecContext(ctx,
 			"INSERT INTO api_key_users (api_key, user_id, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
 			u.APIKey, u.UserID, u.Description, now, now)
@@ -148,26 +197,12 @@ func (s *apiKeyUserStore) update(ctx context.Context, id int64, u *APIKeyUser) e
 	now := time.Now().UTC().Format(time.RFC3339)
 	// NOTE: api_key is immutable after creation — never add it to SET clause
 	// without also calling KeyValidator.RemoveKey(old) + AddKey(new).
-	return s.writeMu.WithLock(func() error {
+	return s.withLock(func() error {
 		res, err := s.db.ExecContext(ctx,
 			"UPDATE api_key_users SET user_id = ?, description = ?, updated_at = ? WHERE id = ?",
 			u.UserID, u.Description, now, id)
 		if err != nil {
 			return fmt.Errorf("admin: update api key user: %w", err)
-		}
-		n, _ := res.RowsAffected()
-		if n == 0 {
-			return fmt.Errorf("admin: api key user ID %d not found", id)
-		}
-		return nil
-	})
-}
-
-func (s *apiKeyUserStore) delete(ctx context.Context, id int64) error {
-	return s.writeMu.WithLock(func() error {
-		res, err := s.db.ExecContext(ctx, "DELETE FROM api_key_users WHERE id = ?", id)
-		if err != nil {
-			return fmt.Errorf("admin: delete api key user: %w", err)
 		}
 		n, _ := res.RowsAffected()
 		if n == 0 {

--- a/internal/admin/apikey_handlers.go
+++ b/internal/admin/apikey_handlers.go
@@ -129,7 +129,6 @@ func (b *apiKeyStoreBase) delete(ctx context.Context, id int64) error {
 // PG-backed callers use pgStore (apikey_pg_store.go) instead.
 type apiKeyUserStore struct {
 	apiKeyStoreBase
-	writeMu *sqlutil.WriteMu
 }
 
 // APIKeyUserStorer defines CRUD operations for API key user records.
@@ -166,7 +165,6 @@ func newAPIKeyUserStoreWithInvalidator(db DBExecutor, inv cacheInvalidator, writ
 			rebind:      nil,
 			withLock:    writeMu.WithLock,
 		},
-		writeMu: writeMu,
 	}
 }
 

--- a/internal/admin/apikey_handlers.go
+++ b/internal/admin/apikey_handlers.go
@@ -45,11 +45,6 @@ type apiKeyStoreBase struct {
 	writeMu     *sqlutil.WriteMu // nil-safe; PG dialect = no-op
 }
 
-// prepareQuery applies dialect placeholder rebind (e.g. ? → $1, $2).
-func (b *apiKeyStoreBase) prepareQuery(q string) string {
-	return b.dialect.Rebind(q)
-}
-
 // ensureAPIKey generates a random API key (hpk_ prefix) if not already set.
 func (b *apiKeyStoreBase) ensureAPIKey(u *APIKeyUser) error {
 	if u.APIKey != "" {
@@ -100,7 +95,7 @@ func (b *apiKeyStoreBase) list(ctx context.Context) ([]APIKeyUser, error) {
 func (b *apiKeyStoreBase) get(ctx context.Context, id int64) (*APIKeyUser, error) {
 	var u APIKeyUser
 	err := b.db.QueryRowContext(ctx,
-		b.prepareQuery("SELECT id, api_key, user_id, description, created_at, updated_at FROM api_key_users WHERE id = ?"), id,
+		b.dialect.Rebind("SELECT id, api_key, user_id, description, created_at, updated_at FROM api_key_users WHERE id = ?"), id,
 	).Scan(&u.ID, &u.APIKey, &u.UserID, &u.Description, &u.CreatedAt, &u.UpdatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("admin: get api key user: %w", err)
@@ -109,7 +104,7 @@ func (b *apiKeyStoreBase) get(ctx context.Context, id int64) (*APIKeyUser, error
 }
 
 func (b *apiKeyStoreBase) delete(ctx context.Context, id int64) error {
-	query := b.prepareQuery("DELETE FROM api_key_users WHERE id = ?")
+	query := b.dialect.Rebind("DELETE FROM api_key_users WHERE id = ?")
 	return b.writeMu.WithLock(func() error {
 		res, err := b.db.ExecContext(ctx, query, id)
 		if err != nil {

--- a/internal/admin/apikey_handlers.go
+++ b/internal/admin/apikey_handlers.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hrygo/hotplex/internal/dbutil"
 	"github.com/hrygo/hotplex/internal/sqlutil"
 )
 
@@ -40,16 +41,13 @@ type apiKeyStoreBase struct {
 	db          DBExecutor
 	mu          sync.Mutex
 	invalidator cacheInvalidator
-	rebind      func(string) string      // nil for SQLite, dialect.Rebind for PG
-	withLock    func(func() error) error // writeMu.WithLock for SQLite, identity for PG
+	dialect     dbutil.Dialect     // DialectSQLite or DialectPostgres; controls placeholder style
+	writeMu     *sqlutil.WriteMu   // nil-safe; PG dialect = no-op
 }
 
-// prepareQuery applies dialect rebind if configured.
+// prepareQuery applies dialect placeholder rebind (e.g. ? → $1, $2).
 func (b *apiKeyStoreBase) prepareQuery(q string) string {
-	if b.rebind != nil {
-		return b.rebind(q)
-	}
-	return q
+	return b.dialect.Rebind(q)
 }
 
 // ensureAPIKey generates a random API key (hpk_ prefix) if not already set.
@@ -112,7 +110,7 @@ func (b *apiKeyStoreBase) get(ctx context.Context, id int64) (*APIKeyUser, error
 
 func (b *apiKeyStoreBase) delete(ctx context.Context, id int64) error {
 	query := b.prepareQuery("DELETE FROM api_key_users WHERE id = ?")
-	return b.withLock(func() error {
+	return b.writeMu.WithLock(func() error {
 		res, err := b.db.ExecContext(ctx, query, id)
 		if err != nil {
 			return fmt.Errorf("admin: delete api key user: %w", err)
@@ -162,8 +160,8 @@ func newAPIKeyUserStoreWithInvalidator(db DBExecutor, inv cacheInvalidator, writ
 		apiKeyStoreBase: apiKeyStoreBase{
 			db:          db,
 			invalidator: inv,
-			rebind:      nil,
-			withLock:    writeMu.WithLock,
+			dialect:     dbutil.DialectSQLite,
+			writeMu:     writeMu,
 		},
 	}
 }
@@ -175,7 +173,7 @@ func (s *apiKeyUserStore) create(ctx context.Context, u *APIKeyUser) error {
 		return err
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
-	return s.withLock(func() error {
+	return s.writeMu.WithLock(func() error {
 		res, err := s.db.ExecContext(ctx,
 			"INSERT INTO api_key_users (api_key, user_id, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
 			u.APIKey, u.UserID, u.Description, now, now)
@@ -195,7 +193,7 @@ func (s *apiKeyUserStore) update(ctx context.Context, id int64, u *APIKeyUser) e
 	now := time.Now().UTC().Format(time.RFC3339)
 	// NOTE: api_key is immutable after creation — never add it to SET clause
 	// without also calling KeyValidator.RemoveKey(old) + AddKey(new).
-	return s.withLock(func() error {
+	return s.writeMu.WithLock(func() error {
 		res, err := s.db.ExecContext(ctx,
 			"UPDATE api_key_users SET user_id = ?, description = ?, updated_at = ? WHERE id = ?",
 			u.UserID, u.Description, now, id)

--- a/internal/admin/apikey_pg_store.go
+++ b/internal/admin/apikey_pg_store.go
@@ -18,13 +18,12 @@ func NewAPIKeyUserPGStore(db *dbutil.DB, inv cacheInvalidator) APIKeyUserStorer 
 	if db == nil {
 		return nil
 	}
-	d := db.Dialect()
 	return &pgStore{
 		apiKeyStoreBase: apiKeyStoreBase{
 			db:          db,
 			invalidator: inv,
-			rebind:      d.Rebind,
-			withLock:    func(fn func() error) error { return fn() }, // no write serialization for PG
+			dialect:     dbutil.DialectPostgres,
+			writeMu:     nil, // PG handles concurrency natively; WriteMu.WithLock is nil-safe
 		},
 	}
 }
@@ -39,7 +38,7 @@ func (s *pgStore) create(ctx context.Context, u *APIKeyUser) error {
 		return err
 	}
 	// created_at and updated_at use DEFAULT NOW() in the Postgres schema.
-	return s.withLock(func() error {
+	return s.writeMu.WithLock(func() error {
 		query := s.prepareQuery("INSERT INTO api_key_users (api_key, user_id, description) VALUES (?, ?, ?) RETURNING id")
 		if err := s.db.QueryRowContext(ctx, query, u.APIKey, u.UserID, u.Description).Scan(&u.ID); err != nil {
 			return fmt.Errorf("admin: create api key user: %w", err)
@@ -51,7 +50,7 @@ func (s *pgStore) create(ctx context.Context, u *APIKeyUser) error {
 func (s *pgStore) update(ctx context.Context, id int64, u *APIKeyUser) error {
 	// NOTE: api_key is immutable after creation — never add it to SET clause
 	// without also calling KeyValidator.RemoveKey(old) + AddKey(new).
-	return s.withLock(func() error {
+	return s.writeMu.WithLock(func() error {
 		query := s.prepareQuery("UPDATE api_key_users SET user_id = ?, description = ?, updated_at = NOW() WHERE id = ?")
 		res, err := s.db.ExecContext(ctx, query, u.UserID, u.Description, id)
 		if err != nil {

--- a/internal/admin/apikey_pg_store.go
+++ b/internal/admin/apikey_pg_store.go
@@ -39,7 +39,7 @@ func (s *pgStore) create(ctx context.Context, u *APIKeyUser) error {
 	}
 	// created_at and updated_at use DEFAULT NOW() in the Postgres schema.
 	return s.writeMu.WithLock(func() error {
-		query := s.prepareQuery("INSERT INTO api_key_users (api_key, user_id, description) VALUES (?, ?, ?) RETURNING id")
+		query := s.dialect.Rebind("INSERT INTO api_key_users (api_key, user_id, description) VALUES (?, ?, ?) RETURNING id")
 		if err := s.db.QueryRowContext(ctx, query, u.APIKey, u.UserID, u.Description).Scan(&u.ID); err != nil {
 			return fmt.Errorf("admin: create api key user: %w", err)
 		}
@@ -51,7 +51,7 @@ func (s *pgStore) update(ctx context.Context, id int64, u *APIKeyUser) error {
 	// NOTE: api_key is immutable after creation — never add it to SET clause
 	// without also calling KeyValidator.RemoveKey(old) + AddKey(new).
 	return s.writeMu.WithLock(func() error {
-		query := s.prepareQuery("UPDATE api_key_users SET user_id = ?, description = ?, updated_at = NOW() WHERE id = ?")
+		query := s.dialect.Rebind("UPDATE api_key_users SET user_id = ?, description = ?, updated_at = NOW() WHERE id = ?")
 		res, err := s.db.ExecContext(ctx, query, u.UserID, u.Description, id)
 		if err != nil {
 			return fmt.Errorf("admin: update api key user: %w", err)

--- a/internal/admin/apikey_pg_store.go
+++ b/internal/admin/apikey_pg_store.go
@@ -39,24 +39,28 @@ func (s *pgStore) create(ctx context.Context, u *APIKeyUser) error {
 		return err
 	}
 	// created_at and updated_at use DEFAULT NOW() in the Postgres schema.
-	query := s.prepareQuery("INSERT INTO api_key_users (api_key, user_id, description) VALUES (?, ?, ?) RETURNING id")
-	if err := s.db.QueryRowContext(ctx, query, u.APIKey, u.UserID, u.Description).Scan(&u.ID); err != nil {
-		return fmt.Errorf("admin: create api key user: %w", err)
-	}
-	return nil
+	return s.withLock(func() error {
+		query := s.prepareQuery("INSERT INTO api_key_users (api_key, user_id, description) VALUES (?, ?, ?) RETURNING id")
+		if err := s.db.QueryRowContext(ctx, query, u.APIKey, u.UserID, u.Description).Scan(&u.ID); err != nil {
+			return fmt.Errorf("admin: create api key user: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *pgStore) update(ctx context.Context, id int64, u *APIKeyUser) error {
 	// NOTE: api_key is immutable after creation — never add it to SET clause
 	// without also calling KeyValidator.RemoveKey(old) + AddKey(new).
-	query := s.prepareQuery("UPDATE api_key_users SET user_id = ?, description = ?, updated_at = NOW() WHERE id = ?")
-	res, err := s.db.ExecContext(ctx, query, u.UserID, u.Description, id)
-	if err != nil {
-		return fmt.Errorf("admin: update api key user: %w", err)
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("admin: api key user ID %d not found", id)
-	}
-	return nil
+	return s.withLock(func() error {
+		query := s.prepareQuery("UPDATE api_key_users SET user_id = ?, description = ?, updated_at = NOW() WHERE id = ?")
+		res, err := s.db.ExecContext(ctx, query, u.UserID, u.Description, id)
+		if err != nil {
+			return fmt.Errorf("admin: update api key user: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			return fmt.Errorf("admin: api key user ID %d not found", id)
+		}
+		return nil
+	})
 }

--- a/internal/admin/apikey_pg_store.go
+++ b/internal/admin/apikey_pg_store.go
@@ -2,20 +2,15 @@ package admin
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
-	"sync"
 
 	"github.com/hrygo/hotplex/internal/dbutil"
 )
 
 // pgStore implements APIKeyUserStorer backed by PostgreSQL.
+// It embeds apiKeyStoreBase for shared list/get/delete/invalidator logic.
 type pgStore struct {
-	db          *dbutil.DB
-	dialect     dbutil.Dialect
-	mu          sync.Mutex
-	invalidator cacheInvalidator
+	apiKeyStoreBase
 }
 
 // NewAPIKeyUserPGStore creates a PG-backed API key store.
@@ -23,19 +18,15 @@ func NewAPIKeyUserPGStore(db *dbutil.DB, inv cacheInvalidator) APIKeyUserStorer 
 	if db == nil {
 		return nil
 	}
+	d := db.Dialect()
 	return &pgStore{
-		db:          db,
-		dialect:     db.Dialect(),
-		invalidator: inv,
+		apiKeyStoreBase: apiKeyStoreBase{
+			db:          db,
+			invalidator: inv,
+			rebind:      d.Rebind,
+			withLock:    func(fn func() error) error { return fn() }, // no write serialization for PG
+		},
 	}
-}
-
-// SetInvalidator sets the cache invalidator used after API key CRUD operations.
-// Safe for concurrent use — last call wins.
-func (s *pgStore) SetInvalidator(inv cacheInvalidator) {
-	s.mu.Lock()
-	s.invalidator = inv
-	s.mu.Unlock()
 }
 
 var (
@@ -43,56 +34,12 @@ var (
 	_                  = NewAPIKeyUserPGStore
 )
 
-func (s *pgStore) Invalidator() cacheInvalidator {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.invalidator
-}
-
-func (s *pgStore) list(ctx context.Context) ([]APIKeyUser, error) {
-	rows, err := s.db.QueryContext(ctx,
-		"SELECT id, api_key, user_id, description, created_at, updated_at FROM api_key_users ORDER BY created_at DESC")
-	if err != nil {
-		return nil, fmt.Errorf("admin: list api key users: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var result []APIKeyUser
-	for rows.Next() {
-		var u APIKeyUser
-		if err := rows.Scan(&u.ID, &u.APIKey, &u.UserID, &u.Description, &u.CreatedAt, &u.UpdatedAt); err != nil {
-			return nil, fmt.Errorf("admin: scan api key user: %w", err)
-		}
-		result = append(result, u)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("admin: iterate api key users: %w", err)
-	}
-	return result, nil
-}
-
-func (s *pgStore) get(ctx context.Context, id int64) (*APIKeyUser, error) {
-	var u APIKeyUser
-	query := s.dialect.Rebind(
-		"SELECT id, api_key, user_id, description, created_at, updated_at FROM api_key_users WHERE id = ?")
-	err := s.db.QueryRowContext(ctx, query, id).
-		Scan(&u.ID, &u.APIKey, &u.UserID, &u.Description, &u.CreatedAt, &u.UpdatedAt)
-	if err != nil {
-		return nil, fmt.Errorf("admin: get api key user: %w", err)
-	}
-	return &u, nil
-}
-
 func (s *pgStore) create(ctx context.Context, u *APIKeyUser) error {
-	if u.APIKey == "" {
-		key := make([]byte, 24)
-		if _, err := rand.Read(key); err != nil {
-			return fmt.Errorf("admin: generate api key: %w", err)
-		}
-		u.APIKey = "hpk_" + hex.EncodeToString(key)
+	if err := s.ensureAPIKey(u); err != nil {
+		return err
 	}
 	// created_at and updated_at use DEFAULT NOW() in the Postgres schema.
-	query := s.dialect.Rebind("INSERT INTO api_key_users (api_key, user_id, description) VALUES (?, ?, ?) RETURNING id")
+	query := s.prepareQuery("INSERT INTO api_key_users (api_key, user_id, description) VALUES (?, ?, ?) RETURNING id")
 	if err := s.db.QueryRowContext(ctx, query, u.APIKey, u.UserID, u.Description).Scan(&u.ID); err != nil {
 		return fmt.Errorf("admin: create api key user: %w", err)
 	}
@@ -102,23 +49,10 @@ func (s *pgStore) create(ctx context.Context, u *APIKeyUser) error {
 func (s *pgStore) update(ctx context.Context, id int64, u *APIKeyUser) error {
 	// NOTE: api_key is immutable after creation — never add it to SET clause
 	// without also calling KeyValidator.RemoveKey(old) + AddKey(new).
-	query := s.dialect.Rebind("UPDATE api_key_users SET user_id = ?, description = ?, updated_at = NOW() WHERE id = ?")
+	query := s.prepareQuery("UPDATE api_key_users SET user_id = ?, description = ?, updated_at = NOW() WHERE id = ?")
 	res, err := s.db.ExecContext(ctx, query, u.UserID, u.Description, id)
 	if err != nil {
 		return fmt.Errorf("admin: update api key user: %w", err)
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return fmt.Errorf("admin: api key user ID %d not found", id)
-	}
-	return nil
-}
-
-func (s *pgStore) delete(ctx context.Context, id int64) error {
-	query := s.dialect.Rebind("DELETE FROM api_key_users WHERE id = ?")
-	res, err := s.db.ExecContext(ctx, query, id)
-	if err != nil {
-		return fmt.Errorf("admin: delete api key user: %w", err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {

--- a/internal/admin/apikey_pg_store_test.go
+++ b/internal/admin/apikey_pg_store_test.go
@@ -20,9 +20,9 @@ func newAPIKeyPGMock(t *testing.T) (*pgStore, sqlmock.Sqlmock, func()) {
 
 	store := &pgStore{
 		apiKeyStoreBase: apiKeyStoreBase{
-			db:       db,
-			rebind:   dbutil.DialectPostgres.Rebind,
-			withLock: func(fn func() error) error { return fn() },
+			db:      db,
+			dialect: dbutil.DialectPostgres,
+			writeMu: nil, // nil-safe; WithLock calls fn directly
 		},
 	}
 

--- a/internal/admin/apikey_pg_store_test.go
+++ b/internal/admin/apikey_pg_store_test.go
@@ -19,8 +19,11 @@ func newAPIKeyPGMock(t *testing.T) (*pgStore, sqlmock.Sqlmock, func()) {
 	db := &dbutil.DB{DB: mockDB}
 
 	store := &pgStore{
-		db:      db,
-		dialect: dbutil.DialectPostgres,
+		apiKeyStoreBase: apiKeyStoreBase{
+			db:       db,
+			rebind:   dbutil.DialectPostgres.Rebind,
+			withLock: func(fn func() error) error { return fn() },
+		},
 	}
 
 	return store, mock, func() {

--- a/internal/gateway/conn_test.go
+++ b/internal/gateway/conn_test.go
@@ -494,16 +494,6 @@ func (m *mockSessionStoreForBotID) DeletePhysical(ctx context.Context, id string
 	return args.Error(0)
 }
 
-func (m *mockSessionStoreForBotID) DeleteExpiredEvents(ctx context.Context, cutoff time.Time) (int64, error) {
-	args := m.Called(ctx, cutoff)
-	return args.Get(0).(int64), args.Error(1)
-}
-
-func (m *mockSessionStoreForBotID) Compact(ctx context.Context, threshold float64) error {
-	args := m.Called(ctx, threshold)
-	return args.Error(0)
-}
-
 func (m *mockSessionStoreForBotID) GetSessionsByState(ctx context.Context, state events.SessionState) ([]string, error) {
 	args := m.Called(ctx, state)
 	return args.Get(0).([]string), args.Error(1)

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -68,16 +68,6 @@ func (m *mockStore) DeletePhysical(ctx context.Context, id string) error {
 	return args.Error(0)
 }
 
-func (m *mockStore) DeleteExpiredEvents(ctx context.Context, cutoff time.Time) (int64, error) {
-	args := m.Called(ctx, cutoff)
-	return args.Get(0).(int64), args.Error(1)
-}
-
-func (m *mockStore) Compact(ctx context.Context, threshold float64) error {
-	args := m.Called(ctx, threshold)
-	return args.Error(0)
-}
-
 func (m *mockStore) GetSessionsByState(ctx context.Context, state events.SessionState) ([]string, error) {
 	args := m.Called(ctx, state)
 	return args.Get(0).([]string), args.Error(1)

--- a/internal/messaging/stt/stt.go
+++ b/internal/messaging/stt/stt.go
@@ -326,11 +326,7 @@ func (s *PersistentSTT) start(_ context.Context) error {
 	s.jobHandle = proc.CreateAndAssignJob(s.pgid, s.log)
 
 	// Track PID for orphan cleanup.
-	if tracker := proc.GlobalTracker(); tracker != nil {
-		if err := tracker.Write(s.pidKey, s.pgid); err != nil {
-			s.log.Warn("persistent stt: pidfile write", "err", err, "key", s.pidKey)
-		}
-	}
+	s.trackPID()
 
 	// Set up line scanner for stdout (64KB init, 10MB cap).
 	buf := make([]byte, 64*1024)
@@ -397,11 +393,25 @@ func (s *PersistentSTT) shutdownProcess(ctx context.Context) {
 	s.started = false
 
 	// Clean up PID file.
+	s.untrackPID()
+
+	s.log.Info("persistent stt: stopped")
+}
+
+// trackPID writes the current PGID to the global PID file tracker.
+func (s *PersistentSTT) trackPID() {
+	if tracker := proc.GlobalTracker(); tracker != nil {
+		if err := tracker.Write(s.pidKey, s.pgid); err != nil {
+			s.log.Warn("persistent stt: pidfile write", "err", err, "key", s.pidKey)
+		}
+	}
+}
+
+// untrackPID removes the PID file entry for this process.
+func (s *PersistentSTT) untrackPID() {
 	if tracker := proc.GlobalTracker(); tracker != nil {
 		_ = tracker.Remove(s.pidKey)
 	}
-
-	s.log.Info("persistent stt: stopped")
 }
 
 // kill force-kills immediately and cleans up.
@@ -424,9 +434,7 @@ func (s *PersistentSTT) kill() {
 	s.started = false
 
 	// Clean up PID file.
-	if tracker := proc.GlobalTracker(); tracker != nil {
-		_ = tracker.Remove(s.pidKey)
-	}
+	s.untrackPID()
 }
 
 // forceKillAndWait closes the Job Object, force-kills the process group, and waits for exit.

--- a/internal/messaging/stt/stt.go
+++ b/internal/messaging/stt/stt.go
@@ -400,18 +400,12 @@ func (s *PersistentSTT) shutdownProcess(ctx context.Context) {
 
 // trackPID writes the current PGID to the global PID file tracker.
 func (s *PersistentSTT) trackPID() {
-	if tracker := proc.GlobalTracker(); tracker != nil {
-		if err := tracker.Write(s.pidKey, s.pgid); err != nil {
-			s.log.Warn("persistent stt: pidfile write", "err", err, "key", s.pidKey)
-		}
-	}
+	proc.TrackPID(s.pidKey, s.pgid, s.log, "persistent stt")
 }
 
 // untrackPID removes the PID file entry for this process.
 func (s *PersistentSTT) untrackPID() {
-	if tracker := proc.GlobalTracker(); tracker != nil {
-		_ = tracker.Remove(s.pidKey)
-	}
+	proc.UntrackPID(s.pidKey)
 }
 
 // kill force-kills immediately and cleans up.

--- a/internal/messaging/tts/moss_process.go
+++ b/internal/messaging/tts/moss_process.go
@@ -279,11 +279,7 @@ func (p *MossProcess) spawn() error {
 	p.started = true
 
 	// Track PID for orphan cleanup.
-	if tracker := proc.GlobalTracker(); tracker != nil {
-		if err := tracker.Write(p.pidKey, p.pgid); err != nil {
-			p.log.Warn("tts moss: pidfile write", "err", err)
-		}
-	}
+	p.trackPID()
 
 	return nil
 }
@@ -313,6 +309,22 @@ func (p *MossProcess) waitForReady(ctx context.Context) error {
 		time.Sleep(mossReadyInterval)
 	}
 	return fmt.Errorf("moss sidecar warmup timed out after %v", mossReadyTimeout)
+}
+
+// trackPID registers the process PID with the global tracker for orphan cleanup.
+func (p *MossProcess) trackPID() {
+	if tracker := proc.GlobalTracker(); tracker != nil {
+		if err := tracker.Write(p.pidKey, p.pgid); err != nil {
+			p.log.Warn("tts moss: pidfile write", "err", err)
+		}
+	}
+}
+
+// untrackPID removes the process PID from the global tracker.
+func (p *MossProcess) untrackPID() {
+	if tracker := proc.GlobalTracker(); tracker != nil {
+		_ = tracker.Remove(p.pidKey)
+	}
 }
 
 // terminate cancels the idle monitor and shuts down the subprocess.
@@ -356,9 +368,7 @@ func (p *MossProcess) shutdownProcess() {
 	}
 
 	// Clean up PID file.
-	if tracker := proc.GlobalTracker(); tracker != nil {
-		_ = tracker.Remove(p.pidKey)
-	}
+	p.untrackPID()
 
 	p.started = false
 	p.cmd = nil

--- a/internal/messaging/tts/moss_process.go
+++ b/internal/messaging/tts/moss_process.go
@@ -313,18 +313,12 @@ func (p *MossProcess) waitForReady(ctx context.Context) error {
 
 // trackPID registers the process PID with the global tracker for orphan cleanup.
 func (p *MossProcess) trackPID() {
-	if tracker := proc.GlobalTracker(); tracker != nil {
-		if err := tracker.Write(p.pidKey, p.pgid); err != nil {
-			p.log.Warn("tts moss: pidfile write", "err", err)
-		}
-	}
+	proc.TrackPID(p.pidKey, p.pgid, p.log, "tts moss")
 }
 
 // untrackPID removes the process PID from the global tracker.
 func (p *MossProcess) untrackPID() {
-	if tracker := proc.GlobalTracker(); tracker != nil {
-		_ = tracker.Remove(p.pidKey)
-	}
+	proc.UntrackPID(p.pidKey)
 }
 
 // terminate cancels the idle monitor and shuts down the subprocess.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -64,11 +64,6 @@ func (m *mockStore) DeletePhysical(ctx context.Context, id string) error {
 	return args.Error(0)
 }
 
-func (m *mockStore) Compact(ctx context.Context, threshold float64) error {
-	args := m.Called(ctx, threshold)
-	return args.Error(0)
-}
-
 func (m *mockStore) GetSessionsByState(ctx context.Context, state events.SessionState) ([]string, error) {
 	args := m.Called(ctx, state)
 	return args.Get(0).([]string), args.Error(1)

--- a/internal/session/pg_store.go
+++ b/internal/session/pg_store.go
@@ -3,7 +3,6 @@ package session
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -44,33 +43,17 @@ func NewPGStore(ctx context.Context, db *dbutil.DB) (Store, error) {
 // Upsert inserts or updates a session record.
 // Unlike SQLiteStore, no write serialization is needed — PG handles concurrency natively.
 func (s *pgStore) Upsert(ctx context.Context, info *SessionInfo) error {
-	if _, ok := ctx.Deadline(); !ok {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
+	ctx, cancel := upsertTimeout(ctx)
+	defer cancel()
+
+	ctxJSON, pkJSON, err := marshalSessionJSON(info)
+	if err != nil {
+		return err
 	}
 
-	var ctxJSON []byte
-	if info.Context != nil {
-		var err error
-		ctxJSON, err = json.Marshal(info.Context)
-		if err != nil {
-			return fmt.Errorf("session store: marshal context: %w", err)
-		}
-	}
-
-	var platformKeyJSON []byte
-	if info.PlatformKey != nil {
-		var err2 error
-		platformKeyJSON, err2 = json.Marshal(info.PlatformKey)
-		if err2 != nil {
-			return fmt.Errorf("session store: marshal platform key: %w", err2)
-		}
-	}
-
-	_, err := s.db.ExecContext(ctx, s.queries["sessions.upsert_session"],
+	_, err = s.db.ExecContext(ctx, s.queries["sessions.upsert_session"],
 		info.ID, info.UserID, info.OwnerID, info.BotID, info.BotName, info.WorkerSessionID, info.WorkerType, string(info.State),
-		info.Platform, string(platformKeyJSON), info.WorkDir, info.Title,
+		info.Platform, string(pkJSON), info.WorkDir, info.Title,
 		info.CreatedAt, info.UpdatedAt, info.ExpiresAt, info.IdleExpiresAt,
 		string(ctxJSON), info.Source, info.ClientKey,
 	)
@@ -151,12 +134,6 @@ func (s *pgStore) DeletePhysical(ctx context.Context, id string) error {
 	if err != nil {
 		return fmt.Errorf("session store: delete physical: %w", err)
 	}
-	return nil
-}
-
-// Compact is a no-op for PostgreSQL. PG handles bloat automatically with autovacuum;
-// there is no equivalent of SQLite VACUUM needed for routine session table maintenance.
-func (s *pgStore) Compact(_ context.Context, _ float64) error {
 	return nil
 }
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -24,7 +24,6 @@ type Store interface {
 	GetExpiredIdle(ctx context.Context, now time.Time) ([]string, error)
 	DeleteTerminated(ctx context.Context, cronCutoff, defaultCutoff time.Time) error
 	DeletePhysical(ctx context.Context, id string) error
-	Compact(ctx context.Context, threshold float64) error
 	GetSessionsByState(ctx context.Context, state events.SessionState) ([]string, error)
 	Close() error
 }
@@ -61,35 +60,44 @@ func NewSQLiteStore(ctx context.Context, cfg *config.Config, writeMu *sqlutil.Wr
 	return &SQLiteStore{db: db, log: slog.Default().With("component", "session_store"), writeMu: writeMu}, nil
 }
 
-func (s *SQLiteStore) Upsert(ctx context.Context, info *SessionInfo) error {
-	if _, ok := ctx.Deadline(); !ok {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
-	}
-
-	var ctxJSON []byte
+// marshalSessionJSON serializes the Context and PlatformKey fields for Upsert.
+func marshalSessionJSON(info *SessionInfo) (ctxJSON, pkJSON []byte, err error) {
 	if info.Context != nil {
-		var err error
 		ctxJSON, err = json.Marshal(info.Context)
 		if err != nil {
-			return fmt.Errorf("session store: marshal context: %w", err)
+			return nil, nil, fmt.Errorf("session store: marshal context: %w", err)
 		}
 	}
-
-	var platformKeyJSON []byte
 	if info.PlatformKey != nil {
-		var err2 error
-		platformKeyJSON, err2 = json.Marshal(info.PlatformKey)
-		if err2 != nil {
-			return fmt.Errorf("session store: marshal platform key: %w", err2)
+		pkJSON, err = json.Marshal(info.PlatformKey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("session store: marshal platform key: %w", err)
 		}
+	}
+	return ctxJSON, pkJSON, nil
+}
+
+// upsertTimeout ensures the context has a deadline, defaulting to 5 seconds.
+func upsertTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, 5*time.Second)
+}
+
+func (s *SQLiteStore) Upsert(ctx context.Context, info *SessionInfo) error {
+	ctx, cancel := upsertTimeout(ctx)
+	defer cancel()
+
+	ctxJSON, pkJSON, err := marshalSessionJSON(info)
+	if err != nil {
+		return err
 	}
 
 	return s.writeMu.WithLock(func() error {
 		_, err := s.db.ExecContext(ctx, queries["sessions.upsert_session"],
 			info.ID, info.UserID, info.OwnerID, info.BotID, info.BotName, info.WorkerSessionID, info.WorkerType, string(info.State),
-			info.Platform, string(platformKeyJSON), info.WorkDir, info.Title,
+			info.Platform, string(pkJSON), info.WorkDir, info.Title,
 			info.CreatedAt, info.UpdatedAt, info.ExpiresAt, info.IdleExpiresAt,
 			string(ctxJSON), info.Source, info.ClientKey,
 		)

--- a/internal/worker/base/worker.go
+++ b/internal/worker/base/worker.go
@@ -59,47 +59,41 @@ func NewBaseWorker(log *slog.Logger, cfg *config.Config) *BaseWorker {
 	}
 }
 
-// withProc executes fn while holding a snapshot of w.Proc. If Proc is nil, it
-// returns nil immediately. On success, Proc is nil'd under the mutex. This
-// eliminates the repeated lock-get-nil-unlock pattern across Terminate/Kill.
-func (w *BaseWorker) withProc(fn func(*proc.Manager) error) error {
+// withProcResult executes fn with a snapshot of w.Proc. If Proc is nil,
+// returns (zero, errNil). On success, Proc is nil'd under the mutex.
+// This eliminates the repeated lock-snapshot-nil-clear pattern.
+func withProcResult[T any](w *BaseWorker, fn func(*proc.Manager) (T, error), zero T, errNil error) (T, error) {
 	w.Mu.Lock()
 	p := w.Proc
 	w.Mu.Unlock()
 
 	if p == nil {
-		return nil
+		return zero, errNil
 	}
-	if err := fn(p); err != nil {
-		return err
+
+	result, err := fn(p)
+	if err != nil {
+		return result, err
 	}
 
 	w.Mu.Lock()
 	w.Proc = nil
 	w.Mu.Unlock()
 
-	return nil
+	return result, nil
+}
+
+// withProc executes fn with a snapshot of w.Proc. If Proc is nil, returns nil.
+func (w *BaseWorker) withProc(fn func(*proc.Manager) error) error {
+	_, err := withProcResult(w, func(p *proc.Manager) (struct{}, error) {
+		return struct{}{}, fn(p)
+	}, struct{}{}, nil)
+	return err
 }
 
 // withProcCode is the (int, error) variant of withProc, used by Wait.
 func (w *BaseWorker) withProcCode(fn func(*proc.Manager) (int, error)) (int, error) {
-	w.Mu.Lock()
-	p := w.Proc
-	w.Mu.Unlock()
-
-	if p == nil {
-		return -1, fmt.Errorf("base: not started")
-	}
-	code, err := fn(p)
-	if err != nil {
-		return code, err
-	}
-
-	w.Mu.Lock()
-	w.Proc = nil
-	w.Mu.Unlock()
-
-	return code, nil
+	return withProcResult(w, fn, -1, fmt.Errorf("base: not started"))
 }
 
 // Terminate gracefully stops the worker process: SIGTERM → 5s grace → SIGKILL.

--- a/internal/worker/base/worker.go
+++ b/internal/worker/base/worker.go
@@ -59,18 +59,19 @@ func NewBaseWorker(log *slog.Logger, cfg *config.Config) *BaseWorker {
 	}
 }
 
-// Terminate gracefully stops the worker process: SIGTERM → 5s grace → SIGKILL.
-func (w *BaseWorker) Terminate(ctx context.Context) error {
+// withProc executes fn while holding a snapshot of w.Proc. If Proc is nil, it
+// returns nil immediately. On success, Proc is nil'd under the mutex. This
+// eliminates the repeated lock-get-nil-unlock pattern across Terminate/Kill.
+func (w *BaseWorker) withProc(fn func(*proc.Manager) error) error {
 	w.Mu.Lock()
-	proc := w.Proc
+	p := w.Proc
 	w.Mu.Unlock()
 
-	if proc == nil {
+	if p == nil {
 		return nil
 	}
-
-	if err := proc.Terminate(ctx, GracefulShutdownTimeout); err != nil {
-		return fmt.Errorf("base: terminate: %w", err)
+	if err := fn(p); err != nil {
+		return err
 	}
 
 	w.Mu.Lock()
@@ -80,40 +81,18 @@ func (w *BaseWorker) Terminate(ctx context.Context) error {
 	return nil
 }
 
-// Kill immediately terminates the worker process with SIGKILL.
-func (w *BaseWorker) Kill() error {
+// withProcCode is the (int, error) variant of withProc, used by Wait.
+func (w *BaseWorker) withProcCode(fn func(*proc.Manager) (int, error)) (int, error) {
 	w.Mu.Lock()
-	proc := w.Proc
+	p := w.Proc
 	w.Mu.Unlock()
 
-	if proc == nil {
-		return nil
-	}
-
-	if err := proc.Kill(); err != nil {
-		return fmt.Errorf("base: kill: %w", err)
-	}
-
-	w.Mu.Lock()
-	w.Proc = nil
-	w.Mu.Unlock()
-
-	return nil
-}
-
-// Wait blocks until the worker process exits, returning the exit code.
-func (w *BaseWorker) Wait() (int, error) {
-	w.Mu.Lock()
-	proc := w.Proc
-	w.Mu.Unlock()
-
-	if proc == nil {
+	if p == nil {
 		return -1, fmt.Errorf("base: not started")
 	}
-
-	code, err := proc.Wait()
+	code, err := fn(p)
 	if err != nil {
-		return code, fmt.Errorf("base: wait: %w", err)
+		return code, err
 	}
 
 	w.Mu.Lock()
@@ -121,6 +100,37 @@ func (w *BaseWorker) Wait() (int, error) {
 	w.Mu.Unlock()
 
 	return code, nil
+}
+
+// Terminate gracefully stops the worker process: SIGTERM → 5s grace → SIGKILL.
+func (w *BaseWorker) Terminate(ctx context.Context) error {
+	return w.withProc(func(p *proc.Manager) error {
+		if err := p.Terminate(ctx, GracefulShutdownTimeout); err != nil {
+			return fmt.Errorf("base: terminate: %w", err)
+		}
+		return nil
+	})
+}
+
+// Kill immediately terminates the worker process with SIGKILL.
+func (w *BaseWorker) Kill() error {
+	return w.withProc(func(p *proc.Manager) error {
+		if err := p.Kill(); err != nil {
+			return fmt.Errorf("base: kill: %w", err)
+		}
+		return nil
+	})
+}
+
+// Wait blocks until the worker process exits, returning the exit code.
+func (w *BaseWorker) Wait() (int, error) {
+	return w.withProcCode(func(p *proc.Manager) (int, error) {
+		code, err := p.Wait()
+		if err != nil {
+			return code, fmt.Errorf("base: wait: %w", err)
+		}
+		return code, nil
+	})
 }
 
 // Health returns a snapshot of the worker's runtime health.

--- a/internal/worker/proc/manager.go
+++ b/internal/worker/proc/manager.go
@@ -323,18 +323,12 @@ func (m *Manager) SetPIDKey(key string) {
 // trackPID writes the current PGID to the tracker. Must be called after Start()
 // when m.pgid is set. Safe to call even if tracker is nil.
 func (m *Manager) trackPID() {
-	if t := GlobalTracker(); t != nil && m.pidKey != "" {
-		if err := t.Write(m.pidKey, m.pgid); err != nil {
-			m.log.Warn("proc: pidfile write", "key", m.pidKey, "err", err)
-		}
-	}
+	TrackPID(m.pidKey, m.pgid, m.log, "proc")
 }
 
 // untrackPID removes the PID file for key. Safe to call even if tracker is nil.
 func (m *Manager) untrackPID(key string) {
-	if t := GlobalTracker(); t != nil && key != "" {
-		_ = t.Remove(key)
-	}
+	UntrackPID(key)
 }
 
 // IsRunning returns true if the process has been started and has not exited.

--- a/internal/worker/proc/pid_helpers.go
+++ b/internal/worker/proc/pid_helpers.go
@@ -1,0 +1,25 @@
+package proc
+
+import "log/slog"
+
+// TrackPID writes (key, pgid) to the global PID tracker. No-op if tracker is
+// nil or key is empty. On write error, logs a warning prefixed with component.
+func TrackPID(key string, pgid int, log *slog.Logger, component string) {
+	t := GlobalTracker()
+	if t == nil || key == "" {
+		return
+	}
+	if err := t.Write(key, pgid); err != nil {
+		log.Warn(component+": pidfile write", "key", key, "err", err)
+	}
+}
+
+// UntrackPID removes the PID file entry for key. No-op if tracker is nil or
+// key is empty.
+func UntrackPID(key string) {
+	t := GlobalTracker()
+	if t == nil || key == "" {
+		return
+	}
+	_ = t.Remove(key)
+}


### PR DESCRIPTION
## Summary

4 high-ROI DRY extractions targeting repeated code patterns across worker, messaging, session, and admin modules.

Closes #504, #511, #508, #516

## Changes by Issue

### #504 — messaging/stt: PersistentSTT PID tracker cleanup DRY
- Extract `trackPID()` and `untrackPID()` helpers on PersistentSTT
- Replace 3 inline copy-paste sites in `start()`, `shutdownProcess()`, `kill()`
- Eliminates risk of new cleanup paths forgetting PID tracking

### #511 — worker/base: Terminate/Kill/Wait lock pattern DRY
- Extract `withProc()` (error) and `withProcCode()` (int, error) helpers
- Terminate/Kill use `withProc`, Wait uses `withProcCode`
- Reduces 18 Lock/Unlock calls to 6, single source of truth for lock protocol

### #508 — session/store: Compact ISP violation + Upsert DRY
- Remove `Compact()` from `Store` interface (never called via interface)
- Remove pgStore Compact no-op and mockStore stub
- Extract `marshalSessionJSON()` and `upsertTimeout()` to eliminate Upsert JSON serialization duplication

### #516 — admin: dual-store CRUD DRY
- Add `apiKeyStoreBase` with shared `list`/`get`/`delete`/`Invalidator`/`SetInvalidator`
- Add `prepareQuery()` for dialect rebind and `ensureAPIKey()` for key generation
- Add `withLock` func field to abstract write serialization (writeMu vs identity)
- SQLite/PG stores embed base, keep `create`/`update` where dialect differences are real

## Testing

- [x] `make test-short` — all packages pass
- [x] `make lint` — 0 issues
- [x] `make build` — compiles cleanly
- [x] Pre-push hooks (gofmt, golangci-lint, go vet, module checksum, build, tests) — all passed

## Commits

4 atomic commits, one per issue:
1. `refactor(messaging/stt): extract trackPID/untrackPID helpers`
2. `refactor(worker/base): extract withProc/withProcCode helpers`
3. `refactor(session/store): remove Compact from Store interface + extract Upsert helpers`
4. `refactor(admin): extract apiKeyStoreBase

---
### Merged from #694
- docs(patrol): cron delivery retry docs + metrics (#693)