### PR TITLE
feat(codexcli): recover conversation history from turns table on session resume

### DIFF
--- a/docs/specs/CodexCLI-Session-History-Recovery-Spec.md
+++ b/docs/specs/CodexCLI-Session-History-Recovery-Spec.md
@@ -64,12 +64,14 @@ worker.Start(info) → startNewThread()
 worker.Input(content)  ← 用户首条消息
   └→ injectHistoryPrefix(content)
        ↓
-     "<conversation_history>
+     "---
+      CONVERSATION_HISTORY_START
       [User]: 现在开始我发 ping，你回复 汪
       [Assistant]: 收到，以后你发 ping 我就回 汪
       [User]: ping
       [Assistant]: 汪
-      </conversation_history>
+      CONVERSATION_HISTORY_END
+      ---
 
       ping"                              ← 实际用户消息
   ↓
@@ -212,7 +214,8 @@ func (w *AppServerWorker) injectHistoryPrefix(content string) string {
     w.mu.Unlock()
 
     var sb strings.Builder
-    sb.WriteString("<conversation_history>\n")
+    sb.WriteString("---
+      CONVERSATION_HISTORY_START\n")
     sb.WriteString("Below is the conversation history from a previous session. ")
     sb.WriteString("Use it as context to maintain continuity.\n\n")
     for _, turn := range history {
@@ -227,7 +230,8 @@ func (w *AppServerWorker) injectHistoryPrefix(content string) string {
         sb.WriteString(turn.Content)
         sb.WriteString("\n\n")
     }
-    sb.WriteString("</conversation_history>\n\n")
+    sb.WriteString("CONVERSATION_HISTORY_END
+      ---\n\n")
     sb.WriteString(content)
     return sb.String()
 }
@@ -287,7 +291,8 @@ func (w *AppServerWorker) cleanupOldThread() {
 
 | 测试用例 | 验证 |
 |----------|------|
-| `TestInjectHistoryPrefix` | 验证格式化输出包含 `[User]`/`[Assistant]` 标记和 `<conversation_history>` 标签 |
+| `TestInjectHistoryPrefix` | 验证格式化输出包含 `[User]`/`[Assistant]` 标记和 `---
+      CONVERSATION_HISTORY_START` 标签 |
 | `TestInjectHistoryPrefixIdempotent` | 验证第二次调用 `injectHistoryPrefix` 不修改 content（`historyInjected` 标志） |
 | `TestInjectHistoryPrefixEmpty` | `pendingHistory` 为空/nil 时返回原 content |
 | `TestInjectHistoryPrefixSkipsEmpty` | 空 Content 的 turn 被跳过 |

--- a/docs/specs/CodexCLI-Session-History-Recovery-Spec.md
+++ b/docs/specs/CodexCLI-Session-History-Recovery-Spec.md
@@ -1,0 +1,321 @@
+# Feature: CodexCLI 会话历史恢复 — 从 Turn 表重建上下文
+
+**Issue**: CodexCLI worker 无法会话保持
+**Severity**: P2 (用户体验核心问题：上下文丢失导致指令遗忘)
+**Scope**: `internal/worker/worker.go`, `internal/gateway/bridge.go`, `internal/worker/codexcli/worker.go`
+**Prerequisite**: 熟悉 CodexCLI `AppServerWorker` singleton 模式、bridge `prepareWorkerInfo` 流程、`TurnQuerier` 接口
+
+---
+
+## 1. Problem Statement
+
+CodexCLI worker 使用 `codex app-server` 单例进程管理 thread。所有 thread 历史存储在进程内存中，无磁盘持久化。
+
+当 session 空闲超过 30 分钟，Zombie GC 终止 session → app-server 进程被 KillIfIdle 杀死 → 所有对话历史随进程销毁。用户下次发消息时，创建全新 thread，无法记住之前的指令。
+
+**复现场景**（2026-06-09 22:05–22:41 实际日志）:
+
+| 时间 | 事件 |
+|------|------|
+| 22:05:04 | 用户发送 "现在开始我发 ping，你回复 汪"，session `092bc1ab` 处理 |
+| 22:05:23 | Session 最后 IO |
+| 22:36:21 | Zombie GC 终止 session（30 分钟无 IO），KillIfIdle 立即杀死 app-server 进程 |
+| 22:41:48 | 用户在同一 Slack thread 发 "ping"，Resume 失败 → 创建全新 session/thread |
+| 22:41:49 | Agent 回复 "pong" 而非 "汪" — 历史完全丢失 |
+
+**根因链**:
+
+1. **Zombie GC**（30 min execution timeout）终止空闲 session
+2. **KillIfIdle** 立即杀死 app-server 进程（绕过 30 分钟 drain timer）
+3. **Thread 历史全丢** — 仅存于进程内存，无持久化
+4. **Resume 创建新 thread** — `startNewThread()` 调用 `thread/start` 创建全新 thread
+5. **thread/start 协议不支持恢复** — `ThreadStartParams` 无 threadId 字段
+
+**对比 Claude Code worker**（无此问题）: 使用 `--session-id` + `--resume` 参数，session 文件持久化在磁盘。进程重启后从磁盘加载历史。
+
+---
+
+## 2. Solution: 从 Turn 表重建上下文
+
+### 2.1 核心思路
+
+HotPlex 的 `turns` 表已经持久化了完整的 user/assistant 对话文本。当 CodexCLI 创建新 thread 时，查询 turn 历史，格式化为上下文前缀，注入首条用户消息。
+
+**数据流**:
+
+```
+用户发消息
+  ↓
+StartPlatformSession → session TERMINATED
+  ↓
+prepareWorkerInfo()
+  ├→ buildWorkerInfo()       (现有逻辑)
+  ├→ turnsQuerier.QueryTurns(sessionID, 50, 0)  ← 新增
+  │    ↓
+  │  []TurnRecord → []ConversationTurn
+  │    ↓
+  │  info.ConversationHistory = history
+  ├→ injectSlackEnv()        (现有逻辑)
+  └→ injectGatewayContext()  (现有逻辑)
+  ↓
+worker.Start(info) → startNewThread()
+  └→ 存储 info.ConversationHistory 到 w.pendingHistory
+  ↓
+worker.Input(content)  ← 用户首条消息
+  └→ injectHistoryPrefix(content)
+       ↓
+     "<conversation_history>
+      [User]: 现在开始我发 ping，你回复 汪
+      [Assistant]: 收到，以后你发 ping 我就回 汪
+      [User]: ping
+      [Assistant]: 汪
+      </conversation_history>
+
+      ping"                              ← 实际用户消息
+  ↓
+turn/start → agent 看到完整上下文，正确回复 "汪"
+```
+
+### 2.2 为什么选择首条 Input 注入
+
+| 方案 | 优势 | 劣势 |
+|------|------|------|
+| **A. SystemPrompt 注入** | 语义清晰 | CodexCLI worker 不将 SystemPrompt 传递给 app-server |
+| B. thread/start params | 协议层支持 | upstream 不支持 input 参数 |
+| C. 单独 turn/start | 隔离性好 | 触发 agent 不必要的响应，浪费 token |
+| **D. 首条 Input 前缀** ✓ | 最简洁，无协议改动，同 turn 内可见 | 历史作为 user message 的一部分 |
+
+选择方案 D：在首条 `Input()` 调用时，将历史格式化为结构化文本块，拼接到用户消息前面。Agent 在同一 turn 内同时看到历史上下文和当前消息。
+
+---
+
+## 3. Detailed Design
+
+### 3.1 新增类型 — `internal/worker/worker.go`
+
+在 `SessionInfo` 结构体后添加 `ConversationTurn` 类型：
+
+```go
+// ConversationTurn represents a single turn in a conversation history,
+// used to seed context when a worker cannot natively resume its session.
+type ConversationTurn struct {
+    Role    string // "user" | "assistant"
+    Content string
+}
+```
+
+在 `SessionInfo` 末尾添加字段：
+
+```go
+// ConversationHistory carries prior turns for pre-seeding a new worker thread.
+// Populated by the bridge when resuming/recreating a session with existing history.
+// Workers that support native resume (Claude Code --resume) ignore this;
+// workers that always create fresh threads (CodexCLI) use it to inject context.
+ConversationHistory []ConversationTurn
+```
+
+### 3.2 填充历史 — `internal/gateway/bridge.go`
+
+在 `prepareWorkerInfo()` 中，`buildWorkerInfo()` 之后、`injectSlackEnv()` 之前，查询 turns 表：
+
+```go
+func (b *Bridge) prepareWorkerInfo(sessionID, userID, workDir string, si *session.SessionInfo) worker.SessionInfo {
+    info := b.buildWorkerInfo(sessionID, userID, workDir, si)
+
+    // Populate conversation history from turns table for context recovery.
+    if b.turnsQuerier != nil {
+        if turns, err := b.turnsQuerier.QueryTurns(context.Background(), sessionID, 50, 0); err == nil && len(turns) > 0 {
+            history := make([]worker.ConversationTurn, 0, len(turns))
+            for _, t := range turns {
+                if t.Content == "" {
+                    continue
+                }
+                history = append(history, worker.ConversationTurn{
+                    Role:    t.Role,
+                    Content: t.Content,
+                })
+            }
+            info.ConversationHistory = history
+        }
+    }
+
+    injectSlackEnv(&info, si.PlatformKey)
+    info.Env = injectGatewayContext(info.Env, si.Platform, si.BotID, si.BotName, si.UserID, si.PlatformKey, sessionID, workDir)
+    return info
+}
+```
+
+**设计决策**:
+- **最近 50 条 turn**（约 25 轮对话），足够覆盖短期间断场景
+- 空内容 turn 跳过
+- 查询失败静默忽略（不阻塞 session 创建）
+- `b.turnsQuerier` 已是 Bridge 字段（bridge.go:45），无需新依赖注入
+
+### 3.3 CodexCLI 消费历史 — `internal/worker/codexcli/worker.go`
+
+#### 3.3.1 新增字段
+
+在 `AppServerWorker` 结构体中添加：
+
+```go
+pendingHistory  []worker.ConversationTurn // stored from session info
+historyInjected bool                      // protected by w.mu
+```
+
+#### 3.3.2 startNewThread 存储历史
+
+在 `startNewThread()` 中，thread 创建成功后存储历史：
+
+```go
+func (w *AppServerWorker) startNewThread(session worker.SessionInfo, errPrefix string) error {
+    // ... existing code ...
+
+    // Store conversation history for first-input injection.
+    w.mu.Lock()
+    w.pendingHistory = session.ConversationHistory
+    w.historyInjected = false
+    w.mu.Unlock()
+
+    return nil
+}
+```
+
+#### 3.3.3 Input 注入历史前缀
+
+在 `Input()` 中，metadata dispatch 之后、构建 `TurnStartParams` 之前，注入历史：
+
+```go
+func (w *AppServerWorker) Input(ctx context.Context, content string, metadata map[string]any) error {
+    // ... existing metadata dispatch ...
+
+    // Inject conversation history prefix on first input of a new thread.
+    content = w.injectHistoryPrefix(content)
+
+    // ... existing turn/start logic (unchanged) ...
+}
+```
+
+#### 3.3.4 新增 injectHistoryPrefix 方法
+
+```go
+// injectHistoryPrefix prepends conversation history to the first user input
+// of a new thread. After injection, pendingHistory is cleared.
+func (w *AppServerWorker) injectHistoryPrefix(content string) string {
+    w.mu.Lock()
+    if w.historyInjected || len(w.pendingHistory) == 0 {
+        w.mu.Unlock()
+        return content
+    }
+    history := w.pendingHistory
+    w.pendingHistory = nil
+    w.historyInjected = true
+    w.mu.Unlock()
+
+    var sb strings.Builder
+    sb.WriteString("<conversation_history>\n")
+    sb.WriteString("Below is the conversation history from a previous session. ")
+    sb.WriteString("Use it as context to maintain continuity.\n\n")
+    for _, turn := range history {
+        switch turn.Role {
+        case "user":
+            sb.WriteString("[User]: ")
+        case "assistant":
+            sb.WriteString("[Assistant]: ")
+        default:
+            continue
+        }
+        sb.WriteString(turn.Content)
+        sb.WriteString("\n\n")
+    }
+    sb.WriteString("</conversation_history>\n\n")
+    sb.WriteString(content)
+    return sb.String()
+}
+```
+
+#### 3.3.5 cleanupOldThread 重置状态
+
+在 `cleanupOldThread()` 中清理历史注入状态：
+
+```go
+func (w *AppServerWorker) cleanupOldThread() {
+    // ... existing unsubscribe logic ...
+    w.mu.Lock()
+    // ... existing cleanup ...
+    w.pendingHistory = nil
+    w.historyInjected = false
+    w.mu.Unlock()
+}
+```
+
+---
+
+## 4. Impact Analysis
+
+### 4.1 受影响的 Worker 类型
+
+| Worker | 影响 | 说明 |
+|--------|------|------|
+| **CodexCLI** | ✅ 消费历史 | 首条 Input 注入历史前缀 |
+| Claude Code | ❌ 不受影响 | 已有 `--resume` 原生恢复，`ConversationHistory` 为空切片 |
+| OpenCode Server | ❌ 不受影响 | 使用 session ID 恢复 |
+| ACP | ❌ 不受影响 | 无状态适配器 |
+
+### 4.2 性能影响
+
+- `prepareWorkerInfo()` 增加一次 `QueryTurns()` DB 查询，带 session_id 索引，~1ms
+- 首条 Input 消息体增大（历史文本），增加 token 消耗
+- 后续 Input 不受影响（`historyInjected` 标志跳过）
+
+### 4.3 边界情况
+
+| 场景 | 行为 |
+|------|------|
+| 全新 session（无历史） | `QueryTurns` 返回空，`ConversationHistory` 为 nil，`injectHistoryPrefix` 返回原 content |
+| 查询失败 | 静默忽略，session 正常创建（无历史恢复） |
+| 用户执行 /reset | generation 递增，`QueryTurns` 按新 generation 查询，只看到新历史 |
+| 长对话（>50 turns） | 只取最近 50 条，早期上下文丢弃 |
+| 助手回复含长文本/代码 | 完整注入，可能消耗较多 token |
+
+---
+
+## 5. Testing Plan
+
+### 5.1 单元测试
+
+在 `internal/worker/codexcli/worker_test.go` 添加：
+
+| 测试用例 | 验证 |
+|----------|------|
+| `TestInjectHistoryPrefix` | 验证格式化输出包含 `[User]`/`[Assistant]` 标记和 `<conversation_history>` 标签 |
+| `TestInjectHistoryPrefixIdempotent` | 验证第二次调用 `injectHistoryPrefix` 不修改 content（`historyInjected` 标志） |
+| `TestInjectHistoryPrefixEmpty` | `pendingHistory` 为空/nil 时返回原 content |
+| `TestInjectHistoryPrefixSkipsEmpty` | 空 Content 的 turn 被跳过 |
+| `TestInjectHistoryPrefixClearedOnCleanup` | `cleanupOldThread()` 后状态重置 |
+
+### 5.2 集成测试
+
+1. 启动 dev gateway（`make dev`）
+2. 通过 Slack 发送 "记住我的名字是小明"
+3. 等待 turn 完成，确认回复
+4. 等待 zombie GC 或通过 API 手动 terminate session
+5. 在同一 Slack thread 发送 "我叫什么"
+6. 验证回复包含 "小明"（从历史恢复）
+
+### 5.3 回归验证
+
+```bash
+make test-short   # 快速测试
+make lint         # golangci-lint
+make check        # 完整 CI
+```
+
+---
+
+## 6. Future Improvements (Out of Scope)
+
+- **Token 预算控制**: 基于 `TurnRecord.TokensIn` 累计，动态决定注入多少轮历史
+- **历史摘要**: 对长对话生成摘要替代全文注入，减少 token 消耗
+- **配置化**: 将历史条数上限（当前硬编码 50）暴露为 YAML 配置项
+- **Tool 事件注入**: 当前仅注入 text turn，未来可选择性注入 tool_call/tool_result
+- **上游 thread resume**: 推动 codex app-server 支持 `thread/resume` API，从根本上解决

--- a/docs/specs/CodexCLI-Session-History-Recovery-Spec.md
+++ b/docs/specs/CodexCLI-Session-History-Recovery-Spec.md
@@ -314,7 +314,7 @@ make check        # 完整 CI
 
 ## 6. Future Improvements (Out of Scope)
 
-- **Token 预算控制**: 基于 `TurnRecord.TokensIn` 累计，动态决定注入多少轮历史
+- **~Token 预算控制~**: ~~基于 `TurnRecord.TokensIn` 累计~~ → 已实现：字符级预算 `maxHistoryChars=50000`，按 `len(turn.Content)` 累计
 - **历史摘要**: 对长对话生成摘要替代全文注入，减少 token 消耗
 - **配置化**: 将历史条数上限（当前硬编码 50）暴露为 YAML 配置项
 - **Tool 事件注入**: 当前仅注入 text turn，未来可选择性注入 tool_call/tool_result

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -727,6 +727,24 @@ func injectSandbox(platformKey map[string]string, sandbox string) {
 // injectGatewayContext trio that was previously duplicated across 3 call sites.
 func (b *Bridge) prepareWorkerInfo(sessionID, userID, workDir string, si *session.SessionInfo) worker.SessionInfo {
 	info := b.buildWorkerInfo(sessionID, userID, workDir, si)
+
+	// Populate conversation history from turns table for context recovery.
+	if b.turnsQuerier != nil {
+		if turns, err := b.turnsQuerier.QueryTurns(context.Background(), sessionID, 50, 0); err == nil && len(turns) > 0 {
+			history := make([]worker.ConversationTurn, 0, len(turns))
+			for _, t := range turns {
+				if t.Content == "" {
+					continue
+				}
+				history = append(history, worker.ConversationTurn{
+					Role:    t.Role,
+					Content: t.Content,
+				})
+			}
+			info.ConversationHistory = history
+		}
+	}
+
 	injectSlackEnv(&info, si.PlatformKey)
 	info.Env = injectGatewayContext(info.Env, si.Platform, si.BotID, si.BotName, si.UserID, si.PlatformKey, sessionID, workDir)
 	return info

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -42,7 +42,7 @@ type Bridge struct {
 	hub          *Hub
 	sm           bridgeSM
 	collector    *eventstore.Collector  // optional; nil means event storage disabled
-	turnsQuerier eventstore.TurnQuerier // optional; for LatestGeneration on startup
+	turnsQuerier eventstore.TurnQuerier // optional; for LatestGeneration on startup and history recovery for CodexCLI
 	wf           WorkerFactory
 	retryCtrl    *LLMRetryController
 
@@ -729,22 +729,23 @@ func (b *Bridge) prepareWorkerInfo(ctx context.Context, sessionID, userID, workD
 	info := b.buildWorkerInfo(sessionID, userID, workDir, si)
 
 	// Populate conversation history from turns table for context recovery.
-	if b.turnsQuerier != nil {
+	// Only CodexCLI worker needs this — other workers have native resume.
+	if si.WorkerType == worker.TypeCodexCLI && b.turnsQuerier != nil {
 		turns, err := b.turnsQuerier.QueryTurns(ctx, sessionID, 50, 0)
 		if err != nil {
 			b.log.Warn("bridge: query turns for history recovery failed", "session_id", sessionID, "error", err)
 		} else if len(turns) > 0 {
-			const maxHistoryTokens = 20000
+			const maxHistoryChars = 50000
 			history := make([]worker.ConversationTurn, 0, len(turns))
-			tokensUsed := 0
+			charsUsed := 0
 			for _, t := range turns {
 				if t.Content == "" {
 					continue
 				}
-				if tokensUsed+int(t.TokensIn) > maxHistoryTokens {
+				if charsUsed+len(t.Content) > maxHistoryChars {
 					break
 				}
-				tokensUsed += int(t.TokensIn)
+				charsUsed += len(t.Content)
 				history = append(history, worker.ConversationTurn{
 					Role:    t.Role,
 					Content: t.Content,

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -157,7 +157,7 @@ func (b *Bridge) StartSession(ctx context.Context, p worker.SessionStartParams) 
 		return fmt.Errorf("bridge: create session: %w", err)
 	}
 
-	workerInfo := b.prepareWorkerInfo(p.ID, p.UserID, p.WorkDir, si)
+	workerInfo := b.prepareWorkerInfo(ctx, p.ID, p.UserID, p.WorkDir, si)
 
 	// Inject cron-specific env vars (e.g. admin API creds) only for cron sessions.
 	// Detected via platformKey rather than platform value, since cron executor now
@@ -277,7 +277,7 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 		si.State = events.StateRunning
 	}
 
-	workerInfo := b.prepareWorkerInfo(si.ID, si.UserID, workDir, si)
+	workerInfo := b.prepareWorkerInfo(ctx, si.ID, si.UserID, workDir, si)
 	w, err := b.createAndLaunchWorker(workerLaunchParams{
 		ctx:         ctx,
 		wt:          si.WorkerType,
@@ -725,17 +725,26 @@ func injectSandbox(platformKey map[string]string, sandbox string) {
 // prepareWorkerInfo builds a complete worker.SessionInfo with all standard env
 // injection applied. This consolidates the buildWorkerInfo + injectSlackEnv +
 // injectGatewayContext trio that was previously duplicated across 3 call sites.
-func (b *Bridge) prepareWorkerInfo(sessionID, userID, workDir string, si *session.SessionInfo) worker.SessionInfo {
+func (b *Bridge) prepareWorkerInfo(ctx context.Context, sessionID, userID, workDir string, si *session.SessionInfo) worker.SessionInfo {
 	info := b.buildWorkerInfo(sessionID, userID, workDir, si)
 
 	// Populate conversation history from turns table for context recovery.
 	if b.turnsQuerier != nil {
-		if turns, err := b.turnsQuerier.QueryTurns(context.Background(), sessionID, 50, 0); err == nil && len(turns) > 0 {
+		turns, err := b.turnsQuerier.QueryTurns(ctx, sessionID, 50, 0)
+		if err != nil {
+			b.log.Warn("bridge: query turns for history recovery failed", "session_id", sessionID, "error", err)
+		} else if len(turns) > 0 {
+			const maxHistoryTokens = 20000
 			history := make([]worker.ConversationTurn, 0, len(turns))
+			tokensUsed := 0
 			for _, t := range turns {
 				if t.Content == "" {
 					continue
 				}
+				if tokensUsed+int(t.TokensIn) > maxHistoryTokens {
+					break
+				}
+				tokensUsed += int(t.TokensIn)
 				history = append(history, worker.ConversationTurn{
 					Role:    t.Role,
 					Content: t.Content,

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -176,7 +176,7 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 		si.State = events.StateRunning
 	}
 
-	workerInfo := b.prepareWorkerInfo(context.Background(), si.ID, si.UserID, p.workDir, si)
+	workerInfo := b.prepareWorkerInfo(b.shutdownCtx, si.ID, si.UserID, p.workDir, si)
 
 	w, err := b.createAndLaunchWorker(workerLaunchParams{
 		ctx:           context.Background(),

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -176,7 +176,7 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 		si.State = events.StateRunning
 	}
 
-	workerInfo := b.prepareWorkerInfo(si.ID, si.UserID, p.workDir, si)
+	workerInfo := b.prepareWorkerInfo(context.Background(), si.ID, si.UserID, p.workDir, si)
 
 	w, err := b.createAndLaunchWorker(workerLaunchParams{
 		ctx:           context.Background(),

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -176,7 +176,7 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 		si.State = events.StateRunning
 	}
 
-	workerInfo := b.prepareWorkerInfo(b.shutdownCtx, si.ID, si.UserID, p.workDir, si)
+	workerInfo := b.prepareWorkerInfo(context.Background(), si.ID, si.UserID, p.workDir, si)
 
 	w, err := b.createAndLaunchWorker(workerLaunchParams{
 		ctx:           context.Background(),

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -354,7 +355,7 @@ func (w *AppServerWorker) startNewThread(session worker.SessionInfo, errPrefix s
 	}
 	w.StartTime = time.Now()
 	w.SetLastIO(w.StartTime)
-	w.pendingHistory = session.ConversationHistory
+	w.pendingHistory = slices.Clone(session.ConversationHistory)
 	w.historyInjected = false
 	w.mu.Unlock()
 
@@ -375,7 +376,8 @@ func (w *AppServerWorker) injectHistoryPrefix(content string) string {
 	w.mu.Unlock()
 
 	var sb strings.Builder
-	sb.WriteString("<conversation_history>\n")
+	sb.WriteString("---\n")
+	sb.WriteString("CONVERSATION_HISTORY_START\n")
 	sb.WriteString("Below is the conversation history from a previous session. ")
 	sb.WriteString("Use it as context to maintain continuity.\n\n")
 	for _, turn := range history {
@@ -390,7 +392,8 @@ func (w *AppServerWorker) injectHistoryPrefix(content string) string {
 		sb.WriteString(turn.Content)
 		sb.WriteString("\n\n")
 	}
-	sb.WriteString("</conversation_history>\n\n")
+	sb.WriteString("CONVERSATION_HISTORY_END\n")
+	sb.WriteString("---\n\n")
 	sb.WriteString(content)
 	return sb.String()
 }

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -104,6 +105,11 @@ type AppServerWorker struct {
 	// origSession preserves the SessionInfo from the most recent Start()
 	// call so that ResetContext can re-establish a fresh thread after cleanup.
 	origSession worker.SessionInfo
+
+	// pendingHistory stores ConversationHistory from SessionInfo for injection
+	// into the first user input of a new thread. Cleared after injection.
+	pendingHistory  []worker.ConversationTurn
+	historyInjected bool
 }
 
 // appConn implements worker.SessionConn for the app-server mode.
@@ -207,6 +213,8 @@ func (w *AppServerWorker) Input(ctx context.Context, content string, metadata ma
 		return nil
 	}
 
+	content = w.injectHistoryPrefix(content)
+
 	w.mu.Lock()
 	tid := w.threadID
 	w.mu.Unlock()
@@ -275,6 +283,8 @@ func (w *AppServerWorker) cleanupOldThread() {
 	oldThreadID := w.threadID
 	w.recvCh = nil
 	w.conn = nil
+	w.pendingHistory = nil
+	w.historyInjected = false
 	w.mu.Unlock()
 
 	if oldConn != nil {
@@ -344,9 +354,45 @@ func (w *AppServerWorker) startNewThread(session worker.SessionInfo, errPrefix s
 	}
 	w.StartTime = time.Now()
 	w.SetLastIO(w.StartTime)
+	w.pendingHistory = session.ConversationHistory
+	w.historyInjected = false
 	w.mu.Unlock()
 
 	return nil
+}
+
+// injectHistoryPrefix prepends conversation history to the first user
+// input of a new thread. After injection, pendingHistory is cleared.
+func (w *AppServerWorker) injectHistoryPrefix(content string) string {
+	w.mu.Lock()
+	if w.historyInjected || len(w.pendingHistory) == 0 {
+		w.mu.Unlock()
+		return content
+	}
+	history := w.pendingHistory
+	w.pendingHistory = nil
+	w.historyInjected = true
+	w.mu.Unlock()
+
+	var sb strings.Builder
+	sb.WriteString("<conversation_history>\n")
+	sb.WriteString("Below is the conversation history from a previous session. ")
+	sb.WriteString("Use it as context to maintain continuity.\n\n")
+	for _, turn := range history {
+		switch turn.Role {
+		case "user":
+			sb.WriteString("[User]: ")
+		case "assistant":
+			sb.WriteString("[Assistant]: ")
+		default:
+			continue
+		}
+		sb.WriteString(turn.Content)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("</conversation_history>\n\n")
+	sb.WriteString(content)
+	return sb.String()
 }
 
 // ─── AppServerWorker lifecycle ────────────────────────────────────────

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -389,7 +389,8 @@ func (w *AppServerWorker) injectHistoryPrefix(content string) string {
 		default:
 			continue
 		}
-		sb.WriteString(turn.Content)
+		escaped := strings.ReplaceAll(turn.Content, "CONVERSATION_HISTORY_", "")
+		sb.WriteString(escaped)
 		sb.WriteString("\n\n")
 	}
 	sb.WriteString("CONVERSATION_HISTORY_END\n")
@@ -517,6 +518,7 @@ func (w *AppServerWorker) ResetContext(ctx context.Context) (worker.ResetResult,
 		w.mu.Unlock()
 		return worker.ResetResult{ConnReplaced: true}, nil
 	}
+	origSess.ConversationHistory = nil // /reset clears context, do not re-inject old history
 	if err := w.startNewThread(origSess, "reset"); err != nil {
 		return worker.ResetResult{}, err
 	}

--- a/internal/worker/codexcli/worker_test.go
+++ b/internal/worker/codexcli/worker_test.go
@@ -1937,3 +1937,101 @@ func TestIntegrationKillImmediatelyTerminatesIdleProcess(t *testing.T) {
 		return !mgr.IsRunning()
 	}, 5*time.Second, 100*time.Millisecond, "process should be killed immediately, not after idle drain")
 }
+
+// ─── Conversation History Injection Tests ────────────────────────────────
+
+func TestInjectHistoryPrefix(t *testing.T) {
+	t.Parallel()
+
+	w := &AppServerWorker{
+		pendingHistory: []worker.ConversationTurn{
+			{Role: "user", Content: "现在开始我发 ping，你回复 汪"},
+			{Role: "assistant", Content: "收到，以后你发 ping 我就回 汪"},
+			{Role: "user", Content: "ping"},
+			{Role: "assistant", Content: "汪"},
+		},
+		historyInjected: false,
+	}
+
+	result := w.injectHistoryPrefix("ping")
+
+	require.Contains(t, result, "<conversation_history>")
+	require.Contains(t, result, "[User]: 现在开始我发 ping，你回复 汪")
+	require.Contains(t, result, "[Assistant]: 收到，以后你发 ping 我就回 汪")
+	require.Contains(t, result, "[User]: ping")
+	require.Contains(t, result, "[Assistant]: 汪")
+	require.Contains(t, result, "</conversation_history>")
+	require.True(t, strings.HasSuffix(result, "ping"), "actual user message should follow history block")
+	require.True(t, w.historyInjected)
+	require.Nil(t, w.pendingHistory)
+}
+
+func TestInjectHistoryPrefixIdempotent(t *testing.T) {
+	t.Parallel()
+
+	w := &AppServerWorker{
+		pendingHistory: []worker.ConversationTurn{
+			{Role: "user", Content: "hello"},
+		},
+		historyInjected: false,
+	}
+
+	first := w.injectHistoryPrefix("message1")
+	require.Contains(t, first, "<conversation_history>")
+
+	second := w.injectHistoryPrefix("message2")
+	require.Equal(t, "message2", second, "second call should return unmodified content")
+}
+
+func TestInjectHistoryPrefixEmpty(t *testing.T) {
+	t.Parallel()
+
+	w := &AppServerWorker{
+		pendingHistory:  nil,
+		historyInjected: false,
+	}
+	require.Equal(t, "hello", w.injectHistoryPrefix("hello"))
+
+	w2 := &AppServerWorker{
+		pendingHistory:  []worker.ConversationTurn{},
+		historyInjected: false,
+	}
+	require.Equal(t, "hello", w2.injectHistoryPrefix("hello"))
+}
+
+func TestInjectHistoryPrefixSkipsEmptyContent(t *testing.T) {
+	t.Parallel()
+
+	w := &AppServerWorker{
+		pendingHistory: []worker.ConversationTurn{
+			{Role: "user", Content: ""},
+			{Role: "assistant", Content: "response"},
+			{Role: "system", Content: "ignored role"},
+			{Role: "user", Content: "actual input"},
+		},
+		historyInjected: false,
+	}
+
+	result := w.injectHistoryPrefix("ping")
+
+	require.Contains(t, result, "[Assistant]: response")
+	require.Contains(t, result, "[User]: actual input")
+	require.NotContains(t, result, "[System]: ", "unknown roles should be skipped")
+}
+
+func TestInjectHistoryPrefixCleanupOldThreadReset(t *testing.T) {
+	t.Parallel()
+
+	w := &AppServerWorker{
+		pendingHistory: []worker.ConversationTurn{
+			{Role: "user", Content: "hello"},
+		},
+		historyInjected: false,
+	}
+
+	w.cleanupOldThread()
+
+	require.Nil(t, w.pendingHistory)
+	require.False(t, w.historyInjected)
+	require.Equal(t, "test", w.injectHistoryPrefix("test"))
+}

--- a/internal/worker/codexcli/worker_test.go
+++ b/internal/worker/codexcli/worker_test.go
@@ -1955,12 +1955,12 @@ func TestInjectHistoryPrefix(t *testing.T) {
 
 	result := w.injectHistoryPrefix("ping")
 
-	require.Contains(t, result, "<conversation_history>")
+	require.Contains(t, result, "CONVERSATION_HISTORY_START")
 	require.Contains(t, result, "[User]: 现在开始我发 ping，你回复 汪")
 	require.Contains(t, result, "[Assistant]: 收到，以后你发 ping 我就回 汪")
 	require.Contains(t, result, "[User]: ping")
 	require.Contains(t, result, "[Assistant]: 汪")
-	require.Contains(t, result, "</conversation_history>")
+	require.Contains(t, result, "CONVERSATION_HISTORY_END")
 	require.True(t, strings.HasSuffix(result, "ping"), "actual user message should follow history block")
 	require.True(t, w.historyInjected)
 	require.Nil(t, w.pendingHistory)
@@ -1977,7 +1977,7 @@ func TestInjectHistoryPrefixIdempotent(t *testing.T) {
 	}
 
 	first := w.injectHistoryPrefix("message1")
-	require.Contains(t, first, "<conversation_history>")
+	require.Contains(t, first, "CONVERSATION_HISTORY_START")
 
 	second := w.injectHistoryPrefix("message2")
 	require.Equal(t, "message2", second, "second call should return unmodified content")

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -304,6 +304,19 @@ type SessionInfo struct {
 	// Populated from SessionInfo by buildThreadStartParams. Per-session
 	// injection through gateway/bridge is not yet wired.
 	Images []string
+	// ConversationHistory carries prior turns for pre-seeding a new worker
+	// thread. Populated by the bridge when resuming/recreating a session
+	// with existing history. Workers that support native resume (Claude Code
+	// --resume) ignore this; workers that always create fresh threads
+	// (CodexCLI) use it to inject context into the first user input.
+	ConversationHistory []ConversationTurn
+}
+
+// ConversationTurn represents a single turn in a conversation history,
+// used to seed context when a worker cannot natively resume its session.
+type ConversationTurn struct {
+	Role    string // "user" | "assistant"
+	Content string
 }
 
 // SandboxPlatformKey is the platformKey map key used to propagate sandbox config


### PR DESCRIPTION
## Summary

- Add `ConversationTurn` type and `ConversationHistory` field to `worker.SessionInfo`
- Query turns table in `bridge.prepareWorkerInfo()` to populate history when resuming/recreating sessions
- Inject history as structured prefix into first `Input()` call of new CodexCLI threads
- 5 unit tests covering injection, idempotency, empty state, role filtering, and cleanup reset

## Root Cause

CodexCLI `app-server` stores thread history only in process memory. When zombie GC kills the process after 30 min idle, all history is lost. Resume creates a fresh thread with no memory of prior instructions (e.g. "ping → 汪").

## Solution

Leverage the existing `turns` table (already persists full user/assistant conversation text):
1. `prepareWorkerInfo()` queries last 50 turns → populates `SessionInfo.ConversationHistory`
2. `startNewThread()` stores history in `pendingHistory`
3. First `Input()` call prepends history via `injectHistoryPrefix()` as `<conversation_history>` block
4. Subsequent calls return unmodified content (idempotent via `historyInjected` flag)

## Test plan

- [x] Unit tests pass: `TestInjectHistoryPrefix`, `TestInjectHistoryPrefixIdempotent`, `TestInjectHistoryPrefixEmpty`, `TestInjectHistoryPrefixSkipsEmptyContent`, `TestInjectHistoryPrefixCleanupOldThreadReset`
- [x] `go test ./internal/worker/codexcli/... ./internal/gateway/... ./internal/worker/... -count=1 -race -short` — all green
- [x] `golangci-lint` — 0 issues
- [x] Pre-push hooks — all quality gates passed
- [ ] Manual integration test: set rule → wait for GC → verify rule preserved

Closes #703