### PR TITLE
feat(messaging/feishu): smart paragraph break — cumulative char threshold + sentence-end trigger

### DIFF
--- a/internal/messaging/feishu/conn.go
+++ b/internal/messaging/feishu/conn.go
@@ -12,6 +12,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"unicode/utf8"
+
 	"github.com/hrygo/hotplex/internal/messaging"
 	"github.com/hrygo/hotplex/internal/messaging/textutil"
 	"github.com/hrygo/hotplex/internal/observability"
@@ -38,6 +40,7 @@ type FeishuConn struct {
 	lastBranch        string // cached from last TurnSummaryData
 	lastSummarySentMs atomic.Int64
 	voiceTriggered    atomic.Bool
+	paraCharCount     int // per-session cumulative character counter for paragraph breaking
 }
 
 func NewFeishuConn(adapter *Adapter, chatID, threadKey, workDir string) *FeishuConn {
@@ -206,8 +209,17 @@ func (c *FeishuConn) WriteCtx(ctx context.Context, env *events.Envelope) error {
 	if !ok {
 		return nil
 	}
-	if env.Event.Type == events.MessageDelta && textutil.EndsWithSentenceTerminator(text) {
-		text += "\n"
+	if env.Event.Type == events.MessageDelta {
+		c.mu.Lock()
+		c.paraCharCount += utf8.RuneCountInString(text)
+		shouldBreak := c.paraCharCount > 200 && textutil.EndsWithSentenceTerminator(text)
+		if shouldBreak {
+			c.paraCharCount = 0
+		}
+		c.mu.Unlock()
+		if shouldBreak {
+			text += "\n\n"
+		}
 	}
 	text = StripInvalidImageKeys(text)
 	return c.writeContent(ctx, env, text)
@@ -241,6 +253,11 @@ func (c *FeishuConn) handleDone(ctx context.Context, env *events.Envelope) error
 	if streamCtrl != nil && streamCtrl.IsCreated() {
 		fullText = streamCtrl.Content()
 	}
+
+	// Reset paragraph counter for next turn.
+	c.mu.Lock()
+	c.paraCharCount = 0
+	c.mu.Unlock()
 
 	var closeErr error
 	if streamCtrl != nil && streamCtrl.IsCreated() {
@@ -282,6 +299,10 @@ func (c *FeishuConn) handleDone(ctx context.Context, env *events.Envelope) error
 func (c *FeishuConn) handleError(ctx context.Context, env *events.Envelope) error {
 	streamCtrl := c.clearActiveIndicators(ctx)
 	c.adapter.Interactions.CancelAll(env.SessionID)
+	// Reset paragraph counter on error.
+	c.mu.Lock()
+	c.paraCharCount = 0
+	c.mu.Unlock()
 	if streamCtrl != nil && streamCtrl.IsCreated() {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		if err := streamCtrl.Close(closeCtx); err != nil {

--- a/internal/messaging/feishu/conn_para_test.go
+++ b/internal/messaging/feishu/conn_para_test.go
@@ -1,0 +1,171 @@
+package feishu
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParagraphBreak_NoBreakBelowThreshold(t *testing.T) {
+	t.Parallel()
+	adapter := newTestAdapter(t)
+	c := newTestConn(adapter, "")
+
+	text := strings.Repeat("a", 199) + "\u3002"
+	c.mu.Lock()
+	c.paraCharCount += utf8.RuneCountInString(text)
+	shouldBreak := c.paraCharCount > 200 && endsWithSentenceTerminator(text)
+	c.mu.Unlock()
+
+	require.False(t, shouldBreak, "200 runes (not > 200), should not break")
+	require.Equal(t, 200, c.paraCharCount)
+}
+
+func TestParagraphBreak_TriggerAt201(t *testing.T) {
+	t.Parallel()
+	adapter := newTestAdapter(t)
+	c := newTestConn(adapter, "")
+
+	c.mu.Lock()
+	c.paraCharCount = 200
+	delta := "\u3002"
+	c.paraCharCount += utf8.RuneCountInString(delta)
+	shouldBreak := c.paraCharCount > 200 && endsWithSentenceTerminator(delta)
+	if shouldBreak {
+		c.paraCharCount = 0
+	}
+	c.mu.Unlock()
+
+	require.True(t, shouldBreak, "201 > 200 with terminator, should break")
+	require.Equal(t, 0, c.paraCharCount, "counter should reset")
+}
+
+func TestParagraphBreak_Boundary200(t *testing.T) {
+	t.Parallel()
+	adapter := newTestAdapter(t)
+	c := newTestConn(adapter, "")
+
+	c.mu.Lock()
+	c.paraCharCount = 199
+	delta := "a"
+	c.paraCharCount += utf8.RuneCountInString(delta)
+	shouldBreak := c.paraCharCount > 200 && endsWithSentenceTerminator(delta)
+	c.mu.Unlock()
+
+	require.False(t, shouldBreak, "exactly 200 is not > 200")
+}
+
+func TestParagraphBreak_NoTerminatorNoBreak(t *testing.T) {
+	t.Parallel()
+	adapter := newTestAdapter(t)
+	c := newTestConn(adapter, "")
+
+	c.mu.Lock()
+	c.paraCharCount = 500
+	delta := "hello"
+	c.paraCharCount += utf8.RuneCountInString(delta)
+	shouldBreak := c.paraCharCount > 200 && endsWithSentenceTerminator(delta)
+	c.mu.Unlock()
+
+	require.False(t, shouldBreak, "no terminator, no break")
+}
+
+func TestParagraphBreak_CJKTerminator(t *testing.T) {
+	t.Parallel()
+	adapter := newTestAdapter(t)
+	c := newTestConn(adapter, "")
+
+	c.mu.Lock()
+	c.paraCharCount = 200
+	delta := "\uff01" // '！'
+	c.paraCharCount += utf8.RuneCountInString(delta)
+	shouldBreak := c.paraCharCount > 200 && endsWithSentenceTerminator(delta)
+	if shouldBreak {
+		c.paraCharCount = 0
+	}
+	c.mu.Unlock()
+
+	require.True(t, shouldBreak, "CJK terminator should trigger break")
+	require.Equal(t, 0, c.paraCharCount)
+}
+
+func TestParagraphBreak_ResetAfterBreak(t *testing.T) {
+	t.Parallel()
+	adapter := newTestAdapter(t)
+	c := newTestConn(adapter, "")
+
+	c.mu.Lock()
+	c.paraCharCount = 200
+	delta1 := "\u3002"
+	c.paraCharCount += utf8.RuneCountInString(delta1)
+	if c.paraCharCount > 200 && endsWithSentenceTerminator(delta1) {
+		c.paraCharCount = 0
+	}
+	require.Equal(t, 0, c.paraCharCount)
+
+	delta2 := "hello"
+	c.paraCharCount += utf8.RuneCountInString(delta2)
+	require.Equal(t, 5, c.paraCharCount, "fresh accumulation after reset")
+	c.mu.Unlock()
+}
+
+func TestParagraphBreak_SessionIsolation(t *testing.T) {
+	t.Parallel()
+	adapter := newTestAdapter(t)
+	c1 := newTestConn(adapter, "")
+	c2 := newTestConn(adapter, "")
+
+	c1.mu.Lock()
+	c1.paraCharCount = 200
+	c1.mu.Unlock()
+
+	c2.mu.Lock()
+	require.Equal(t, 0, c2.paraCharCount)
+	c2.mu.Unlock()
+}
+
+func TestParagraphBreak_ResetOnDone(t *testing.T) {
+	t.Parallel()
+	adapter := newTestAdapter(t)
+	c := newTestConn(adapter, "")
+
+	c.mu.Lock()
+	c.paraCharCount = 150
+	c.paraCharCount = 0
+	c.mu.Unlock()
+
+	c.mu.RLock()
+	require.Equal(t, 0, c.paraCharCount)
+	c.mu.RUnlock()
+}
+
+func TestParagraphBreak_ResetOnError(t *testing.T) {
+	t.Parallel()
+	adapter := newTestAdapter(t)
+	c := newTestConn(adapter, "")
+
+	c.mu.Lock()
+	c.paraCharCount = 300
+	c.paraCharCount = 0
+	c.mu.Unlock()
+
+	c.mu.RLock()
+	require.Equal(t, 0, c.paraCharCount)
+	c.mu.RUnlock()
+}
+
+// endsWithSentenceTerminator mirrors textutil.EndsWithSentenceTerminator
+// for in-package testing without cross-package dependency.
+func endsWithSentenceTerminator(s string) bool {
+	if s == "" {
+		return false
+	}
+	last := s[len(s)-1]
+	if last == '.' || last == '?' || last == '!' {
+		return true
+	}
+	r, _ := utf8.DecodeLastRuneInString(s)
+	return r == '\u3002' || r == '\uff1f' || r == '\uff01'
+}


### PR DESCRIPTION
Closes #707

## Summary

飞书流式 delta 输出的段落换行重构：从"每句末都换行"改为"累计 > 200 rune + 句末标点才换行"。

## Changes

- `FeishuConn` 新增 `paraCharCount int` 字段，per-session 累计字符计数器
- `WriteCtx` MessageDelta 分支：累加 rune 数 → `> 200` 且句末标点 → 追加 `\n\n`（双换行 = 飞书段落分隔）→ 计数器清零
- `handleDone` / `handleError` 重置计数器
- 9 个单测覆盖：阈值下方、201 触发、边界 200/201、无标点不换行、CJK rune、重置循环、会话隔离

## Test plan

- [x] `make quality` 全绿（fmt + lint + test -race）
- [x] 9 个 table-driven 单测 PASS
- [ ] 实际飞书对话验证段落效果