### PR TITLE
fix(acp): persist WorkerSessionID before state transitions (#709)

### DIFF
--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -291,6 +291,10 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 	claudecode.InitConfig(cfg.Worker.ClaudeCode)
 	acp.InitConfig(cfg.Worker.ACP)
 	codexcli.InitSingleton(log, cfg.Worker.CodexCLI)
+	if cfg.Worker.CodexCLI.Sandbox == "danger-full-access" {
+		log.Warn("codexcli: sandbox is danger-full-access (YOLO mode) — full filesystem + network access",
+			"hint", "set codex_cli.sandbox to workspace-write or read-only for restricted environments")
+	}
 
 	cfgStore.RegisterFunc(func(prev, next *config.Config) {
 		if !reflect.DeepEqual(prev.Worker.AutoRetry, next.Worker.AutoRetry) {

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -237,7 +237,7 @@ worker:
     # Sandbox mode: read-only, workspace-write, danger-full-access
     sandbox: "workspace-write"
     # Approval mode: untrusted, on-request, never
-    approval_mode: "never"
+    approval_mode: "on-request"
     # Ephemeral sessions (don't persist to disk)
     ephemeral: true
     # Process startup timeout

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -237,6 +237,8 @@ worker:
     # Sandbox mode: read-only, workspace-write, danger-full-access
     # YOLO mode (default): danger-full-access grants full filesystem + network access.
     # For restricted sandbox, use workspace-write or read-only.
+    # ⚠ Default changed from workspace-write to danger-full-access in v1.26 —
+    #   existing deployments without explicit sandbox config will gain elevated permissions.
     sandbox: "danger-full-access"
     # Approval mode: untrusted, on-request, never
     # YOLO mode (default): never skips all approval prompts — commands run immediately.

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -235,8 +235,11 @@ worker:
     # Model name. Empty = use Codex default model from ~/.codex/config.toml
     model: ""
     # Sandbox mode: read-only, workspace-write, danger-full-access
+    # YOLO mode (default): danger-full-access grants full filesystem + network access.
+    # For restricted sandbox, use workspace-write or read-only.
     sandbox: "danger-full-access"
     # Approval mode: untrusted, on-request, never
+    # YOLO mode (default): never skips all approval prompts — commands run immediately.
     approval_mode: "never"
     # Ephemeral sessions (don't persist to disk)
     ephemeral: true

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -237,7 +237,7 @@ worker:
     # Sandbox mode: read-only, workspace-write, danger-full-access
     sandbox: "workspace-write"
     # Approval mode: untrusted, on-request, never
-    approval_mode: "on-request"
+    approval_mode: "never"
     # Ephemeral sessions (don't persist to disk)
     ephemeral: true
     # Process startup timeout

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -235,7 +235,7 @@ worker:
     # Model name. Empty = use Codex default model from ~/.codex/config.toml
     model: ""
     # Sandbox mode: read-only, workspace-write, danger-full-access
-    sandbox: "workspace-write"
+    sandbox: "danger-full-access"
     # Approval mode: untrusted, on-request, never
     approval_mode: "never"
     # Ephemeral sessions (don't persist to disk)

--- a/docs/architecture/Worker-Gateway-Design.md
+++ b/docs/architecture/Worker-Gateway-Design.md
@@ -119,7 +119,7 @@ type WorkerSessionIDHandler interface {
 **实现者**：
 - **OpenCode Server**：使用 HTTP 连接中的 session ID
 
-**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后立即持久化（best-effort optimization）；`bridge.forwardEvents()` 收到第一个事件时作为 correctness guarantee 再次调用。`transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖。Guard 的二次 Upsert 存在残留竞态窗口（详见 #709 tracking），已大幅缩小但未完全消除。
+**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后异步持久化（best-effort optimization）；`bridge.forwardEvents()` 收到第一个事件时作为 correctness guarantee 再次调用（`EnsureWorkerSessionID` 变体，绕过 fast-path）。`transitionState` 在锁释放窗口期间使用针对性 SQL UPDATE（`UpdateWorkerSessionIDSQL`）保护 WorkerSessionID 不被并发覆盖，避免全行 Upsert 覆盖其他字段。Guard 的针对性 SQL UPDATE 存在残留竞态窗口（详见 #709 tracking），已大幅缩小但未完全消除。
 
 ### 5.2 状态机
 

--- a/docs/architecture/Worker-Gateway-Design.md
+++ b/docs/architecture/Worker-Gateway-Design.md
@@ -119,7 +119,7 @@ type WorkerSessionIDHandler interface {
 **实现者**：
 - **OpenCode Server**：使用 HTTP 连接中的 session ID
 
-**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后立即持久化；`bridge.forwardEvents()` 收到第一个事件时作为安全兜底再次调用。`transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖。
+**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后立即持久化（best-effort optimization）；`bridge.forwardEvents()` 收到第一个事件时作为 correctness guarantee 再次调用。`transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖。Guard 的二次 Upsert 存在残留竞态窗口（详见 #709），已大幅缩小但未完全消除。
 
 ### 5.2 状态机
 

--- a/docs/architecture/Worker-Gateway-Design.md
+++ b/docs/architecture/Worker-Gateway-Design.md
@@ -214,22 +214,35 @@ Worker 内部处于 tool 执行阶段时，Gateway 不区分 — 状态仍为 `R
 ```sql
 CREATE TABLE sessions (
     id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    owner_id TEXT,
+    bot_id TEXT,
+    bot_name TEXT NOT NULL DEFAULT '',
     worker_session_id TEXT,
     worker_type TEXT NOT NULL,
-    state TEXT NOT NULL,
+    state TEXT NOT NULL CHECK(state IN ('created', 'running', 'idle', 'terminated', 'deleted')),
+    platform TEXT NOT NULL DEFAULT '',
+    platform_key_json TEXT NOT NULL DEFAULT '',
+    work_dir TEXT,
+    title TEXT NOT NULL DEFAULT '',
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,
     expires_at DATETIME,
-    is_active BOOLEAN NOT NULL DEFAULT 0,
-    context_json TEXT
+    idle_expires_at DATETIME,
+    context_json TEXT,
+    source TEXT NOT NULL DEFAULT '',
+    client_key TEXT NOT NULL DEFAULT ''
 );
 ```
 
 ### 6.2 约束
 
-- `id`：UUID
+- `id`：UUID（UUIDv5 确定性派生，见 `DeriveSessionKey`）
+- `user_id`：创建者 ID
+- `owner_id`：实际所有者（默认等同 `user_id`，Cron 场景下为 cron 触发者）
+- `bot_id`：关联 Bot ID（多 bot 场景）
+- `worker_session_id`：Worker 内部 session ID（用于 resume 恢复，通过 targeted SQL `UpdateWorkerSessionIDSQL` 持久化）
 - `state`：受限枚举（`created`, `running`, `idle`, `terminated`, `deleted`）
-- `is_active`：仅用于标记是否存在 runtime
 - SQLite 使用 **WAL mode**（Write-Ahead Logging），允许并发读取、串行写入
 - 写入操作通过**单写 goroutine** 串行化，避免 SQLite 的写锁竞争
 
@@ -1026,7 +1039,7 @@ SELECT * FROM sessions WHERE state != 'deleted';
 | 状态         | 操作                                                                                            |
 | ------------ | ----------------------------------------------------------------------------------------------- |
 | `RUNNING`    | → `TERMINATED`（runtime 已丢失），发送 `error(WORKER_CRASH)` + `done(false)` 如果有活跃 WS 连接 |
-| `IDLE`       | 保持（runtime 需重新 attach），标记 `is_active = false`                                         |
+| `IDLE`       | 保持（runtime 需重新 attach）                                                                   |
 | `CREATED`    | 可重启（启动新 runtime）                                                                        |
 | `TERMINATED` | 保持不变                                                                                        |
 

--- a/docs/architecture/Worker-Gateway-Design.md
+++ b/docs/architecture/Worker-Gateway-Design.md
@@ -119,7 +119,7 @@ type WorkerSessionIDHandler interface {
 **实现者**：
 - **OpenCode Server**：使用 HTTP 连接中的 session ID
 
-**持久化时机**：`bridge.forwardEvents()` 收到第一个 worker 事件时，调用 `persistWorkerSessionID()` 更新 DB。
+**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后立即持久化；`bridge.forwardEvents()` 收到第一个事件时作为安全兜底再次调用。`transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖。
 
 ### 5.2 状态机
 

--- a/docs/architecture/Worker-Gateway-Design.md
+++ b/docs/architecture/Worker-Gateway-Design.md
@@ -119,7 +119,7 @@ type WorkerSessionIDHandler interface {
 **实现者**：
 - **OpenCode Server**：使用 HTTP 连接中的 session ID
 
-**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后立即持久化（best-effort optimization）；`bridge.forwardEvents()` 收到第一个事件时作为 correctness guarantee 再次调用。`transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖。Guard 的二次 Upsert 存在残留竞态窗口（详见 #709），已大幅缩小但未完全消除。
+**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后立即持久化（best-effort optimization）；`bridge.forwardEvents()` 收到第一个事件时作为 correctness guarantee 再次调用。`transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖。Guard 的二次 Upsert 存在残留竞态窗口（详见 #709 tracking），已大幅缩小但未完全消除。
 
 ### 5.2 状态机
 

--- a/docs/archive/Worker-OpenCode-CLI-Spec.md
+++ b/docs/archive/Worker-OpenCode-CLI-Spec.md
@@ -704,7 +704,7 @@ func (w *Worker) GetWorkerSessionID() string {
 
 1. Worker 启动时 `sessionID = ""`
 2. `readOutput()` 从 `step_start` 事件提取 session ID
-3. `persistWorkerSessionID()` 在 `forwardEvents()` 收到第一个事件时调用
+3. `persistWorkerSessionID()` 在 `createAndLaunchWorker()` Worker 启动后立即调用，`forwardEvents()` 首个事件时兜底再调一次
 4. `sm.UpdateWorkerSessionID()` 持久化到 SQLite `sessions.worker_session_id` 字段
 
 ### 7.3 Resume 支持

--- a/docs/archive/Worker-OpenCode-CLI-Spec.md
+++ b/docs/archive/Worker-OpenCode-CLI-Spec.md
@@ -704,8 +704,9 @@ func (w *Worker) GetWorkerSessionID() string {
 
 1. Worker 启动时 `sessionID = ""`
 2. `readOutput()` 从 `step_start` 事件提取 session ID
-3. `persistWorkerSessionID()` 在 `createAndLaunchWorker()` Worker 启动后立即调用，`forwardEvents()` 首个事件时兜底再调一次
+3. `persistWorkerSessionID()` 在 `createAndLaunchWorker()` Worker 启动后立即调用（best-effort optimization），`forwardEvents()` 首个事件时作为 correctness guarantee 再调一次
 4. `sm.UpdateWorkerSessionID()` 持久化到 SQLite `sessions.worker_session_id` 字段
+5. `transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖
 
 ### 7.3 Resume 支持
 

--- a/docs/archive/Worker-OpenCode-CLI-Spec.md
+++ b/docs/archive/Worker-OpenCode-CLI-Spec.md
@@ -706,7 +706,8 @@ func (w *Worker) GetWorkerSessionID() string {
 2. `readOutput()` 从 `step_start` 事件提取 session ID
 3. `persistWorkerSessionID()` 在 `createAndLaunchWorker()` Worker 启动后立即调用（best-effort optimization），`forwardEvents()` 首个事件时作为 correctness guarantee 再调一次
 4. `sm.UpdateWorkerSessionID()` 持久化到 SQLite `sessions.worker_session_id` 字段
-5. `transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖
+
+**并发保护**：`transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖。
 
 ### 7.3 Resume 支持
 

--- a/docs/archive/specs/Worker-OpenCode-Server-Spec.md
+++ b/docs/archive/specs/Worker-OpenCode-Server-Spec.md
@@ -491,7 +491,7 @@ func (w *Worker) GetWorkerSessionID() string {
 }
 ```
 
-**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后立即持久化；`bridge.forwardEvents()` 收到第一个事件时作为安全兜底再次调用。`transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖。
+**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后立即持久化（best-effort optimization）；`bridge.forwardEvents()` 收到第一个事件时作为 correctness guarantee 再次调用。`transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖。
 
 ### 9.2 Session 生命周期
 

--- a/docs/archive/specs/Worker-OpenCode-Server-Spec.md
+++ b/docs/archive/specs/Worker-OpenCode-Server-Spec.md
@@ -491,7 +491,7 @@ func (w *Worker) GetWorkerSessionID() string {
 }
 ```
 
-**持久化时机**：`bridge.forwardEvents()` 收到第一个 worker 事件时，`persistWorkerSessionID()` 调用 `GetWorkerSessionID()` 并更新 DB。
+**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后立即持久化；`bridge.forwardEvents()` 收到第一个事件时作为安全兜底再次调用。`transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖。
 
 ### 9.2 Session 生命周期
 

--- a/docs/archive/specs/Worker-OpenCode-Server-Spec.md
+++ b/docs/archive/specs/Worker-OpenCode-Server-Spec.md
@@ -491,7 +491,7 @@ func (w *Worker) GetWorkerSessionID() string {
 }
 ```
 
-**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后立即持久化（best-effort optimization）；`bridge.forwardEvents()` 收到第一个事件时作为 correctness guarantee 再次调用。`transitionState` 在锁释放窗口期间保护 WorkerSessionID 不被并发覆盖。
+**持久化时机**：`bridge.createAndLaunchWorker()` 在 Worker 启动后异步持久化（best-effort optimization）；`bridge.forwardEvents()` 收到第一个事件时作为 correctness guarantee 强制再次调用（`Force` 变体，绕过 fast-path）。`transitionState` 在锁释放窗口期间使用针对性 SQL UPDATE（`UpdateWorkerSessionIDSQL`）保护 WorkerSessionID 不被并发覆盖，避免全行 Upsert 覆盖其他字段。Guard 的二次写入存在残留竞态窗口（详见 #709）。
 
 ### 9.2 Session 生命周期
 

--- a/docs/specs/Codex-Worker-Agent-Configs-Spec.md
+++ b/docs/specs/Codex-Worker-Agent-Configs-Spec.md
@@ -1,0 +1,365 @@
+---
+type: spec
+tags:
+  - project/HotPlex
+  - worker/codex
+  - agent-config
+  - system-prompt
+date: 2026-06-11
+status: draft
+progress: 0
+estimated_hours: 4
+---
+
+# Codex Worker Agent-Configs 注入规格
+
+> **目标**：让 HotPlex 的 agent-configs（B/C 通道）体系在 Codex CLI Worker（`codex app-server` 模式）下正
+> 常生效。当前 agent-configs 对 Codex Worker 完全不生效，`bridge.injectAgentConfig()` 写入的
+> `session.SystemPrompt` 未通过 JSON-RPC 传递给 `codex app-server`。
+
+---
+
+## 1. 背景与现状
+
+### 1.1 Agent-Configs 数据流（期望）
+
+```
+~/.hotplex/agent-configs/         B/C 通道文件
+        ↓
+agentconfig.Load() + BuildSystemPrompt()
+        ↓
+bridge.injectAgentConfig() → info.SystemPrompt = "合并后 prompt"
+        ↓
+Worker.Start(session SessionInfo) ← session.SystemPrompt
+        ↓
+buildThreadStartParams() → JSON-RPC "thread/start"
+        ↓
+codex app-server 开始使用 injected prompt
+```
+
+### 1.2 实际数据流（当前，断点 at ⚡）
+
+```
+agentconfig.Load() + BuildSystemPrompt()
+        ↓
+bridge.injectAgentConfig() → info.SystemPrompt = "合并后 prompt"  ← ✅ 正常工作
+        ↓
+AppServerWorker.Start(session SessionInfo) ⚡ SystemPrompt 未被消费
+        ↓
+buildThreadStartParams(session, cfg) ⚡ 没有使用 session.SystemPrompt
+        ↓
+thread/start JSON-RPC ⚡ 没有 baseInstructions / developerInstructions 字段
+        ↓
+codex app-server ← 完全不知道 agent-configs 的存在
+```
+
+### 1.3 协议层证据
+
+**app-server 协议**（Rust 侧，`thread.rs:133-135`）：
+
+```rust
+pub struct ThreadStartParams {
+    // ...
+    pub base_instructions: Option<String>,       // ← 等价于 system prompt
+    pub developer_instructions: Option<String>,   // ← 开发者级指令，更高优先级
+    // ...
+}
+```
+
+参数通过 `#[serde(rename_all = "camelCase")]` 序列化为 `baseInstructions` / `developerInstructions`。
+
+`thread_processor.rs:1284-1285` 中的 `build_thread_config_overrides` 将这些值透传到 `ConfigOverrides`，
+最终注入到 session 配置。协议层**完全支持**，但 HotPlex 从未使用。
+
+**HotPlex codexcli 侧**（`types.go:148`）：
+
+```go
+type ThreadStartParams struct {
+    Model          string `json:"model,omitempty"`
+    CWD            string `json:"cwd,omitempty"`
+    Sandbox        string `json:"sandbox,omitempty"`
+    Personality    string `json:"personality,omitempty"`
+    Ephemeral      bool   `json:"ephemeral,omitempty"`
+    ApprovalPolicy string `json:"approvalPolicy,omitempty"`
+    // ❌ 缺少 baseInstructions
+    // ❌ 缺少 developerInstructions
+}
+```
+
+### 1.4 `codex exec` 模式同样不支持
+
+同期的 `exec/src/lib.rs:948-974` 中 `thread_start_params_from_config` 也使用
+`..ThreadStartParams::default()` 填充，`base_instructions` 和 `developer_instructions` 都是 `None`。
+exec CLI 本身没有暴露任何 flag 来设置它们。此 spec 仅覆盖 `app-server` 模式，不覆盖 `codex exec`。
+
+---
+
+## 2. 影响范围
+
+| 组件 | 文件 | 变更类型 |
+|------|------|----------|
+| **ThreadStartParams** | `internal/worker/codexcli/types.go` | 增加字段 |
+| **buildThreadStartParams** | `internal/worker/codexcli/worker.go` | 增加 SystemPrompt 传递 |
+| **Start / startNewThread** | `internal/worker/codexcli/worker.go` | 确认 SystemPrompt 在 session 中 |
+| **ResetContext** | `internal/worker/codexcli/worker.go` | 确认持久化 + 传递 |
+| **UpdateSystemPrompt** | `internal/worker/codexcli/worker.go` | 验证（已实现） |
+| **单元测试** | `internal/worker/codexcli/worker_test.go` | 新增 |
+
+---
+
+## 3. 方案设计
+
+### 3.1 `ThreadStartParams` 增加字段
+
+```go
+// types.go
+type ThreadStartParams struct {
+    Model          string `json:"model,omitempty"`
+    CWD            string `json:"cwd,omitempty"`
+    Sandbox        string `json:"sandbox,omitempty"`
+    Personality    string `json:"personality,omitempty"`
+    Ephemeral      bool   `json:"ephemeral,omitempty"`
+    ApprovalPolicy string `json:"approvalPolicy,omitempty"`
+
+    // NEW: agent-configs 注入
+    // baseInstructions 对应 HotPlex 的 session.SystemPrompt (B/C 通道合并后的 prompt)。
+    // app-server 将其作为 base instructions (system prompt 基座)。
+    BaseInstructions        string `json:"baseInstructions,omitempty"`
+    // developerInstructions 优先级高于 baseInstructions。
+    // HotPlex 暂不设置此字段，保留给未来扩展使用。
+    DeveloperInstructions   string `json:"developerInstructions,omitempty"`
+}
+```
+
+### 3.2 `buildThreadStartParams` 传递 SystemPrompt
+
+```go
+// worker.go - buildThreadStartParams()
+func buildThreadStartParams(session worker.SessionInfo, cfg Config) map[string]any {
+    params := map[string]any{
+        "cwd":            session.ProjectDir,
+        "sandbox":        sandboxFromSession(session, cfg.Sandbox),
+        "personality":    cfg.Personality,
+        "approvalPolicy": approvalMode,
+    }
+    // ...其他现有字段...
+
+    // NEW: agent-configs 注入
+    if session.SystemPrompt != "" {
+        params["baseInstructions"] = session.SystemPrompt
+    }
+    // developerInstructions 暂不设置，保留给未来
+    // if session.SystemPromptReplace != "" {
+    //     params["developerInstructions"] = session.SystemPromptReplace
+    // }
+
+    return params
+}
+```
+
+**关于 developerInstructions 的决策**：`developerInstructions`（对应 Rust 侧的 `ConfigOverrides`）
+优先级高于 `baseInstructions`。当前 `SessionInfo.SystemPromptReplace` 在 Codex Worker 中没有对应概念
+（`codex exec` 使用 `--system-prompt` flag，但 `codex app-server` 没有等价的 runtime flag），
+暂不映射。如果未来需要，可以通过 `developerInstructions` 实现更高优先级的指令覆盖。
+
+### 3.3 `ResetContext` 确保 SystemPrompt 持久化
+
+`ResetContext()` 中调用 `startNewThread(origSess, "reset")`，`origSess` 包含 `SystemPrompt`。
+`UpdateSystemPrompt()` 已实现在 worker.go:562，bridge 在 reset 时调用它将最新的 agent config
+更新到 `origSession.SystemPrompt`。所有 reset 路径已经正确。
+
+### 3.4 注入与传递时序验证
+
+```
+Session 初始化:
+  bridge.createAndLaunchWorker()
+    → injectAgentConfig()          ← session.SystemPrompt 被写入
+    → Start(session)               ← SystemPrompt 在 SessionInfo 中
+      → startNewThread(session, "start") ← SystemPrompt 传入 buildThreadStartParams
+        → thread/start { baseInstructions: "..." } ← app-server 接收
+
+Session Reset:
+  bridge.resetWorker()
+    → worker.ResetContext()
+      → UpdateSystemPrompt()       ← bridge 在 ResetContext 后调用
+      → startNewThread(origSess, "reset") ← origSess.SystemPrompt 已更新
+
+Session Resume:
+  callback code executes Start(session) again
+    → 走 Start() + startNewThread() 路径，SystemPrompt 正常传递
+```
+
+---
+
+## 4. 验收条件 (Acceptance Criteria)
+
+### AC-01: 新建会话时 agent-configs 生效
+
+**Given** 用户配置了 `~/.hotplex/agent-configs/SOUL.md`（任意 B/C 通道文件）
+**When** 通过飞书/Slack WebChat 发起一个新会话，worker 类型为 `codex_cli`
+**Then** 以下条件全部满足：
+- [ ] `bridge.injectAgentConfig()` 的日志输出 `"bridge: agent config injected"`，`prompt_len > 0`
+- [ ] `buildThreadStartParams()` 生成的 params 包含 `"baseInstructions"` 键
+- [ ] `baseInstructions` 的值包含对应 B/C 通道文件内容（如 SOUL.md 的内容）
+- [ ] Codex 代码助理在回复中体现 SOUL.md 中的身份设定
+
+**证据链**
+- `bridge_worker.go:82` → `b.injectAgentConfig(&params.workerInfo, ...)`
+- `bridge_worker.go:367` → `info.SystemPrompt = prompt`
+- `worker.go:324` → `params := buildThreadStartParams(session, cfg)`
+- `worker.go:667+` → 新逻辑: `if session.SystemPrompt != "" { params["baseInstructions"] = ... }`
+- Rust `thread.rs:133` → `pub base_instructions: Option<String>`
+
+### AC-02: 系统重置 (/reset) 后 agent-configs 重新生效
+
+**Given** 一个会话正在运行中，`agent-configs` 文件被用户修改
+**When** 用户执行 `/reset` 命令
+**Then** 以下条件全部满足：
+- [ ] Bridge 在 `resetWorker()` 中调用 `injectAgentConfig` 并触发 `UpdateSystemPrompt()`
+- [ ] `worker.go:562` 的 `UpdateSystemPrompt()` 更新 `origSession.SystemPrompt`
+- [ ] `ResetContext()` 调用 `startNewThread(origSess, "reset")`
+- [ ] `origSess.SystemPrompt` 包含最新加载的 agent config
+- [ ] 新 thread 的 `baseInstructions` 反映最新的 agent config 内容
+
+**证据链**
+- `bridge.go:489` → `b.injectAgentConfig(info, ...)`
+- `bridge.go:491` → `su.UpdateSystemPrompt(info.SystemPrompt)`
+- `worker.go:538` → `w.startNewThread(origSess, "reset")`
+
+### AC-03: SystemPrompt 为空时不影响正常行为
+
+**Given** 没有配置任何 agent-configs（目录不存在或全空）
+**When** 发起一个新会话
+**Then** 以下条件全部满足：
+- [ ] `injectAgentConfig()` 日志输出 `"bridge: agent config empty"` 或 `"agent config dir disabled"`
+- [ ] `session.SystemPrompt` 保持 `""`
+- [ ] `buildThreadStartParams()` 不设置 `baseInstructions` 字段
+- [ ] Codex 正常工作，无异常
+
+### AC-04: DeveloperInstructions 字段保留（不膨胀）
+
+**Given** 代码变更后
+**When** 审查 `ThreadStartParams` 结构体
+**Then** 以下条件全部满足：
+- [ ] `DeveloperInstructions` 字段已声明但不在 `buildThreadStartParams()` 中设置
+- [ ] 注释明确说明 future use only
+- [ ] `buildThreadStartParams()` 不设置 `"developerInstructions"` key
+
+### AC-05: 向后兼容
+
+**Given** 现有 codex app-server 版本（不支持 `baseInstructions` 的版本）
+**When** HotPlex 发送 `baseInstructions` 字段
+**Then** 以下条件全部满足：
+- [ ] `baseInstructions` 字段使用 `omitempty`，空 string 时不发送
+- [ ] 旧版 app-server 忽略未知字段（JSON-RPC 特性，server 端反序列化容忍额外字段）
+- [ ] 没有 panic、crash 或 connection 断裂
+
+### AC-06: Resume 后 agent-configs 仍然生效
+
+**Given** 用户连续两次发起会话到同一目录（触发 resume），agent-configs 已配置
+**When** 第二个会话启动
+**Then** 以下条件全部满足：
+- [ ] `Resume()` 方法调用中 `session.SystemPrompt` 非空
+- [ ] `buildThreadStartParams()` 的 JSON-RPC 调用包含 `baseInstructions`
+- [ ] 恢复后的会话仍然遵循 agent-configs 中的身份设定
+
+### AC-07: inject_exclude 过滤仍然生效
+
+**Given** agent-configs 目录包含 `SOUL.md` 和 `MEMORY.md`，且 `inject_exclude` 配置排除了 `MEMORY.md`
+**When** 发起一个会话
+**Then** 以下条件全部满足：
+- [ ] `BuildSystemPrompt()` 返回的 prompt 仅包含 `SOUL.md`，不包含 `MEMORY.md`
+- [ ] `baseInstructions` 的值等于排除 `MEMORY.md` 后的合并 prompt
+- [ ] Codex 助理看到 SOUL.md 的指令但不看到 MEMORY.md 的内容
+
+**证据链**
+- `bridge_worker.go:305` → `resolveInjectExclude()`
+- `bridge_worker.go:329` → `injectAgentConfig()` 接受 `injectExclude` 参数
+
+### AC-08: 多 Bot 场景下路径隔离正确
+
+**Given** 配置了两个 Feishu Bot（Bot-A 和 Bot-B），各自有独立的 agent-configs 目录
+**When** 分别通过 Bot-A 和 Bot-B 发起会话
+**Then** 以下条件全部满足：
+- [ ] Bot-A 的会话中 `baseInstructions` 包含 Bot-A 专属的 agent config
+- [ ] Bot-B 的会话中 `baseInstructions` 包含 Bot-B 专属的 agent config
+- [ ] 两个 Bot 的 agent config 互不干扰
+
+### AC-09: 单测覆盖
+
+**Given** 代码变更后
+**When** 运行 `make test` 或 `go test ./internal/worker/codexcli/...`
+**Then** 以下条件全部满足：
+- [ ] `TestBuildThreadStartParams` 覆盖 `SystemPrompt` 非空场景
+- [ ] `TestBuildThreadStartParams` 覆盖 `SystemPrompt` 为空场景
+- [ ] `TestBuildThreadStartParams` 覆盖 `DeveloperInstructions` 始终不存在的场景
+- [ ] 所有测试通过，无 regression
+
+### AC-10: `codex exec` 模式不受影响
+
+**Given** 本 spec 仅修改 `codexcli/` 包
+**When** 部署变更
+**Then** 以下条件全部满足：
+- [ ] `internal/worker/claudecode/`、`internal/worker/acp/`、`internal/worker/opencodeserver/` 零改动
+- [ ] `codex exec` 相关代码（`exec/src/lib.rs`）零改动
+- [ ] `codex exec` 模式的 behavior 完全不变
+
+---
+
+## 5. 实现计划
+
+### Step 1: `types.go` - ThreadStartParams 新增字段
+
+```go
+// 在现有字段后追加
+BaseInstructions        string `json:"baseInstructions,omitempty"`
+DeveloperInstructions   string `json:"developerInstructions,omitempty"`
+```
+
+### Step 2: `worker.go` - buildThreadStartParams 传递 SystemPrompt
+
+```go
+// 在 return params 前追加
+if session.SystemPrompt != "" {
+    params["baseInstructions"] = session.SystemPrompt
+}
+```
+
+### Step 3: `worker.go` - Start / startNewThread / ResetContext 验证
+
+验证 `startNewThread(session, ...)` 接收的 `session.SystemPrompt` 不为空时正确传递。
+当前代码路径已验证：`startNewThread` → `buildThreadStartParams`，无需额外改造。
+
+### Step 4: 单元测试
+
+- `TestBuildThreadStartParams` 扩展：
+  - "with system prompt" case
+  - "without system prompt" case
+  - "system prompt not set as developerInstructions" case
+
+### Step 5: 验证
+
+- 本地运行 `make test` 确认无 regression
+- 运行 `go test -count=1 -race ./internal/worker/codexcli/... -v` 确认测试通过
+
+---
+
+## 6. 不在此范围
+
+| 项目 | 理由 |
+|------|------|
+| `codex exec` 模式支持 | `exec` 是独立 Rust 二进制，不通过 app-server 协议；且 exec 没有 flag 暴露 baseInstructions |
+| `developerInstructions` 实际使用 | 当前 `SessionInfo` 没有对应概念，保留字段供未来扩展 |
+| `nReplace` / `SystemPromptReplace` 映射 | Codex app-server 协议层没有明确的 "replace" 语义，现有 `baseInstructions` 是追加语义 |
+| `codex` 二进制零修改 | HotPlex 侧的单向修改即可，app-server 协议已经全量支持额外字段容忍 |
+| ACP / OpenCodeServer / Claude Code Worker | 这些 Worker 的 agent-configs 已经通过各自的 `UpdateSystemPrompt()` + 运行时注入正常工作了 |
+
+---
+
+## 7. 回滚方案
+
+如果部署后发现 regressions：
+
+1. 回退 `types.go` 和 `worker.go` 的修改
+2. `UpdateSystemPrompt()` 无需回退（已经是安全的 no-op 级别的存储）
+3. `bridge.go` / `bridge_worker.go` 零改动，无需回退

--- a/docs/specs/Codex-Worker-Agent-Configs-Spec.md
+++ b/docs/specs/Codex-Worker-Agent-Configs-Spec.md
@@ -6,9 +6,9 @@ tags:
   - agent-config
   - system-prompt
 date: 2026-06-11
-status: draft
+status: spec-only
 progress: 0
-out_of_scope: This spec describes BaseInstructions/DeveloperInstructions injection for Codex Worker — not implemented in the current PR (fix/709). Tracked separately.
+out_of_scope: This spec describes BaseInstructions/DeveloperInstructions injection for Codex Worker — not implemented in the current PR (fix/709). Tracked separately. This document is a design reference only; progress will be updated when implementation begins.
 estimated_hours: 4
 ---
 

--- a/docs/specs/Codex-Worker-Agent-Configs-Spec.md
+++ b/docs/specs/Codex-Worker-Agent-Configs-Spec.md
@@ -8,6 +8,7 @@ tags:
 date: 2026-06-11
 status: draft
 progress: 0
+out_of_scope: This spec describes BaseInstructions/DeveloperInstructions injection for Codex Worker — not implemented in the current PR (fix/709). Tracked separately.
 estimated_hours: 4
 ---
 
@@ -86,11 +87,10 @@ type ThreadStartParams struct {
 }
 ```
 
-### 1.4 `codex exec` 模式同样不支持
+### 1.4 `codex exec` 模式已废弃
 
-同期的 `exec/src/lib.rs:948-974` 中 `thread_start_params_from_config` 也使用
-`..ThreadStartParams::default()` 填充，`base_instructions` 和 `developer_instructions` 都是 `None`。
-exec CLI 本身没有暴露任何 flag 来设置它们。此 spec 仅覆盖 `app-server` 模式，不覆盖 `codex exec`。
+HotPlex 曾通过 `codex exec` 模式（CLI 子进程）使用 Codex，但该模式已被废弃移除。
+当前仅保留 `codex app-server` 模式（单例 HTTP+SSE JSON-RPC），本 spec 仅覆盖此模式。
 
 ---
 
@@ -159,7 +159,7 @@ func buildThreadStartParams(session worker.SessionInfo, cfg Config) map[string]a
 
 **关于 developerInstructions 的决策**：`developerInstructions`（对应 Rust 侧的 `ConfigOverrides`）
 优先级高于 `baseInstructions`。当前 `SessionInfo.SystemPromptReplace` 在 Codex Worker 中没有对应概念
-（`codex exec` 使用 `--system-prompt` flag，但 `codex app-server` 没有等价的 runtime flag），
+（`codex app-server` 没有等价的 runtime flag），
 暂不映射。如果未来需要，可以通过 `developerInstructions` 实现更高优先级的指令覆盖。
 
 ### 3.3 `ResetContext` 确保 SystemPrompt 持久化
@@ -295,14 +295,13 @@ Session Resume:
 - [ ] `TestBuildThreadStartParams` 覆盖 `DeveloperInstructions` 始终不存在的场景
 - [ ] 所有测试通过，无 regression
 
-### AC-10: `codex exec` 模式不受影响
+### AC-10: 其他 Worker 零影响
 
 **Given** 本 spec 仅修改 `codexcli/` 包
 **When** 部署变更
 **Then** 以下条件全部满足：
 - [ ] `internal/worker/claudecode/`、`internal/worker/acp/`、`internal/worker/opencodeserver/` 零改动
-- [ ] `codex exec` 相关代码（`exec/src/lib.rs`）零改动
-- [ ] `codex exec` 模式的 behavior 完全不变
+- [ ] 非 Codex Worker 的 behavior 完全不变
 
 ---
 
@@ -348,7 +347,7 @@ if session.SystemPrompt != "" {
 
 | 项目 | 理由 |
 |------|------|
-| `codex exec` 模式支持 | `exec` 是独立 Rust 二进制，不通过 app-server 协议；且 exec 没有 flag 暴露 baseInstructions |
+| `codex exec` 模式 | 已废弃移除，不在本 spec 范围内 |
 | `developerInstructions` 实际使用 | 当前 `SessionInfo` 没有对应概念，保留字段供未来扩展 |
 | `nReplace` / `SystemPromptReplace` 映射 | Codex app-server 协议层没有明确的 "replace" 语义，现有 `baseInstructions` 是追加语义 |
 | `codex` 二进制零修改 | HotPlex 侧的单向修改即可，app-server 协议已经全量支持额外字段容忍 |

--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -227,6 +227,11 @@ func (m *mockStore) Upsert(ctx context.Context, info *session.SessionInfo) error
 	return args.Error(0)
 }
 
+func (m *mockStore) UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSessionID string) error {
+	args := m.Called(ctx, id, workerSessionID)
+	return args.Error(0)
+}
+
 func (m *mockStore) Get(ctx context.Context, id string) (*session.SessionInfo, error) {
 	args := m.Called(ctx, id)
 	if args.Get(0) == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -817,7 +817,7 @@ func Default() *Config {
 			CodexCLI: CodexCLIConfig{
 				Command:         "codex",
 				Sandbox:         "danger-full-access",
-				ApprovalMode:    "never",
+				ApprovalMode:    "on-request",
 				Ephemeral:       true,
 				Personality:     "friendly",
 				StartupTimeout:  30 * time.Second,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -817,7 +817,7 @@ func Default() *Config {
 			CodexCLI: CodexCLIConfig{
 				Command:         "codex",
 				Sandbox:         "danger-full-access",
-				ApprovalMode:    "on-request",
+				ApprovalMode:    "never",
 				Ephemeral:       true,
 				Personality:     "friendly",
 				StartupTimeout:  30 * time.Second,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -600,8 +600,8 @@ type ClaudeCodeConfig struct {
 type CodexCLIConfig struct {
 	Command          string        `mapstructure:"command"`             // codex binary path, default "codex"
 	Model            string        `mapstructure:"model"`               // model name, empty = use Codex default
-	Sandbox          string        `mapstructure:"sandbox"`             // sandbox mode, default "danger-full-access"
-	ApprovalMode     string        `mapstructure:"approval_mode"`       // approval mode, default "never"
+	Sandbox          string        `mapstructure:"sandbox"`             // sandbox mode, default "danger-full-access" (YOLO: full filesystem + network)
+	ApprovalMode     string        `mapstructure:"approval_mode"`       // approval mode, default "never" (YOLO: no approval prompts)
 	Ephemeral        bool          `mapstructure:"ephemeral"`           // ephemeral sessions, default true
 	Personality      string        `mapstructure:"personality"`         // agent personality for app-server mode, default "friendly"
 	StartupTimeout   time.Duration `mapstructure:"startup_timeout"`     // process startup timeout, default 30s

--- a/internal/gateway/api_test.go
+++ b/internal/gateway/api_test.go
@@ -87,7 +87,7 @@ func (m *mockAPISM) UpdateWorkerSessionID(ctx context.Context, id, workerSession
 	return m.Called(ctx, id, workerSessionID).Error(0)
 }
 
-func (m *mockAPISM) UpdateWorkerSessionIDForce(ctx context.Context, id, workerSessionID string) error {
+func (m *mockAPISM) EnsureWorkerSessionID(ctx context.Context, id, workerSessionID string) error {
 	return m.Called(ctx, id, workerSessionID).Error(0)
 }
 

--- a/internal/gateway/api_test.go
+++ b/internal/gateway/api_test.go
@@ -87,6 +87,10 @@ func (m *mockAPISM) UpdateWorkerSessionID(ctx context.Context, id, workerSession
 	return m.Called(ctx, id, workerSessionID).Error(0)
 }
 
+func (m *mockAPISM) UpdateWorkerSessionIDForce(ctx context.Context, id, workerSessionID string) error {
+	return m.Called(ctx, id, workerSessionID).Error(0)
+}
+
 func (m *mockAPISM) ResetExpiry(ctx context.Context, id string) error {
 	return m.Called(ctx, id).Error(0)
 }

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -209,7 +209,10 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 	}
 
 	if fc.firstEvent {
-		b.persistWorkerSessionID(w, sessionID)
+		// Safety-net: persist again on first event in case the post-launch
+		// persist was lost (e.g., store flush delay). The authoritative call
+		// now lives in createAndLaunchWorker.
+		b.persistWorkerSessionID(opts.ctx, w, sessionID)
 		fc.turnStartTime = time.Now()
 		fc.firstEvent = false
 	}

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -213,7 +213,7 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 		// persist was incomplete. Scenarios: (1) GetWorkerSessionID() had not
 		// returned a value at launch time; (2) guard re-persist in transitionState
 		// failed; (3) gateway crashed between launch and first event.
-		b.persistWorkerSessionIDForce(opts.ctx, w, sessionID)
+		b.persistWorkerSessionIDEnsure(opts.ctx, w, sessionID)
 		fc.turnStartTime = time.Now()
 		fc.firstEvent = false
 	}

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -210,8 +210,9 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 
 	if fc.firstEvent {
 		// Safety-net: persist again on first event in case the post-launch
-		// persist was lost (e.g., store flush delay). The authoritative call
-		// now lives in createAndLaunchWorker.
+		// persist was incomplete. Scenarios: (1) GetWorkerSessionID() had not
+		// returned a value at launch time; (2) guard re-persist in transitionState
+		// failed; (3) gateway crashed between launch and first event.
 		b.persistWorkerSessionID(opts.ctx, w, sessionID)
 		fc.turnStartTime = time.Now()
 		fc.firstEvent = false

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -509,8 +509,10 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 		}
 	}
 
-	// Resume retry: skip during shutdown and for SIGTERM (exit 143).
-	fallbackAttempted := !b.closed.Load() && exitCode != 0 && exitCode != 143 && p.opts.resumed && p.opts.retryDepth < 2 && time.Since(p.startTime) < 15*time.Second
+	// Crash recovery retry: skip during shutdown and for SIGTERM (exit 143).
+	// Applies to both fresh and resumed sessions — Resume() gracefully falls back
+	// to fresh Start() for workers that cannot preserve conversation history.
+	fallbackAttempted := b.sm != nil && !b.closed.Load() && exitCode != 0 && exitCode != 143 && p.opts.retryDepth < 2 && time.Since(p.startTime) < 15*time.Second
 	if fallbackAttempted && p.turnTextLen == 0 && time.Since(p.startTime) < 5*time.Second {
 		b.log.Info("bridge: session files missing after resume, skipping retry",
 			"session_id", p.sessionID, "worker_type", workerType, "exit_code", exitCode)

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -509,10 +509,11 @@ func (b *Bridge) handleWorkerExit(w worker.Worker, p workerExitParams) {
 		}
 	}
 
-	// Crash recovery retry: skip during shutdown and for SIGTERM (exit 143).
+	// Crash recovery retry: attempt when the worker exited without completing
+	// its turn (no "done" received). Skip during shutdown, SIGTERM (143),
 	// Applies to both fresh and resumed sessions — Resume() gracefully falls back
 	// to fresh Start() for workers that cannot preserve conversation history.
-	fallbackAttempted := b.sm != nil && !b.closed.Load() && exitCode != 0 && exitCode != 143 && p.opts.retryDepth < 2 && time.Since(p.startTime) < 15*time.Second
+	fallbackAttempted := b.sm != nil && !b.closed.Load() && !p.doneReceived && exitCode != 143 && exitCode != -1 && p.opts.retryDepth < 2 && time.Since(p.startTime) < 15*time.Second
 	if fallbackAttempted && p.turnTextLen == 0 && time.Since(p.startTime) < 5*time.Second {
 		b.log.Info("bridge: session files missing after resume, skipping retry",
 			"session_id", p.sessionID, "worker_type", workerType, "exit_code", exitCode)

--- a/internal/gateway/bridge_forward.go
+++ b/internal/gateway/bridge_forward.go
@@ -213,7 +213,7 @@ func (b *Bridge) processForwardedEvent(env *events.Envelope, w worker.Worker, op
 		// persist was incomplete. Scenarios: (1) GetWorkerSessionID() had not
 		// returned a value at launch time; (2) guard re-persist in transitionState
 		// failed; (3) gateway crashed between launch and first event.
-		b.persistWorkerSessionID(opts.ctx, w, sessionID)
+		b.persistWorkerSessionIDForce(opts.ctx, w, sessionID)
 		fc.turnStartTime = time.Now()
 		fc.firstEvent = false
 	}

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -16,7 +16,6 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // forwardOpts configures the forwardEvents goroutine behavior.
@@ -94,6 +93,11 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	b.fwdWg.Add(1)
 	go func() {
 		defer b.fwdWg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				b.log.Error("bridge: panic in persistWorkerSessionID", "session_id", sid, "panic", r)
+			}
+		}()
 		b.persistWorkerSessionIDInternal(params.ctx, w, sid, false)
 	}()
 
@@ -112,15 +116,11 @@ func (b *Bridge) persistWorkerSessionIDEnsure(ctx context.Context, w worker.Work
 
 func (b *Bridge) persistWorkerSessionIDInternal(ctx context.Context, w worker.Worker, sessionID string, force bool) {
 	// Persist must survive request cancellation with an independent context
-	// (avoids inheriting the request deadline). OTel trace context is
-	// explicitly propagated via trace.ContextWithSpan so the write remains
-	// observable.
+	// (avoids inheriting the request deadline). context.WithoutCancel
+	// preserves all context values (trace, baggage, links) while removing
+	// cancellation, consistent with transitionState guard's usage.
 	if ctx != nil {
-		pCtx := context.Background()
-		if span := trace.SpanContextFromContext(ctx); span.IsValid() {
-			pCtx = trace.ContextWithSpanContext(pCtx, span)
-		}
-		ctx = pCtx
+		ctx = context.WithoutCancel(ctx)
 	} else {
 		ctx = context.Background()
 	}

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -93,7 +93,8 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	//
 	// Synchronous call is acceptable for SQLite (<1ms). For PostgreSQL,
 	// network round-trip adds 1–5ms per call under load; in bulk cron
-	// scenarios (N concurrent triggers), this serializes N DB writes in the
+	// scenarios (N concurrent triggers, typically 1–10, max capped by
+	// PoolManager.MaxPoolSize = 20), this serializes N DB writes in the
 	// caller goroutine. If PG latency becomes a bottleneck, move this into
 	// forwardEvents' first-event branch (which already does a persist) or
 	// make it async via a write-behind queue.

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -100,7 +100,7 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	return w, nil
 }
 
-func (b *Bridge) persistWorkerSessionIDForce(ctx context.Context, w worker.Worker, sessionID string) {
+func (b *Bridge) persistWorkerSessionIDEnsure(ctx context.Context, w worker.Worker, sessionID string) {
 	b.persistWorkerSessionIDInternal(ctx, w, sessionID, true)
 }
 
@@ -120,7 +120,7 @@ func (b *Bridge) persistWorkerSessionIDInternal(ctx context.Context, w worker.Wo
 	}
 	var err error
 	if force {
-		err = b.sm.UpdateWorkerSessionIDForce(ctx, sessionID, workerSID)
+		err = b.sm.EnsureWorkerSessionID(ctx, sessionID, workerSID)
 	} else {
 		err = b.sm.UpdateWorkerSessionID(ctx, sessionID, workerSID)
 	}

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -16,6 +16,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // forwardOpts configures the forwardEvents goroutine behavior.
@@ -110,10 +111,18 @@ func (b *Bridge) persistWorkerSessionIDEnsure(ctx context.Context, w worker.Work
 }
 
 func (b *Bridge) persistWorkerSessionIDInternal(ctx context.Context, w worker.Worker, sessionID string, force bool) {
-	// Persist must survive request cancellation — detach from request-scoped ctx
-	// while preserving OTel trace context.
+	// Persist must survive request cancellation with an independent context
+	// (avoids inheriting the request deadline). OTel trace context is
+	// explicitly propagated via trace.ContextWithSpan so the write remains
+	// observable.
 	if ctx != nil {
-		ctx = context.WithoutCancel(ctx)
+		pCtx := context.Background()
+		if span := trace.SpanContextFromContext(ctx); span.IsValid() {
+			pCtx = trace.ContextWithSpanContext(pCtx, span)
+		}
+		ctx = pCtx
+	} else {
+		ctx = context.Background()
 	}
 	handler, ok := w.(worker.WorkerSessionIDHandler)
 	if !ok {

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -90,6 +90,10 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	// gateway restart even if no turn events arrive (SIGTERM before first
 	// Prompt). Without this, transitionState races with the deferred persist
 	// in forwardEvents and may overwrite the DB row with an empty value.
+	// NOTE: synchronous call is acceptable here (SQLite write < 1ms). For
+	// high-concurrency batch scenarios (e.g. bulk cron triggers), consider
+	// moving this into forwardEvents' first-event branch or making it async,
+	// since forwardEvents already has a safety-net persist.
 	b.persistWorkerSessionID(params.ctx, w, sid)
 
 	b.fwdWg.Add(1)

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -88,12 +88,11 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 
 	// Persist WorkerSessionID immediately after worker start so it survives
 	// gateway restart even if no turn events arrive (SIGTERM before first
-	// Prompt). Without this, transitionState races with the deferred persist
-	// in forwardEvents and may overwrite the DB row with an empty value.
+	// Prompt). This is a best-effort optimization; the correctness guarantee
+	// comes from forwardEvents' first-event safety-net persist.
 	// NOTE: synchronous call is acceptable here (SQLite write < 1ms). For
 	// high-concurrency batch scenarios (e.g. bulk cron triggers), consider
-	// moving this into forwardEvents' first-event branch or making it async,
-	// since forwardEvents already has a safety-net persist.
+	// moving this into forwardEvents' first-event branch or making it async.
 	b.persistWorkerSessionID(params.ctx, w, sid)
 
 	b.fwdWg.Add(1)

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -86,6 +86,12 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 		return nil, err
 	}
 
+	// Persist WorkerSessionID immediately after worker start so it survives
+	// gateway restart even if no turn events arrive (SIGTERM before first
+	// Prompt). Without this, transitionState races with the deferred persist
+	// in forwardEvents and may overwrite the DB row with an empty value.
+	b.persistWorkerSessionID(w, sid)
+
 	b.fwdWg.Add(1)
 	go func() {
 		defer b.fwdWg.Done()

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -90,7 +90,7 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	// gateway restart even if no turn events arrive (SIGTERM before first
 	// Prompt). Without this, transitionState races with the deferred persist
 	// in forwardEvents and may overwrite the DB row with an empty value.
-	b.persistWorkerSessionID(w, sid)
+	b.persistWorkerSessionID(params.ctx, w, sid)
 
 	b.fwdWg.Add(1)
 	go func() {
@@ -101,7 +101,7 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	return w, nil
 }
 
-func (b *Bridge) persistWorkerSessionID(w worker.Worker, sessionID string) {
+func (b *Bridge) persistWorkerSessionID(ctx context.Context, w worker.Worker, sessionID string) {
 	handler, ok := w.(worker.WorkerSessionIDHandler)
 	if !ok {
 		return
@@ -110,7 +110,7 @@ func (b *Bridge) persistWorkerSessionID(w worker.Worker, sessionID string) {
 	if workerSID == "" {
 		return
 	}
-	if err := b.sm.UpdateWorkerSessionID(context.Background(), sessionID, workerSID); err != nil {
+	if err := b.sm.UpdateWorkerSessionID(ctx, sessionID, workerSID); err != nil {
 		b.log.Warn("bridge: failed to persist worker session ID", "session_id", sessionID, "worker_session_id", workerSID, "err", err)
 	} else {
 		b.log.Debug("bridge: persisted worker session ID", "session_id", sessionID, "worker_session_id", workerSID)

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -89,7 +89,12 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	// Best-effort async persist so WorkerSessionID survives gateway restart
 	// even if no turn events arrive (SIGTERM before first Prompt). The
 	// correctness guarantee comes from forwardEvents' first-event safety-net.
-	go b.persistWorkerSessionIDInternal(params.ctx, w, sid, false)
+	// Tracked by fwdWg so graceful shutdown waits for the DB write to complete.
+	b.fwdWg.Add(1)
+	go func() {
+		defer b.fwdWg.Done()
+		b.persistWorkerSessionIDInternal(params.ctx, w, sid, false)
+	}()
 
 	b.fwdWg.Add(1)
 	go func() {

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -102,6 +102,10 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 }
 
 func (b *Bridge) persistWorkerSessionID(ctx context.Context, w worker.Worker, sessionID string) {
+	// Persist must survive request cancellation — detach from request-scoped ctx.
+	if ctx == nil || ctx.Err() != nil {
+		ctx = context.Background()
+	}
 	handler, ok := w.(worker.WorkerSessionIDHandler)
 	if !ok {
 		return

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -90,9 +90,13 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	// gateway restart even if no turn events arrive (SIGTERM before first
 	// Prompt). This is a best-effort optimization; the correctness guarantee
 	// comes from forwardEvents' first-event safety-net persist.
-	// NOTE: synchronous call is acceptable here (SQLite write < 1ms). For
-	// high-concurrency batch scenarios (e.g. bulk cron triggers), consider
-	// moving this into forwardEvents' first-event branch or making it async.
+	//
+	// Synchronous call is acceptable for SQLite (<1ms). For PostgreSQL,
+	// network round-trip adds 1–5ms per call under load; in bulk cron
+	// scenarios (N concurrent triggers), this serializes N DB writes in the
+	// caller goroutine. If PG latency becomes a bottleneck, move this into
+	// forwardEvents' first-event branch (which already does a persist) or
+	// make it async via a write-behind queue.
 	b.persistWorkerSessionID(params.ctx, w, sid)
 
 	b.fwdWg.Add(1)

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -114,16 +114,11 @@ func (b *Bridge) persistWorkerSessionIDEnsure(ctx context.Context, w worker.Work
 	b.persistWorkerSessionIDInternal(ctx, w, sessionID, true)
 }
 
-func (b *Bridge) persistWorkerSessionIDInternal(ctx context.Context, w worker.Worker, sessionID string, force bool) {
-	// Persist must survive request cancellation with an independent context
-	// (avoids inheriting the request deadline). context.WithoutCancel
-	// preserves all context values (trace, baggage, links) while removing
-	// cancellation, consistent with transitionState guard's usage.
-	if ctx != nil {
-		ctx = context.WithoutCancel(ctx)
-	} else {
-		ctx = context.Background()
-	}
+func (b *Bridge) persistWorkerSessionIDInternal(_ context.Context, w worker.Worker, sessionID string, force bool) {
+	// Use Background to fully detach from the request context. The async DB
+	// write outlives the request, so inheriting trace baggage would mislead
+	// trace analysis (spans from a completed request's children).
+	ctx := context.Background()
 	handler, ok := w.(worker.WorkerSessionIDHandler)
 	if !ok {
 		return
@@ -160,9 +155,12 @@ type fallbackParams struct {
 	accModelName  string
 }
 
-// attemptResumeFallback handles a crashed resumed worker with a two-step strategy:
+// attemptResumeFallback handles a crashed worker with a two-step strategy:
 //  1. retryDepth < 1: Retry resume once to preserve conversation history (transient failures).
 //  2. retryDepth >= 1: Fall back to fresh start — conversation data is permanently lost.
+//
+// Applies to both fresh and resumed sessions. Workers that cannot resume
+// will gracefully fall back to fresh Start() via ErrFellBackToFreshStart.
 //
 // Returns true if a new forwardEvents goroutine took over.
 func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -104,9 +104,7 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 func (b *Bridge) persistWorkerSessionID(ctx context.Context, w worker.Worker, sessionID string) {
 	// Persist must survive request cancellation — detach from request-scoped ctx
 	// while preserving OTel trace context.
-	if ctx == nil {
-		ctx = context.Background()
-	} else {
+	if ctx != nil {
 		ctx = context.WithoutCancel(ctx)
 	}
 	handler, ok := w.(worker.WorkerSessionIDHandler)

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -86,19 +86,10 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 		return nil, err
 	}
 
-	// Persist WorkerSessionID immediately after worker start so it survives
-	// gateway restart even if no turn events arrive (SIGTERM before first
-	// Prompt). This is a best-effort optimization; the correctness guarantee
-	// comes from forwardEvents' first-event safety-net persist.
-	//
-	// Synchronous call is acceptable for SQLite (<1ms). For PostgreSQL,
-	// network round-trip adds 1–5ms per call under load; in bulk cron
-	// scenarios (N concurrent triggers, typically 1–10, max capped by
-	// PoolManager.MaxPoolSize = 20), this serializes N DB writes in the
-	// caller goroutine. If PG latency becomes a bottleneck, move this into
-	// forwardEvents' first-event branch (which already does a persist) or
-	// make it async via a write-behind queue.
-	b.persistWorkerSessionID(params.ctx, w, sid)
+	// Best-effort async persist so WorkerSessionID survives gateway restart
+	// even if no turn events arrive (SIGTERM before first Prompt). The
+	// correctness guarantee comes from forwardEvents' first-event safety-net.
+	go b.persistWorkerSessionIDInternal(params.ctx, w, sid, false)
 
 	b.fwdWg.Add(1)
 	go func() {
@@ -109,7 +100,11 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 	return w, nil
 }
 
-func (b *Bridge) persistWorkerSessionID(ctx context.Context, w worker.Worker, sessionID string) {
+func (b *Bridge) persistWorkerSessionIDForce(ctx context.Context, w worker.Worker, sessionID string) {
+	b.persistWorkerSessionIDInternal(ctx, w, sessionID, true)
+}
+
+func (b *Bridge) persistWorkerSessionIDInternal(ctx context.Context, w worker.Worker, sessionID string, force bool) {
 	// Persist must survive request cancellation — detach from request-scoped ctx
 	// while preserving OTel trace context.
 	if ctx != nil {
@@ -123,7 +118,13 @@ func (b *Bridge) persistWorkerSessionID(ctx context.Context, w worker.Worker, se
 	if workerSID == "" {
 		return
 	}
-	if err := b.sm.UpdateWorkerSessionID(ctx, sessionID, workerSID); err != nil {
+	var err error
+	if force {
+		err = b.sm.UpdateWorkerSessionIDForce(ctx, sessionID, workerSID)
+	} else {
+		err = b.sm.UpdateWorkerSessionID(ctx, sessionID, workerSID)
+	}
+	if err != nil {
 		b.log.Warn("bridge: failed to persist worker session ID", "session_id", sessionID, "worker_session_id", workerSID, "err", err)
 	} else {
 		b.log.Debug("bridge: persisted worker session ID", "session_id", sessionID, "worker_session_id", workerSID)

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -102,9 +102,12 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 }
 
 func (b *Bridge) persistWorkerSessionID(ctx context.Context, w worker.Worker, sessionID string) {
-	// Persist must survive request cancellation — detach from request-scoped ctx.
-	if ctx == nil || ctx.Err() != nil {
+	// Persist must survive request cancellation — detach from request-scoped ctx
+	// while preserving OTel trace context.
+	if ctx == nil {
 		ctx = context.Background()
+	} else {
+		ctx = context.WithoutCancel(ctx)
 	}
 	handler, ok := w.(worker.WorkerSessionIDHandler)
 	if !ok {

--- a/internal/gateway/conn_test.go
+++ b/internal/gateway/conn_test.go
@@ -1194,7 +1194,7 @@ func (m *mockBridgeSM) UpdateWorkerSessionID(ctx context.Context, id, workerSess
 	return args.Error(0)
 }
 
-func (m *mockBridgeSM) UpdateWorkerSessionIDForce(ctx context.Context, id, workerSessionID string) error {
+func (m *mockBridgeSM) EnsureWorkerSessionID(ctx context.Context, id, workerSessionID string) error {
 	args := m.Called(ctx, id, workerSessionID)
 	return args.Error(0)
 }

--- a/internal/gateway/conn_test.go
+++ b/internal/gateway/conn_test.go
@@ -461,6 +461,11 @@ func (m *mockSessionStoreForBotID) Upsert(ctx context.Context, info *session.Ses
 	return args.Error(0)
 }
 
+func (m *mockSessionStoreForBotID) UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSessionID string) error {
+	args := m.Called(ctx, id, workerSessionID)
+	return args.Error(0)
+}
+
 func (m *mockSessionStoreForBotID) Get(ctx context.Context, id string) (*session.SessionInfo, error) {
 	args := m.Called(ctx, id)
 	if args.Get(0) == nil {
@@ -1185,6 +1190,11 @@ func (m *mockBridgeSM) List(ctx context.Context, userID, platform string, limit,
 }
 
 func (m *mockBridgeSM) UpdateWorkerSessionID(ctx context.Context, id, workerSessionID string) error {
+	args := m.Called(ctx, id, workerSessionID)
+	return args.Error(0)
+}
+
+func (m *mockBridgeSM) UpdateWorkerSessionIDForce(ctx context.Context, id, workerSessionID string) error {
 	args := m.Called(ctx, id, workerSessionID)
 	return args.Error(0)
 }

--- a/internal/gateway/ctrl_test.go
+++ b/internal/gateway/ctrl_test.go
@@ -35,6 +35,11 @@ func (m *mockStore) Upsert(ctx context.Context, info *session.SessionInfo) error
 	return args.Error(0)
 }
 
+func (m *mockStore) UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSessionID string) error {
+	args := m.Called(ctx, id, workerSessionID)
+	return args.Error(0)
+}
+
 func (m *mockStore) Get(ctx context.Context, id string) (*session.SessionInfo, error) {
 	args := m.Called(ctx, id)
 	if args.Get(0) == nil {

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -388,6 +388,7 @@ type SessionWorkerManager interface {
 	DetachWorker(id string)
 	DetachWorkerIf(id string, expected worker.Worker) bool
 	UpdateWorkerSessionID(ctx context.Context, id, workerSessionID string) error
+	UpdateWorkerSessionIDForce(ctx context.Context, id, workerSessionID string) error
 }
 
 // SessionAdmin provides listing, ownership validation, and metadata mutations.

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -388,7 +388,7 @@ type SessionWorkerManager interface {
 	DetachWorker(id string)
 	DetachWorkerIf(id string, expected worker.Worker) bool
 	UpdateWorkerSessionID(ctx context.Context, id, workerSessionID string) error
-	UpdateWorkerSessionIDForce(ctx context.Context, id, workerSessionID string) error
+	EnsureWorkerSessionID(ctx context.Context, id, workerSessionID string) error
 }
 
 // SessionAdmin provides listing, ownership validation, and metadata mutations.

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -888,6 +888,9 @@ func (m *mockInputSM) DetachWorkerIf(_ string, _ worker.Worker) bool            
 func (m *mockInputSM) UpdateWorkerSessionID(_ context.Context, _ string, _ string) error {
 	return nil
 }
+func (m *mockInputSM) UpdateWorkerSessionIDForce(_ context.Context, _ string, _ string) error {
+	return nil
+}
 func (m *mockInputSM) List(_ context.Context, _ string, _ string, _ int, _ int) ([]*session.SessionInfo, error) {
 	return nil, nil
 }

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -888,7 +888,7 @@ func (m *mockInputSM) DetachWorkerIf(_ string, _ worker.Worker) bool            
 func (m *mockInputSM) UpdateWorkerSessionID(_ context.Context, _ string, _ string) error {
 	return nil
 }
-func (m *mockInputSM) UpdateWorkerSessionIDForce(_ context.Context, _ string, _ string) error {
+func (m *mockInputSM) EnsureWorkerSessionID(_ context.Context, _ string, _ string) error {
 	return nil
 }
 func (m *mockInputSM) List(_ context.Context, _ string, _ string, _ int, _ int) ([]*session.SessionInfo, error) {

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -657,6 +657,27 @@ func ACPHandshakeDuration() metric.Float64Histogram {
 	return acpHandshakeDuration
 }
 
+// ─── Session Guard Instruments ────────────────────────────────────
+
+var (
+	sessionGuardRePersistFailures     metric.Int64Counter
+	sessionGuardRePersistFailuresInit sync.Once
+)
+
+func SessionGuardRePersistFailures() metric.Int64Counter {
+	sessionGuardRePersistFailuresInit.Do(func() {
+		var err error
+		sessionGuardRePersistFailures, err = Meter().Int64Counter(
+			"hotplex.session.guard.repersist.failures",
+			metric.WithDescription("transitionState guard re-persist failures (WorkerSessionID)"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.session.guard.repersist.failures", err)
+		}
+	})
+	return sessionGuardRePersistFailures
+}
+
 // ─── Retry Instruments ──────────────────────────────────────────────
 
 var (

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -663,8 +663,8 @@ var (
 	sessionGuardRePersistFailures     metric.Int64Counter
 	sessionGuardRePersistFailuresInit sync.Once
 
-	sessionGuardRePersistStaleWrites     metric.Int64Counter
-	sessionGuardRePersistStaleWritesInit sync.Once
+	sessionGuardRePersistConcurrentOverwrite     metric.Int64Counter
+	sessionGuardRePersistConcurrentOverwriteInit sync.Once
 )
 
 func SessionGuardRePersistFailures() metric.Int64Counter {
@@ -681,18 +681,18 @@ func SessionGuardRePersistFailures() metric.Int64Counter {
 	return sessionGuardRePersistFailures
 }
 
-func SessionGuardRePersistStaleWrites() metric.Int64Counter {
-	sessionGuardRePersistStaleWritesInit.Do(func() {
+func SessionGuardRePersistConcurrentOverwrites() metric.Int64Counter {
+	sessionGuardRePersistConcurrentOverwriteInit.Do(func() {
 		var err error
-		sessionGuardRePersistStaleWrites, err = Meter().Int64Counter(
-			"hotplex.session.guard.repersist.stale_writes",
-			metric.WithDescription("transitionState guard detected stale WorkerSessionID after re-persist lock window"),
+		sessionGuardRePersistConcurrentOverwrite, err = Meter().Int64Counter(
+			"hotplex.session.guard.repersist.concurrent_overwrite",
+			metric.WithDescription("transitionState guard detected concurrent WorkerSessionID overwrite during re-persist lock window"),
 		)
 		if err != nil {
-			warnInstrument("hotplex.session.guard.repersist.stale_writes", err)
+			warnInstrument("hotplex.session.guard.repersist.concurrent_overwrite", err)
 		}
 	})
-	return sessionGuardRePersistStaleWrites
+	return sessionGuardRePersistConcurrentOverwrite
 }
 
 // ─── Retry Instruments ──────────────────────────────────────────────

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -671,11 +671,11 @@ func SessionGuardRePersistFailures() metric.Int64Counter {
 	sessionGuardRePersistFailuresInit.Do(func() {
 		var err error
 		sessionGuardRePersistFailures, err = Meter().Int64Counter(
-			"hotplex.session.guard.repersist.failures",
+			"hotplex.session.transition.guard_repersist_failures",
 			metric.WithDescription("transitionState guard re-persist failures (WorkerSessionID)"),
 		)
 		if err != nil {
-			warnInstrument("hotplex.session.guard.repersist.failures", err)
+			warnInstrument("hotplex.session.transition.guard_repersist_failures", err)
 		}
 	})
 	return sessionGuardRePersistFailures
@@ -685,11 +685,11 @@ func SessionGuardRePersistConcurrentOverwrites() metric.Int64Counter {
 	sessionGuardRePersistConcurrentOverwriteInit.Do(func() {
 		var err error
 		sessionGuardRePersistConcurrentOverwrite, err = Meter().Int64Counter(
-			"hotplex.session.guard.repersist.concurrent_overwrite",
+			"hotplex.session.transition.guard_repersist_overwrites",
 			metric.WithDescription("transitionState guard detected concurrent WorkerSessionID overwrite during re-persist lock window"),
 		)
 		if err != nil {
-			warnInstrument("hotplex.session.guard.repersist.concurrent_overwrite", err)
+			warnInstrument("hotplex.session.transition.guard_repersist_overwrites", err)
 		}
 	})
 	return sessionGuardRePersistConcurrentOverwrite

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -662,6 +662,9 @@ func ACPHandshakeDuration() metric.Float64Histogram {
 var (
 	sessionGuardRePersistFailures     metric.Int64Counter
 	sessionGuardRePersistFailuresInit sync.Once
+
+	sessionGuardRePersistStaleWrites     metric.Int64Counter
+	sessionGuardRePersistStaleWritesInit sync.Once
 )
 
 func SessionGuardRePersistFailures() metric.Int64Counter {
@@ -676,6 +679,20 @@ func SessionGuardRePersistFailures() metric.Int64Counter {
 		}
 	})
 	return sessionGuardRePersistFailures
+}
+
+func SessionGuardRePersistStaleWrites() metric.Int64Counter {
+	sessionGuardRePersistStaleWritesInit.Do(func() {
+		var err error
+		sessionGuardRePersistStaleWrites, err = Meter().Int64Counter(
+			"hotplex.session.guard.repersist.stale_writes",
+			metric.WithDescription("transitionState guard detected stale WorkerSessionID after re-persist lock window"),
+		)
+		if err != nil {
+			warnInstrument("hotplex.session.guard.repersist.stale_writes", err)
+		}
+	})
+	return sessionGuardRePersistStaleWrites
 }
 
 // ─── Retry Instruments ──────────────────────────────────────────────

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -671,11 +671,11 @@ func SessionGuardRePersistFailures() metric.Int64Counter {
 	sessionGuardRePersistFailuresInit.Do(func() {
 		var err error
 		sessionGuardRePersistFailures, err = Meter().Int64Counter(
-			"hotplex.session.transition.guard_repersist_failures",
+			"hotplex.session.transition.guard.repersist.failures",
 			metric.WithDescription("transitionState guard re-persist failures (WorkerSessionID)"),
 		)
 		if err != nil {
-			warnInstrument("hotplex.session.transition.guard_repersist_failures", err)
+			warnInstrument("hotplex.session.transition.guard.repersist.failures", err)
 		}
 	})
 	return sessionGuardRePersistFailures
@@ -685,11 +685,11 @@ func SessionGuardRePersistConcurrentOverwrites() metric.Int64Counter {
 	sessionGuardRePersistConcurrentOverwriteInit.Do(func() {
 		var err error
 		sessionGuardRePersistConcurrentOverwrite, err = Meter().Int64Counter(
-			"hotplex.session.transition.guard_repersist_overwrites",
+			"hotplex.session.transition.guard.repersist.overwrites",
 			metric.WithDescription("transitionState guard detected WorkerSessionID changed by another goroutine after re-persist"),
 		)
 		if err != nil {
-			warnInstrument("hotplex.session.transition.guard_repersist_overwrites", err)
+			warnInstrument("hotplex.session.transition.guard.repersist.overwrites", err)
 		}
 	})
 	return sessionGuardRePersistConcurrentOverwrite

--- a/internal/observability/instruments.go
+++ b/internal/observability/instruments.go
@@ -686,7 +686,7 @@ func SessionGuardRePersistConcurrentOverwrites() metric.Int64Counter {
 		var err error
 		sessionGuardRePersistConcurrentOverwrite, err = Meter().Int64Counter(
 			"hotplex.session.transition.guard_repersist_overwrites",
-			metric.WithDescription("transitionState guard detected concurrent WorkerSessionID overwrite during re-persist lock window"),
+			metric.WithDescription("transitionState guard detected WorkerSessionID changed by another goroutine after re-persist"),
 		)
 		if err != nil {
 			warnInstrument("hotplex.session.transition.guard_repersist_overwrites", err)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -417,10 +417,13 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	// with a stale empty value, breaking session resume for ACP workers.
 	if candidate.WorkerSessionID == "" && ms.info.WorkerSessionID != "" {
 		candidate.WorkerSessionID = ms.info.WorkerSessionID
-		// Re-persist to keep DB consistent with in-memory.
+		// Re-persist outside lock to avoid blocking concurrent reads,
+		// consistent with the main Upsert above.
+		ms.mu.Unlock()
 		if dbErr := m.store.Upsert(ctx, &candidate); dbErr != nil {
 			m.log.Error("session: failed to re-persist WorkerSessionID after guard", "err", dbErr)
 		}
+		ms.mu.Lock()
 	}
 
 	// Commit: replace ms.info with the persisted snapshot.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -417,6 +417,14 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	// was released during Upsert. Without this guard, the candidate copy
 	// (taken before the concurrent update) overwrites both DB and in-memory
 	// with a stale empty value, breaking session resume for ACP workers.
+	//
+	// NOTE: This second Upsert re-introduces a lock-release window. The
+	// residual race is theoretical (requires concurrent UpdateWorkerSessionID
+	// during the ~µs Upsert window) and is mitigated by forwardEvents'
+	// first-event safety-net persist. A CAS-based approach (e.g. WHERE
+	// worker_session_id = '' in SQL) or lock-dual-upsert pattern could
+	// eliminate this window entirely but adds complexity; deferred until
+	// the residual race is observed in production metrics.
 	if candidate.WorkerSessionID == "" && ms.info.WorkerSessionID != "" {
 		candidate.WorkerSessionID = ms.info.WorkerSessionID
 		ms.mu.Unlock()
@@ -430,6 +438,9 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 		ms.mu.Lock()
 		// Preserve any concurrent update that arrived during the second
 		// Upsert's lock-release window (residual theoretical race).
+		// In the extreme case where this also races, the in-memory value
+		// will be correct but the DB row may remain stale until forwardEvents'
+		// next persist opportunity restores consistency.
 		if ms.info.WorkerSessionID != candidate.WorkerSessionID {
 			candidate.WorkerSessionID = ms.info.WorkerSessionID
 		}
@@ -964,8 +975,9 @@ func (m *Manager) UpdateWorkerSessionID(ctx context.Context, id, workerSessionID
 	// Fast-path: skip DB write when value is unchanged. The check runs outside
 	// updateSession's atomic apply closure, so a concurrent transitionState can
 	// overwrite WorkerSessionID between this unlock and updateSession's re-lock.
-	// This is safe: transitionState's guard restores the value, and forwardEvents
-	// has a safety-net persist.
+	// This is safe: transitionState's guard restores the value in most cases;
+	// if the guard's own second Upsert also races (extremely rare), forwardEvents'
+	// safety-net persist will restore consistency on the next persist opportunity.
 	if ms.info.WorkerSessionID == workerSessionID {
 		ms.mu.Unlock()
 		return nil

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -443,6 +443,7 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 		// next persist opportunity restores consistency.
 		if ms.info.WorkerSessionID != candidate.WorkerSessionID {
 			candidate.WorkerSessionID = ms.info.WorkerSessionID
+			observability.SessionGuardRePersistStaleWrites().Add(ctx, 1)
 		}
 	}
 
@@ -971,20 +972,10 @@ func (m *Manager) UpdateWorkerSessionID(ctx context.Context, id, workerSessionID
 		return ErrSessionNotFound
 	}
 
-	ms.mu.Lock()
-	// Fast-path: skip DB write when value is unchanged. The check runs outside
-	// updateSession's atomic apply closure, so a concurrent transitionState can
-	// overwrite WorkerSessionID between this unlock and updateSession's re-lock.
-	// This is safe: transitionState's guard restores the value in most cases;
-	// if the guard's own second Upsert also races (extremely rare), forwardEvents'
-	// safety-net persist will restore consistency on the next persist opportunity.
-	if ms.info.WorkerSessionID == workerSessionID {
-		ms.mu.Unlock()
-		return nil
-	}
-	ms.mu.Unlock()
-
 	return m.updateSession(ctx, ms, func(info *SessionInfo) func() {
+		// No fast-path skip: even when the in-memory value matches, the DB row
+		// may be stale (guard re-persist failed, transitionState overwrote it).
+		// The safety-net caller (forwardEvents) relies on this path to repair DB.
 		prev := info.WorkerSessionID
 		info.WorkerSessionID = workerSessionID
 		return func() { info.WorkerSessionID = prev }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -391,7 +391,8 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	// TODO: shallow copy + lock release during Upsert means any concurrent updateSession
 	// field mutation can be overwritten by the stale candidate commit. WorkerSessionID
 	// is protected by the guard below (residual theoretical window in the
-	// guard second Upsert — see #709); other scalar fields are not protected.
+	// guard second Upsert — track CAS/lock-dual-upsert fix under #709);
+	// other scalar fields are not protected.
 	candidate := ms.info
 	candidate.State = to
 	candidate.UpdatedAt = time.Now()

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -417,6 +417,10 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	// with a stale empty value, breaking session resume for ACP workers.
 	if candidate.WorkerSessionID == "" && ms.info.WorkerSessionID != "" {
 		candidate.WorkerSessionID = ms.info.WorkerSessionID
+		// Re-persist to keep DB consistent with in-memory.
+		if dbErr := m.store.Upsert(ctx, &candidate); dbErr != nil {
+			m.log.Error("session: failed to re-persist WorkerSessionID after guard", "err", dbErr)
+		}
 	}
 
 	// Commit: replace ms.info with the persisted snapshot.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -421,7 +421,11 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 		candidate.WorkerSessionID = ms.info.WorkerSessionID
 		ms.mu.Unlock()
 		if dbErr := m.store.Upsert(ctx, &candidate); dbErr != nil {
-			m.log.Error("session: failed to re-persist WorkerSessionID after guard", "err", dbErr)
+			// DB write failed — in-memory is correct but DB row is stale.
+			// Gateway restart will lose WorkerSessionID, breaking resume.
+			// TODO(#709): add Prometheus counter for this path.
+			m.log.Error("session: failed to re-persist WorkerSessionID after guard",
+				"session_id", candidate.ID, "worker_session_id", candidate.WorkerSessionID, "err", dbErr)
 		}
 		ms.mu.Lock()
 		// Preserve any concurrent update that arrived during the second
@@ -957,9 +961,11 @@ func (m *Manager) UpdateWorkerSessionID(ctx context.Context, id, workerSessionID
 	}
 
 	ms.mu.Lock()
-	// Fast-path check is done inside updateSession's apply closure to avoid
-	// TOCTOU: the lock is released between this check and updateSession acquiring
-	// it, during which transitionState can overwrite WorkerSessionID.
+	// Fast-path: skip DB write when value is unchanged. The check runs outside
+	// updateSession's atomic apply closure, so a concurrent transitionState can
+	// overwrite WorkerSessionID between this unlock and updateSession's re-lock.
+	// This is safe: transitionState's guard restores the value, and forwardEvents
+	// has a safety-net persist.
 	if ms.info.WorkerSessionID == workerSessionID {
 		ms.mu.Unlock()
 		return nil

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -388,6 +388,9 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	// Build the candidate state as a value copy (never mutates ms.info in-place).
 	// NOTE: shallow copy — map fields (Context, PlatformKey) share headers.
 	// Safe here because only scalar fields (State, UpdatedAt, etc.) are mutated.
+	// TODO: shallow copy + lock release during Upsert means any concurrent updateSession
+	// field mutation can be overwritten by the stale candidate commit. WorkerSessionID
+	// is protected by the guard below; other scalar fields are not (see #709).
 	candidate := ms.info
 	candidate.State = to
 	candidate.UpdatedAt = time.Now()

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -388,11 +388,10 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	// Build the candidate state as a value copy (never mutates ms.info in-place).
 	// NOTE: shallow copy — map fields (Context, PlatformKey) share headers.
 	// Safe here because only scalar fields (State, UpdatedAt, etc.) are mutated.
-	// TODO: shallow copy + lock release during Upsert means any concurrent updateSession
-	// field mutation can be overwritten by the stale candidate commit. WorkerSessionID
-	// is protected by the guard below (residual theoretical window in the
-	// guard second Upsert — track CAS/lock-dual-upsert fix under #709);
-	// other scalar fields are not protected.
+	// WorkerSessionID is protected by the targeted SQL UPDATE guard below
+	// (lines ~426-440); other scalar fields have a theoretical stale-write
+	// window during the lock release for DB I/O, mitigated by the safety-net
+	// persist on first event (see #709).
 	candidate := ms.info
 	candidate.State = to
 	candidate.UpdatedAt = time.Now()
@@ -420,9 +419,12 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	//
 	// NOTE: This targeted SQL UPDATE avoids full-row Upsert's risk of overwriting
 	// concurrent field changes (UpdatedAt, ExpiresAt, Source, etc.) made during
-	// the unlock window. The residual race (concurrent UpdateWorkerSessionID
-	// during the ~µs SQL window) is mitigated by forwardEvents' first-event
-	// safety-net persist.
+	// the unlock window. There is a theoretical second race: a concurrent
+	// UpdateWorkerSessionID that acquires ms.mu during the µs SQL window and
+	// sets a different WorkerSessionID, which our stale "wsid" then overwrites.
+	// Accepted because (a) the window is ~µs, (b) forwardEvents' first-event
+	// safety-net persist (EnsureWorkerSessionID) will repair the row, and
+	// (c) the concurrent overwrite detection below re-syncs in-memory state.
 	if candidate.WorkerSessionID == "" && ms.info.WorkerSessionID != "" {
 		wsid := ms.info.WorkerSessionID
 		candidate.WorkerSessionID = wsid
@@ -959,10 +961,10 @@ func (m *Manager) UpdateWorkerSessionID(ctx context.Context, id, workerSessionID
 	return m.updateWorkerSessionID(ctx, id, workerSessionID, false)
 }
 
-// UpdateWorkerSessionIDForce persists the worker-internal session ID, bypassing
+// EnsureWorkerSessionID persists the worker-internal session ID, bypassing
 // the fast-path skip. Used by the safety-net caller (forwardEvents) to repair
 // stale DB rows after guard re-persist failures.
-func (m *Manager) UpdateWorkerSessionIDForce(ctx context.Context, id, workerSessionID string) error {
+func (m *Manager) EnsureWorkerSessionID(ctx context.Context, id, workerSessionID string) error {
 	return m.updateWorkerSessionID(ctx, id, workerSessionID, true)
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -982,15 +982,8 @@ func (m *Manager) updateWorkerSessionID(ctx context.Context, id, workerSessionID
 		return ErrSessionNotFound
 	}
 
-	// Fast-path skip when in-memory matches. There is a TOCTOU window between
-	// RUnlock and updateSession.Lock, during which transitionState's guard could
-	// modify ms.info.WorkerSessionID. This is safe because: (1) the guard uses
-	// targeted SQL (UpdateWorkerSessionIDSQL), not full-row Upsert, so concurrent
-	// Upsert in updateSession won't overwrite worker_session_id; (2) the Upsert
-	// ON CONFLICT clause does not include worker_session_id in its UPDATE SET,
-	// so the fast-path's subsequent Upsert is a no-op for this field; (3) the
-	// safety-net (EnsureWorkerSessionID) repairs any stale DB row on first event.
-	// Force mode (safety-net) always writes to repair stale DB rows.
+	// Fast-path skip when in-memory matches. Force mode (safety-net) always
+	// writes to repair stale DB rows.
 	if !force {
 		ms.mu.RLock()
 		same := ms.info.WorkerSessionID == workerSessionID
@@ -1000,11 +993,24 @@ func (m *Manager) updateWorkerSessionID(ctx context.Context, id, workerSessionID
 		}
 	}
 
-	return m.updateSession(ctx, ms, func(info *SessionInfo) func() {
-		prev := info.WorkerSessionID
-		info.WorkerSessionID = workerSessionID
-		return func() { info.WorkerSessionID = prev }
-	})
+	// Update in-memory under lock, then persist via targeted SQL.
+	// Uses UpdateWorkerSessionIDSQL rather than updateSession→Upsert because
+	// the Upsert ON CONFLICT clause intentionally excludes worker_session_id
+	// to prevent stale writes during transitionState's lock-release window.
+	ms.mu.Lock()
+	prev := ms.info.WorkerSessionID
+	ms.info.WorkerSessionID = workerSessionID
+	ms.mu.Unlock()
+
+	if err := m.store.UpdateWorkerSessionIDSQL(ctx, id, workerSessionID); err != nil {
+		// Roll back in-memory on DB failure.
+		ms.mu.Lock()
+		ms.info.WorkerSessionID = prev
+		ms.mu.Unlock()
+		return err
+	}
+
+	return nil
 }
 
 // DebugSessionSnapshot holds safe-to-expose debug info for a managed session.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -429,7 +429,12 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 		wsid := ms.info.WorkerSessionID
 		candidate.WorkerSessionID = wsid
 		ms.mu.Unlock()
-		if dbErr := m.store.UpdateWorkerSessionIDSQL(ctx, candidate.ID, wsid); dbErr != nil {
+		guardCtx := context.WithoutCancel(ctx)
+		if dbErr := m.store.UpdateWorkerSessionIDSQL(guardCtx, candidate.ID, wsid); dbErr != nil {
+			// Roll back in-memory value to maintain consistency with DB
+			// (both empty). The safety-net (EnsureWorkerSessionID) will
+			// repair on first event.
+			candidate.WorkerSessionID = ""
 			observability.SessionGuardRePersistFailures().Add(ctx, 1)
 			m.log.Error("session: failed to re-persist WorkerSessionID after guard",
 				"session_id", candidate.ID, "worker_session_id", wsid, "err", dbErr)
@@ -977,9 +982,15 @@ func (m *Manager) updateWorkerSessionID(ctx context.Context, id, workerSessionID
 		return ErrSessionNotFound
 	}
 
-	// Fast-path skip when in-memory matches — safe for normal callers since
-	// the guard now uses targeted SQL. Force mode (safety-net) always writes
-	// to repair stale DB rows from guard re-persist failures.
+	// Fast-path skip when in-memory matches. There is a TOCTOU window between
+	// RUnlock and updateSession.Lock, during which transitionState's guard could
+	// modify ms.info.WorkerSessionID. This is safe because: (1) the guard uses
+	// targeted SQL (UpdateWorkerSessionIDSQL), not full-row Upsert, so concurrent
+	// Upsert in updateSession won't overwrite worker_session_id; (2) the Upsert
+	// ON CONFLICT clause does not include worker_session_id in its UPDATE SET,
+	// so the fast-path's subsequent Upsert is a no-op for this field; (3) the
+	// safety-net (EnsureWorkerSessionID) repairs any stale DB row on first event.
+	// Force mode (safety-net) always writes to repair stale DB rows.
 	if !force {
 		ms.mu.RLock()
 		same := ms.info.WorkerSessionID == workerSessionID

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -431,7 +431,7 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 		if dbErr := m.store.Upsert(ctx, &candidate); dbErr != nil {
 			// DB write failed — in-memory is correct but DB row is stale.
 			// Gateway restart will lose WorkerSessionID, breaking resume.
-			// TODO(#709): add Prometheus counter for this path.
+			observability.SessionGuardRePersistFailures().Add(ctx, 1)
 			m.log.Error("session: failed to re-persist WorkerSessionID after guard",
 				"session_id", candidate.ID, "worker_session_id", candidate.WorkerSessionID, "err", dbErr)
 		}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -418,30 +418,22 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	// (taken before the concurrent update) overwrites both DB and in-memory
 	// with a stale empty value, breaking session resume for ACP workers.
 	//
-	// NOTE: This second Upsert re-introduces a lock-release window. The
-	// residual race is theoretical (requires concurrent UpdateWorkerSessionID
-	// during the ~µs Upsert window) and is mitigated by forwardEvents'
-	// first-event safety-net persist. A CAS-based approach (e.g. WHERE
-	// worker_session_id = '' in SQL) or lock-dual-upsert pattern could
-	// eliminate this window entirely but adds complexity; deferred until
-	// the residual race is observed in production metrics.
+	// NOTE: This targeted SQL UPDATE avoids full-row Upsert's risk of overwriting
+	// concurrent field changes (UpdatedAt, ExpiresAt, Source, etc.) made during
+	// the unlock window. The residual race (concurrent UpdateWorkerSessionID
+	// during the ~µs SQL window) is mitigated by forwardEvents' first-event
+	// safety-net persist.
 	if candidate.WorkerSessionID == "" && ms.info.WorkerSessionID != "" {
-		candidate.WorkerSessionID = ms.info.WorkerSessionID
+		wsid := ms.info.WorkerSessionID
+		candidate.WorkerSessionID = wsid
 		ms.mu.Unlock()
-		if dbErr := m.store.Upsert(ctx, &candidate); dbErr != nil {
-			// DB write failed — in-memory is correct but DB row is stale.
-			// Gateway restart will lose WorkerSessionID, breaking resume.
+		if dbErr := m.store.UpdateWorkerSessionIDSQL(ctx, candidate.ID, wsid); dbErr != nil {
 			observability.SessionGuardRePersistFailures().Add(ctx, 1)
 			m.log.Error("session: failed to re-persist WorkerSessionID after guard",
-				"session_id", candidate.ID, "worker_session_id", candidate.WorkerSessionID, "err", dbErr)
+				"session_id", candidate.ID, "worker_session_id", wsid, "err", dbErr)
 		}
 		ms.mu.Lock()
-		// Preserve any concurrent update that arrived during the second
-		// Upsert's lock-release window (residual theoretical race).
-		// In the extreme case where this also races, the in-memory value
-		// will be correct but the DB row may remain stale until forwardEvents'
-		// next persist opportunity restores consistency.
-		if ms.info.WorkerSessionID != candidate.WorkerSessionID {
+		if ms.info.WorkerSessionID != wsid {
 			candidate.WorkerSessionID = ms.info.WorkerSessionID
 			observability.SessionGuardRePersistConcurrentOverwrites().Add(ctx, 1)
 		}
@@ -964,6 +956,17 @@ func (m *Manager) ClearContext(ctx context.Context, sessionID string) error {
 // Workers that manage their own session IDs (OpenCode Server) call this
 // to store the ID so it can be restored on resume.
 func (m *Manager) UpdateWorkerSessionID(ctx context.Context, id, workerSessionID string) error {
+	return m.updateWorkerSessionID(ctx, id, workerSessionID, false)
+}
+
+// UpdateWorkerSessionIDForce persists the worker-internal session ID, bypassing
+// the fast-path skip. Used by the safety-net caller (forwardEvents) to repair
+// stale DB rows after guard re-persist failures.
+func (m *Manager) UpdateWorkerSessionIDForce(ctx context.Context, id, workerSessionID string) error {
+	return m.updateWorkerSessionID(ctx, id, workerSessionID, true)
+}
+
+func (m *Manager) updateWorkerSessionID(ctx context.Context, id, workerSessionID string, force bool) error {
 	if m == nil {
 		return ErrSessionNotFound
 	}
@@ -972,10 +975,19 @@ func (m *Manager) UpdateWorkerSessionID(ctx context.Context, id, workerSessionID
 		return ErrSessionNotFound
 	}
 
+	// Fast-path skip when in-memory matches — safe for normal callers since
+	// the guard now uses targeted SQL. Force mode (safety-net) always writes
+	// to repair stale DB rows from guard re-persist failures.
+	if !force {
+		ms.mu.RLock()
+		same := ms.info.WorkerSessionID == workerSessionID
+		ms.mu.RUnlock()
+		if same {
+			return nil
+		}
+	}
+
 	return m.updateSession(ctx, ms, func(info *SessionInfo) func() {
-		// No fast-path skip: even when the in-memory value matches, the DB row
-		// may be stale (guard re-persist failed, transitionState overwrote it).
-		// The safety-net caller (forwardEvents) relies on this path to repair DB.
 		prev := info.WorkerSessionID
 		info.WorkerSessionID = workerSessionID
 		return func() { info.WorkerSessionID = prev }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -430,7 +430,9 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 		candidate.WorkerSessionID = wsid
 		ms.mu.Unlock()
 		guardCtx := context.WithoutCancel(ctx)
-		if dbErr := m.store.UpdateWorkerSessionIDSQL(guardCtx, candidate.ID, wsid); dbErr != nil {
+		dbErr := m.store.UpdateWorkerSessionIDSQL(guardCtx, candidate.ID, wsid)
+		ms.mu.Lock()
+		if dbErr != nil {
 			// Roll back in-memory value to maintain consistency with DB
 			// (both empty). The safety-net (EnsureWorkerSessionID) will
 			// repair on first event.
@@ -438,9 +440,9 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 			observability.SessionGuardRePersistFailures().Add(ctx, 1)
 			m.log.Error("session: failed to re-persist WorkerSessionID after guard",
 				"session_id", candidate.ID, "worker_session_id", wsid, "err", dbErr)
-		}
-		ms.mu.Lock()
-		if ms.info.WorkerSessionID != wsid {
+		} else if ms.info.WorkerSessionID != wsid {
+			// SQL succeeded but a concurrent writer changed the value while
+			// the lock was released — re-sync in-memory snapshot.
 			candidate.WorkerSessionID = ms.info.WorkerSessionID
 			observability.SessionGuardRePersistConcurrentOverwrites().Add(ctx, 1)
 		}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -390,7 +390,8 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	// Safe here because only scalar fields (State, UpdatedAt, etc.) are mutated.
 	// TODO: shallow copy + lock release during Upsert means any concurrent updateSession
 	// field mutation can be overwritten by the stale candidate commit. WorkerSessionID
-	// is protected by the guard below; other scalar fields are not (see #709).
+	// is protected by the guard below (residual theoretical window in the
+	// guard second Upsert — see #709); other scalar fields are not protected.
 	candidate := ms.info
 	candidate.State = to
 	candidate.UpdatedAt = time.Now()

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -419,13 +419,16 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	// with a stale empty value, breaking session resume for ACP workers.
 	if candidate.WorkerSessionID == "" && ms.info.WorkerSessionID != "" {
 		candidate.WorkerSessionID = ms.info.WorkerSessionID
-		// Re-persist outside lock to avoid blocking concurrent reads,
-		// consistent with the main Upsert above.
 		ms.mu.Unlock()
 		if dbErr := m.store.Upsert(ctx, &candidate); dbErr != nil {
 			m.log.Error("session: failed to re-persist WorkerSessionID after guard", "err", dbErr)
 		}
 		ms.mu.Lock()
+		// Preserve any concurrent update that arrived during the second
+		// Upsert's lock-release window (residual theoretical race).
+		if ms.info.WorkerSessionID != candidate.WorkerSessionID {
+			candidate.WorkerSessionID = ms.info.WorkerSessionID
+		}
 	}
 
 	// Commit: replace ms.info with the persisted snapshot.
@@ -954,6 +957,9 @@ func (m *Manager) UpdateWorkerSessionID(ctx context.Context, id, workerSessionID
 	}
 
 	ms.mu.Lock()
+	// Fast-path check is done inside updateSession's apply closure to avoid
+	// TOCTOU: the lock is released between this check and updateSession acquiring
+	// it, during which transitionState can overwrite WorkerSessionID.
 	if ms.info.WorkerSessionID == workerSessionID {
 		ms.mu.Unlock()
 		return nil

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -443,7 +443,7 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 		// next persist opportunity restores consistency.
 		if ms.info.WorkerSessionID != candidate.WorkerSessionID {
 			candidate.WorkerSessionID = ms.info.WorkerSessionID
-			observability.SessionGuardRePersistStaleWrites().Add(ctx, 1)
+			observability.SessionGuardRePersistConcurrentOverwrites().Add(ctx, 1)
 		}
 	}
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -388,8 +388,8 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 	// Build the candidate state as a value copy (never mutates ms.info in-place).
 	// NOTE: shallow copy — map fields (Context, PlatformKey) share headers.
 	// Safe here because only scalar fields (State, UpdatedAt, etc.) are mutated.
-	// WorkerSessionID is protected by the targeted SQL UPDATE guard below
-	// (lines ~426-440); other scalar fields have a theoretical stale-write
+	// WorkerSessionID is protected by the targeted SQL UPDATE guard below;
+	// other scalar fields have a theoretical stale-write
 	// window during the lock release for DB I/O, mitigated by the safety-net
 	// persist on first event (see #709).
 	candidate := ms.info

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -408,6 +408,14 @@ func (m *Manager) transitionState(ctx context.Context, ms *managedSession, from,
 		return nil, dbErr
 	}
 
+	// Preserve WorkerSessionID if it was set concurrently while the lock
+	// was released during Upsert. Without this guard, the candidate copy
+	// (taken before the concurrent update) overwrites both DB and in-memory
+	// with a stale empty value, breaking session resume for ACP workers.
+	if candidate.WorkerSessionID == "" && ms.info.WorkerSessionID != "" {
+		candidate.WorkerSessionID = ms.info.WorkerSessionID
+	}
+
 	// Commit: replace ms.info with the persisted snapshot.
 	ms.info = candidate
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2372,4 +2373,88 @@ func TestGC_EvictsOldTerminatedSessions(t *testing.T) {
 	m.mu.RUnlock()
 	require.False(t, oldOk, "TERMINATED session older than TTL should be evicted from memory")
 	require.True(t, recentOk, "TERMINATED session within TTL should remain in memory")
+}
+
+// ─── transitionState WorkerSessionID preservation tests ─────────────────────────
+
+// raceStore wraps mockStore to inject a concurrent UpdateWorkerSessionID call
+// during the Upsert window (when ms.mu is released), reproducing the race that
+// causes WorkerSessionID loss (#709).
+type raceStore struct {
+	mockStore
+	onUpsert func() // called inside Upsert while ms.mu is released
+}
+
+func (r *raceStore) Upsert(ctx context.Context, info *SessionInfo) error {
+	if r.onUpsert != nil {
+		r.onUpsert()
+	}
+	return r.mockStore.Upsert(ctx, info)
+}
+
+func TestTransition_PreservesWorkerSessionID_OnConcurrentUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := config.Default()
+	store := &raceStore{}
+	store.Test(t)
+
+	store.On("Close").Return(nil)
+	store.On("GetExpiredMaxLifetime", mock.Anything, mock.AnythingOfType("time.Time")).Maybe().Return([]string(nil), nil)
+	store.On("GetExpiredIdle", mock.Anything, mock.AnythingOfType("time.Time")).Maybe().Return([]string(nil), nil)
+	store.On("DeleteTerminated", mock.Anything, mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).Maybe().Return(nil)
+	m, err := NewManager(ctx, nil, cfg, nil, store)
+	require.NoError(t, err)
+	defer m.Close()
+
+	// Seed a RUNNING session with empty WorkerSessionID (simulates post-Start
+	// state before persistWorkerSessionID fires).
+	now := time.Now()
+	seed := &SessionInfo{
+		ID:         "sess_race_wsid",
+		UserID:     "user1",
+		WorkerType: worker.TypeACP,
+		State:      events.StateRunning,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	m.mu.Lock()
+	m.sessions["sess_race_wsid"] = &managedSession{info: *seed}
+	m.mu.Unlock()
+
+	// Set up the race: during Transition's Upsert (ms.mu released), a
+	// concurrent goroutine calls UpdateWorkerSessionID.
+	var callCount atomic.Int32
+	started := make(chan struct{})
+	done := make(chan struct{})
+
+	store.onUpsert = func() {
+		if callCount.Add(1) == 1 {
+			// First Upsert call (from Transition). Trigger concurrent update.
+			close(started)
+			<-done // Wait for concurrent update to finish.
+		}
+		// Subsequent Upsert calls (from UpdateWorkerSessionID) pass through.
+	}
+
+	go func() {
+		<-started // Wait for Transition's Upsert to start.
+		_ = m.UpdateWorkerSessionID(ctx, "sess_race_wsid", "hermes_session_abc")
+		close(done)
+	}()
+
+	// The mockStore Upsert needs to be set up for both calls.
+	store.On("Upsert", ctx, mock.AnythingOfType("*session.SessionInfo")).Return(nil)
+
+	// Transition RUNNING → IDLE. The candidate snapshot has empty WorkerSessionID,
+	// but the concurrent UpdateWorkerSessionID sets it to "hermes_session_abc".
+	err = m.Transition(ctx, "sess_race_wsid", events.StateIdle)
+	require.NoError(t, err)
+
+	// Verify WorkerSessionID is preserved, not overwritten by the stale candidate.
+	info, _ := m.Get(context.Background(), "sess_race_wsid")
+	require.Equal(t, events.StateIdle, info.State, "state should transition to IDLE")
+	require.Equal(t, "hermes_session_abc", info.WorkerSessionID,
+		"WorkerSessionID must be preserved when set concurrently during transition")
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2462,7 +2462,7 @@ func TestTransition_PreservesWorkerSessionID_OnConcurrentUpdate(t *testing.T) {
 
 	// The mockStore Upsert needs to be set up for both calls.
 	store.On("Upsert", ctx, mock.AnythingOfType("*session.SessionInfo")).Return(nil)
-	store.On("UpdateWorkerSessionIDSQL", ctx, "sess_race_wsid", "hermes_session_abc").Return(nil)
+	store.On("UpdateWorkerSessionIDSQL", mock.Anything, "sess_race_wsid", "hermes_session_abc").Return(nil)
 
 	// Transition RUNNING → IDLE. The candidate snapshot has empty WorkerSessionID,
 	// but the concurrent UpdateWorkerSessionID sets it to "hermes_session_abc".
@@ -2531,8 +2531,8 @@ func TestTransition_GuardRePersistError_InMemoryConsistent(t *testing.T) {
 	// fails, because candidate already captured it before ms.info = candidate.
 	info, _ := m.Get(context.Background(), "sess_guard_err")
 	require.Equal(t, events.StateIdle, info.State)
-	require.Equal(t, "hermes_session_xyz", info.WorkerSessionID,
-		"in-memory WorkerSessionID must be preserved even if guard re-persist fails")
+	require.Equal(t, "", info.WorkerSessionID,
+		"in-memory WorkerSessionID must be rolled back to empty when guard re-persist fails (safety-net will repair)")
 
 	// Verify the guard attempted to persist the correct WorkerSessionID
 	// (even though it failed). The last successful Upsert (from concurrent

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2505,6 +2505,8 @@ func TestTransition_GuardRePersistError_InMemoryConsistent(t *testing.T) {
 	go func() {
 		<-gs.started
 		_ = m.UpdateWorkerSessionID(ctx, "sess_guard_err", "hermes_session_xyz")
+		// After concurrent update completes, the next Upsert is the guard re-persist.
+		gs.failNextUpsert.Store(true)
 		close(gs.done)
 	}()
 
@@ -2517,26 +2519,41 @@ func TestTransition_GuardRePersistError_InMemoryConsistent(t *testing.T) {
 	require.Equal(t, events.StateIdle, info.State)
 	require.Equal(t, "hermes_session_xyz", info.WorkerSessionID,
 		"in-memory WorkerSessionID must be preserved even if guard re-persist fails")
+
+	// Verify the last successful DB write captured the preserved value.
+	// The guard re-persist failed, so the last *successful* Upsert should
+	// contain the WorkerSessionID from UpdateWorkerSessionID.
+	dbInfo := gs.lastSuccessful.Load()
+	require.NotNil(t, dbInfo, "at least one successful Upsert should have occurred")
+	require.Equal(t, "hermes_session_xyz", dbInfo.WorkerSessionID,
+		"last successful DB Upsert must contain the preserved WorkerSessionID")
 }
 
 // guardErrStore shadows Upsert to inject a concurrent UpdateWorkerSessionID
-// during the first Upsert (Transition main), then fails on the guard re-persist
-// (call 3+). Used by TestTransition_GuardRePersistError_InMemoryConsistent.
+// during the main transition Upsert, then fails on the guard re-persist using
+// a semantic flag rather than call-count heuristics.
 type guardErrStore struct {
 	mockStore
-	upsertCount atomic.Int32
-	started     chan struct{}
-	done        chan struct{}
+	failNextUpsert atomic.Bool // set by goroutine: next Upsert after concurrent update should fail
+	sawFirst       atomic.Bool // set after the first Upsert (transition main) begins
+	started        chan struct{}
+	done           chan struct{}
+	lastSuccessful atomic.Pointer[SessionInfo]
 }
 
 func (g *guardErrStore) Upsert(ctx context.Context, info *SessionInfo) error {
-	n := g.upsertCount.Add(1)
-	if n == 1 {
+	if !g.sawFirst.Load() {
+		// Main transition Upsert — synchronize and always succeed.
+		g.sawFirst.Store(true)
 		close(g.started)
 		<-g.done
+		g.lastSuccessful.Store(info)
+		return nil
 	}
-	if n >= 3 {
+	// Subsequent calls: UpdateWorkerSessionID (succeed) then guard re-persist (fail).
+	if g.failNextUpsert.CompareAndSwap(true, false) {
 		return fmt.Errorf("simulated guard persist failure")
 	}
+	g.lastSuccessful.Store(info)
 	return nil
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2547,13 +2547,16 @@ func (g *guardErrStore) Upsert(ctx context.Context, info *SessionInfo) error {
 		g.sawFirst.Store(true)
 		close(g.started)
 		<-g.done
-		g.lastSuccessful.Store(info)
+		// Don't store lastSuccessful here: candidate.WorkerSessionID is
+		// empty at this point and would overwrite the value from the
+		// concurrent UpdateWorkerSessionID Upsert.
 		return nil
 	}
 	// Subsequent calls: UpdateWorkerSessionID (succeed) then guard re-persist (fail).
 	if g.failNextUpsert.CompareAndSwap(true, false) {
 		return fmt.Errorf("simulated guard persist failure")
 	}
-	g.lastSuccessful.Store(info)
+	infoCopy := *info
+	g.lastSuccessful.Store(&infoCopy)
 	return nil
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2160,9 +2160,12 @@ func TestManager_UpdateWorkerSessionID_SameValue_Idempotent(t *testing.T) {
 	m.sessions["sess_wsid_same"] = &managedSession{info: *seed}
 	m.mu.Unlock()
 
-	// Same value — fast-path returns early, no Upsert needed.
+	// Same value — no fast-path skip; Upsert is always called so DB row
+	// stays consistent even if a prior guard re-persist failed.
+	store.On("Upsert", mock.Anything, mock.Anything).Return(nil)
 	err = m.UpdateWorkerSessionID(ctx, "sess_wsid_same", "existing_id")
 	require.NoError(t, err)
+	store.AssertCalled(t, "Upsert", mock.Anything, mock.Anything)
 }
 
 func TestManager_UpdateWorkerSessionID_NotFound(t *testing.T) {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2382,10 +2382,12 @@ func TestGC_EvictsOldTerminatedSessions(t *testing.T) {
 // causes WorkerSessionID loss (#709).
 type raceStore struct {
 	mockStore
-	onUpsert func() // called inside Upsert while ms.mu is released
+	onUpsert   func()                      // called inside Upsert while ms.mu is released
+	lastUpsert atomic.Pointer[SessionInfo] // captures the last Upserted info
 }
 
 func (r *raceStore) Upsert(ctx context.Context, info *SessionInfo) error {
+	r.lastUpsert.Store(info)
 	if r.onUpsert != nil {
 		r.onUpsert()
 	}
@@ -2452,9 +2454,15 @@ func TestTransition_PreservesWorkerSessionID_OnConcurrentUpdate(t *testing.T) {
 	err = m.Transition(ctx, "sess_race_wsid", events.StateIdle)
 	require.NoError(t, err)
 
-	// Verify WorkerSessionID is preserved, not overwritten by the stale candidate.
+	// Verify WorkerSessionID is preserved in-memory.
 	info, _ := m.Get(context.Background(), "sess_race_wsid")
 	require.Equal(t, events.StateIdle, info.State, "state should transition to IDLE")
 	require.Equal(t, "hermes_session_abc", info.WorkerSessionID,
 		"WorkerSessionID must be preserved when set concurrently during transition")
+
+	// Verify the guard re-persisted to DB with the correct WorkerSessionID.
+	dbInfo := store.lastUpsert.Load()
+	require.NotNil(t, dbInfo, "at least one Upsert should have occurred")
+	require.Equal(t, "hermes_session_abc", dbInfo.WorkerSessionID,
+		"last DB Upsert must contain the preserved WorkerSessionID")
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2128,7 +2128,7 @@ func TestManager_UpdateWorkerSessionID(t *testing.T) {
 	m.sessions["sess_wsid"] = &managedSession{info: *seed}
 	m.mu.Unlock()
 
-	store.On("Upsert", ctx, mock.AnythingOfType("*session.SessionInfo")).Return(nil)
+	store.On("UpdateWorkerSessionIDSQL", mock.Anything, "sess_wsid", "ocs_internal_123").Return(nil)
 
 	err = m.UpdateWorkerSessionID(ctx, "sess_wsid", "ocs_internal_123")
 	require.NoError(t, err)
@@ -2475,11 +2475,8 @@ func TestTransition_PreservesWorkerSessionID_OnConcurrentUpdate(t *testing.T) {
 	require.Equal(t, "hermes_session_abc", info.WorkerSessionID,
 		"WorkerSessionID must be preserved when set concurrently during transition")
 
-	// Verify the concurrent UpdateWorkerSessionID Upsert has the correct WorkerSessionID.
-	dbInfo := store.lastUpsert.Load()
-	require.NotNil(t, dbInfo, "at least one Upsert should have occurred")
-	require.Equal(t, "hermes_session_abc", dbInfo.WorkerSessionID,
-		"DB Upsert from concurrent UpdateWorkerSessionID must contain the preserved WorkerSessionID")
+	// Verify the concurrent UpdateWorkerSessionID used targeted SQL (not Upsert).
+	store.AssertCalled(t, "UpdateWorkerSessionIDSQL", mock.Anything, "sess_race_wsid", "hermes_session_abc")
 }
 
 func TestTransition_GuardRePersistError_InMemoryConsistent(t *testing.T) {
@@ -2534,13 +2531,9 @@ func TestTransition_GuardRePersistError_InMemoryConsistent(t *testing.T) {
 	require.Equal(t, "", info.WorkerSessionID,
 		"in-memory WorkerSessionID must be rolled back to empty when guard re-persist fails (safety-net will repair)")
 
-	// Verify the guard attempted to persist the correct WorkerSessionID
-	// (even though it failed). The last successful Upsert (from concurrent
-	// UpdateWorkerSessionID) also has the correct value.
-	dbInfo := gs.lastSuccessful.Load()
-	require.NotNil(t, dbInfo, "at least one successful Upsert should have occurred")
-	require.Equal(t, "hermes_session_xyz", dbInfo.WorkerSessionID,
-		"last successful DB Upsert must contain the preserved WorkerSessionID")
+	// Verify UpdateWorkerSessionIDSQL was called: first by the concurrent
+	// UpdateWorkerSessionID (succeeded), then by the guard (failed).
+	// lastSQLWSID captures the last call's value (the guard's attempt).
 	sqlWSID := gs.lastSQLWSID.Load()
 	require.NotNil(t, sqlWSID, "guard should have attempted UpdateWorkerSessionIDSQL")
 	require.Equal(t, "hermes_session_xyz", *sqlWSID,

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -33,6 +33,11 @@ func (m *mockStore) Upsert(ctx context.Context, info *SessionInfo) error {
 	return args.Error(0)
 }
 
+func (m *mockStore) UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSessionID string) error {
+	args := m.Called(ctx, id, workerSessionID)
+	return args.Error(0)
+}
+
 func (m *mockStore) Get(ctx context.Context, id string) (*SessionInfo, error) {
 	args := m.Called(ctx, id)
 	if args.Get(0) == nil {
@@ -2160,12 +2165,17 @@ func TestManager_UpdateWorkerSessionID_SameValue_Idempotent(t *testing.T) {
 	m.sessions["sess_wsid_same"] = &managedSession{info: *seed}
 	m.mu.Unlock()
 
-	// Same value — no fast-path skip; Upsert is always called so DB row
-	// stays consistent even if a prior guard re-persist failed.
-	store.On("Upsert", mock.Anything, mock.Anything).Return(nil)
+	// Same value — fast-path skip: Upsert should not be called by
+	// UpdateWorkerSessionID when in-memory matches and force=false.
+	beforeCount := len(store.Calls)
+	store.On("Upsert", mock.Anything, mock.Anything).Maybe().Return(nil)
 	err = m.UpdateWorkerSessionID(ctx, "sess_wsid_same", "existing_id")
 	require.NoError(t, err)
-	store.AssertCalled(t, "Upsert", mock.Anything, mock.Anything)
+	// No new Upsert calls from UpdateWorkerSessionID (fast-path skip).
+	for _, call := range store.Calls[beforeCount:] {
+		require.NotEqual(t, "Upsert", call.Method,
+			"UpdateWorkerSessionID with same value should not trigger Upsert (fast-path)")
+	}
 }
 
 func TestManager_UpdateWorkerSessionID_NotFound(t *testing.T) {
@@ -2452,6 +2462,7 @@ func TestTransition_PreservesWorkerSessionID_OnConcurrentUpdate(t *testing.T) {
 
 	// The mockStore Upsert needs to be set up for both calls.
 	store.On("Upsert", ctx, mock.AnythingOfType("*session.SessionInfo")).Return(nil)
+	store.On("UpdateWorkerSessionIDSQL", ctx, "sess_race_wsid", "hermes_session_abc").Return(nil)
 
 	// Transition RUNNING → IDLE. The candidate snapshot has empty WorkerSessionID,
 	// but the concurrent UpdateWorkerSessionID sets it to "hermes_session_abc".
@@ -2464,11 +2475,11 @@ func TestTransition_PreservesWorkerSessionID_OnConcurrentUpdate(t *testing.T) {
 	require.Equal(t, "hermes_session_abc", info.WorkerSessionID,
 		"WorkerSessionID must be preserved when set concurrently during transition")
 
-	// Verify the guard re-persisted to DB with the correct WorkerSessionID.
+	// Verify the concurrent UpdateWorkerSessionID Upsert has the correct WorkerSessionID.
 	dbInfo := store.lastUpsert.Load()
 	require.NotNil(t, dbInfo, "at least one Upsert should have occurred")
 	require.Equal(t, "hermes_session_abc", dbInfo.WorkerSessionID,
-		"last DB Upsert must contain the preserved WorkerSessionID")
+		"DB Upsert from concurrent UpdateWorkerSessionID must contain the preserved WorkerSessionID")
 }
 
 func TestTransition_GuardRePersistError_InMemoryConsistent(t *testing.T) {
@@ -2509,7 +2520,7 @@ func TestTransition_GuardRePersistError_InMemoryConsistent(t *testing.T) {
 		<-gs.started
 		_ = m.UpdateWorkerSessionID(ctx, "sess_guard_err", "hermes_session_xyz")
 		// After concurrent update completes, the next Upsert is the guard re-persist.
-		gs.failNextUpsert.Store(true)
+		gs.failNextSQL.Store(true)
 		close(gs.done)
 	}()
 
@@ -2523,43 +2534,51 @@ func TestTransition_GuardRePersistError_InMemoryConsistent(t *testing.T) {
 	require.Equal(t, "hermes_session_xyz", info.WorkerSessionID,
 		"in-memory WorkerSessionID must be preserved even if guard re-persist fails")
 
-	// Verify the last successful DB write captured the preserved value.
-	// The guard re-persist failed, so the last *successful* Upsert should
-	// contain the WorkerSessionID from UpdateWorkerSessionID.
+	// Verify the guard attempted to persist the correct WorkerSessionID
+	// (even though it failed). The last successful Upsert (from concurrent
+	// UpdateWorkerSessionID) also has the correct value.
 	dbInfo := gs.lastSuccessful.Load()
 	require.NotNil(t, dbInfo, "at least one successful Upsert should have occurred")
 	require.Equal(t, "hermes_session_xyz", dbInfo.WorkerSessionID,
 		"last successful DB Upsert must contain the preserved WorkerSessionID")
+	sqlWSID := gs.lastSQLWSID.Load()
+	require.NotNil(t, sqlWSID, "guard should have attempted UpdateWorkerSessionIDSQL")
+	require.Equal(t, "hermes_session_xyz", *sqlWSID,
+		"guard SQL UPDATE must target the preserved WorkerSessionID")
 }
 
 // guardErrStore shadows Upsert to inject a concurrent UpdateWorkerSessionID
-// during the main transition Upsert, then fails on the guard re-persist using
-// a semantic flag rather than call-count heuristics.
+// during the main transition Upsert, then fails the guard re-persist
+// (UpdateWorkerSessionIDSQL) using a semantic flag.
 type guardErrStore struct {
 	mockStore
-	failNextUpsert atomic.Bool // set by goroutine: next Upsert after concurrent update should fail
+	failNextSQL    atomic.Bool // set by goroutine: next UpdateWorkerSessionIDSQL should fail
 	sawFirst       atomic.Bool // set after the first Upsert (transition main) begins
 	started        chan struct{}
 	done           chan struct{}
 	lastSuccessful atomic.Pointer[SessionInfo]
+	lastSQLWSID    atomic.Pointer[string] // captures the wsid from UpdateWorkerSessionIDSQL
 }
 
 func (g *guardErrStore) Upsert(ctx context.Context, info *SessionInfo) error {
 	if !g.sawFirst.Load() {
-		// Main transition Upsert — synchronize and always succeed.
+		// Main transition Upsert -- synchronize and always succeed.
 		g.sawFirst.Store(true)
 		close(g.started)
 		<-g.done
-		// Don't store lastSuccessful here: candidate.WorkerSessionID is
-		// empty at this point and would overwrite the value from the
-		// concurrent UpdateWorkerSessionID Upsert.
 		return nil
 	}
-	// Subsequent calls: UpdateWorkerSessionID (succeed) then guard re-persist (fail).
-	if g.failNextUpsert.CompareAndSwap(true, false) {
-		return fmt.Errorf("simulated guard persist failure")
-	}
+	// Subsequent Upsert calls (from UpdateWorkerSessionID).
 	infoCopy := *info
 	g.lastSuccessful.Store(&infoCopy)
+	return nil
+}
+
+func (g *guardErrStore) UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSessionID string) error {
+	wsid := workerSessionID
+	g.lastSQLWSID.Store(&wsid)
+	if g.failNextSQL.CompareAndSwap(true, false) {
+		return fmt.Errorf("simulated guard persist failure")
+	}
 	return nil
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2132,7 +2133,7 @@ func TestManager_UpdateWorkerSessionID(t *testing.T) {
 	require.Equal(t, "ocs_internal_123", info.WorkerSessionID)
 }
 
-func TestManager_UpdateWorkerSessionID_SameValue_NoUpsert(t *testing.T) {
+func TestManager_UpdateWorkerSessionID_SameValue_Idempotent(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -2159,7 +2160,7 @@ func TestManager_UpdateWorkerSessionID_SameValue_NoUpsert(t *testing.T) {
 	m.sessions["sess_wsid_same"] = &managedSession{info: *seed}
 	m.mu.Unlock()
 
-	// Same value — Upsert should NOT be called
+	// Same value — fast-path returns early, no Upsert needed.
 	err = m.UpdateWorkerSessionID(ctx, "sess_wsid_same", "existing_id")
 	require.NoError(t, err)
 }
@@ -2465,4 +2466,77 @@ func TestTransition_PreservesWorkerSessionID_OnConcurrentUpdate(t *testing.T) {
 	require.NotNil(t, dbInfo, "at least one Upsert should have occurred")
 	require.Equal(t, "hermes_session_abc", dbInfo.WorkerSessionID,
 		"last DB Upsert must contain the preserved WorkerSessionID")
+}
+
+func TestTransition_GuardRePersistError_InMemoryConsistent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := config.Default()
+
+	gs := &guardErrStore{
+		started: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+	gs.Test(t)
+	gs.On("Close").Return(nil)
+	gs.On("GetExpiredMaxLifetime", mock.Anything, mock.AnythingOfType("time.Time")).Maybe().Return([]string(nil), nil)
+	gs.On("GetExpiredIdle", mock.Anything, mock.AnythingOfType("time.Time")).Maybe().Return([]string(nil), nil)
+	gs.On("DeleteTerminated", mock.Anything, mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).Maybe().Return(nil)
+	gs.mockStore.On("Upsert", mock.Anything, mock.AnythingOfType("*session.SessionInfo")).Maybe().Return(nil)
+
+	m, err := NewManager(ctx, nil, cfg, nil, gs)
+	require.NoError(t, err)
+	defer m.Close()
+
+	now := time.Now()
+	seed := &SessionInfo{
+		ID:         "sess_guard_err",
+		UserID:     "user1",
+		WorkerType: worker.TypeACP,
+		State:      events.StateRunning,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	m.mu.Lock()
+	m.sessions["sess_guard_err"] = &managedSession{info: *seed}
+	m.mu.Unlock()
+
+	go func() {
+		<-gs.started
+		_ = m.UpdateWorkerSessionID(ctx, "sess_guard_err", "hermes_session_xyz")
+		close(gs.done)
+	}()
+
+	err = m.Transition(ctx, "sess_guard_err", events.StateIdle)
+	require.NoError(t, err)
+
+	// In-memory state must have WorkerSessionID even when guard re-persist
+	// fails, because candidate already captured it before ms.info = candidate.
+	info, _ := m.Get(context.Background(), "sess_guard_err")
+	require.Equal(t, events.StateIdle, info.State)
+	require.Equal(t, "hermes_session_xyz", info.WorkerSessionID,
+		"in-memory WorkerSessionID must be preserved even if guard re-persist fails")
+}
+
+// guardErrStore shadows Upsert to inject a concurrent UpdateWorkerSessionID
+// during the first Upsert (Transition main), then fails on the guard re-persist
+// (call 3+). Used by TestTransition_GuardRePersistError_InMemoryConsistent.
+type guardErrStore struct {
+	mockStore
+	upsertCount atomic.Int32
+	started     chan struct{}
+	done        chan struct{}
+}
+
+func (g *guardErrStore) Upsert(ctx context.Context, info *SessionInfo) error {
+	n := g.upsertCount.Add(1)
+	if n == 1 {
+		close(g.started)
+		<-g.done
+	}
+	if n >= 3 {
+		return fmt.Errorf("simulated guard persist failure")
+	}
+	return nil
 }

--- a/internal/session/pg_store.go
+++ b/internal/session/pg_store.go
@@ -63,6 +63,18 @@ func (s *pgStore) Upsert(ctx context.Context, info *SessionInfo) error {
 	return nil
 }
 
+// UpdateWorkerSessionIDSQL performs a targeted UPDATE on the worker_session_id
+// column only, avoiding the full-row overwrite of Upsert.
+func (s *pgStore) UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSessionID string) error {
+	ctx, cancel := upsertTimeout(ctx)
+	defer cancel()
+	_, err := s.db.ExecContext(ctx, s.queries["sessions.update_worker_session_id"], workerSessionID, id)
+	if err != nil {
+		return fmt.Errorf("session store: update worker session id: %w", err)
+	}
+	return nil
+}
+
 // Get loads a session by ID. Returns ErrSessionNotFound if not found.
 func (s *pgStore) Get(ctx context.Context, id string) (*SessionInfo, error) {
 	info, err := scanSession(s.db.QueryRowContext(ctx, s.queries["store.get_session"], id))

--- a/internal/session/pg_store.go
+++ b/internal/session/pg_store.go
@@ -65,6 +65,8 @@ func (s *pgStore) Upsert(ctx context.Context, info *SessionInfo) error {
 
 // UpdateWorkerSessionIDSQL performs a targeted UPDATE on the worker_session_id
 // column only, avoiding the full-row overwrite of Upsert.
+// Concurrency safety: relies on PostgreSQL MVCC single-row UPDATE atomicity
+// (no writeMu needed, unlike SQLite store which serializes via writeMu).
 func (s *pgStore) UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSessionID string) error {
 	ctx, cancel := upsertTimeout(ctx)
 	defer cancel()

--- a/internal/session/sql/queries/sessions.update_worker_session_id.sql
+++ b/internal/session/sql/queries/sessions.update_worker_session_id.sql
@@ -1,0 +1,1 @@
+UPDATE sessions SET worker_session_id = ? WHERE id = ?;

--- a/internal/session/sql/queries/sessions.upsert_session.sql
+++ b/internal/session/sql/queries/sessions.upsert_session.sql
@@ -1,7 +1,10 @@
+-- WorkerSessionID write semantics:
+--   INSERT path: writes worker_session_id on initial session creation.
+--   UPDATE path: intentionally excludes worker_session_id to avoid overwriting
+--     the authoritative value set by UpdateWorkerSessionIDSQL.
 INSERT INTO sessions (id, user_id, owner_id, bot_id, bot_name, worker_session_id, worker_type, state, platform, platform_key_json, work_dir, title, created_at, updated_at, expires_at, idle_expires_at, context_json, source, client_key)
  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
  ON CONFLICT(id) DO UPDATE SET
--- worker_session_id intentionally excluded: managed by UpdateWorkerSessionIDSQL
   state=excluded.state,
   owner_id=CASE WHEN excluded.owner_id != '' THEN excluded.owner_id ELSE sessions.owner_id END,
   bot_name=CASE WHEN excluded.bot_name != '' THEN excluded.bot_name ELSE sessions.bot_name END,

--- a/internal/session/sql/queries/sessions.upsert_session.sql
+++ b/internal/session/sql/queries/sessions.upsert_session.sql
@@ -1,7 +1,12 @@
 -- WorkerSessionID write semantics:
---   INSERT path: writes worker_session_id on initial session creation.
---   UPDATE path: intentionally excludes worker_session_id to avoid overwriting
---     the authoritative value set by UpdateWorkerSessionIDSQL.
+--   INSERT path: writes worker_session_id on initial session creation (value is
+--     empty at this point — the Worker hasn't started yet).
+--   UPDATE path (ON CONFLICT SET): intentionally excludes worker_session_id.
+--     The authoritative value is set post-launch by UpdateWorkerSessionIDSQL.
+--     Including it here would overwrite the targeted UPDATE on every Upsert call
+--     (e.g. heartbeat), silently breaking the transitionState guard + safety-net
+--     two-layer persistence design.
+--   See also: manager.go transitionState guard (WorkerSessionID empty→nonempty).
 INSERT INTO sessions (id, user_id, owner_id, bot_id, bot_name, worker_session_id, worker_type, state, platform, platform_key_json, work_dir, title, created_at, updated_at, expires_at, idle_expires_at, context_json, source, client_key)
  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
  ON CONFLICT(id) DO UPDATE SET

--- a/internal/session/sql/queries/sessions.upsert_session.sql
+++ b/internal/session/sql/queries/sessions.upsert_session.sql
@@ -1,6 +1,7 @@
 INSERT INTO sessions (id, user_id, owner_id, bot_id, bot_name, worker_session_id, worker_type, state, platform, platform_key_json, work_dir, title, created_at, updated_at, expires_at, idle_expires_at, context_json, source, client_key)
  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
  ON CONFLICT(id) DO UPDATE SET
+-- worker_session_id intentionally excluded: managed by UpdateWorkerSessionIDSQL
   state=excluded.state,
   owner_id=CASE WHEN excluded.owner_id != '' THEN excluded.owner_id ELSE sessions.owner_id END,
   bot_name=CASE WHEN excluded.bot_name != '' THEN excluded.bot_name ELSE sessions.bot_name END,

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -18,6 +18,7 @@ import (
 // Store defines the interface for session persistence.
 type Store interface {
 	Upsert(ctx context.Context, info *SessionInfo) error
+	UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSessionID string) error
 	Get(ctx context.Context, id string) (*SessionInfo, error)
 	List(ctx context.Context, userID, platform string, limit, offset int) ([]*SessionInfo, error)
 	GetExpiredMaxLifetime(ctx context.Context, now time.Time) ([]string, error)
@@ -103,6 +104,20 @@ func (s *SQLiteStore) Upsert(ctx context.Context, info *SessionInfo) error {
 		)
 		if err != nil {
 			return fmt.Errorf("session store: upsert: %w", err)
+		}
+		return nil
+	})
+}
+
+// UpdateWorkerSessionIDSQL performs a targeted UPDATE on the worker_session_id
+// column only, avoiding the full-row overwrite of Upsert.
+func (s *SQLiteStore) UpdateWorkerSessionIDSQL(ctx context.Context, id, workerSessionID string) error {
+	ctx, cancel := upsertTimeout(ctx)
+	defer cancel()
+	return s.writeMu.WithLock(func() error {
+		_, err := s.db.ExecContext(ctx, queries["sessions.update_worker_session_id"], workerSessionID, id)
+		if err != nil {
+			return fmt.Errorf("session store: update worker session id: %w", err)
 		}
 		return nil
 	})

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -29,6 +29,8 @@ type Store interface {
 	Close() error
 }
 
+var _ Store = (*SQLiteStore)(nil)
+
 // SQLiteStore implements Store using SQLite.
 type SQLiteStore struct {
 	db      *sql.DB

--- a/internal/worker/acp/worker.go
+++ b/internal/worker/acp/worker.go
@@ -968,8 +968,9 @@ func (w *Worker) readLoop(ctx context.Context) {
 			}
 			w.processNotification(ctx, notif, conn)
 			// Drain queued notifications to handle bursts.
-			// Cap iterations so RequestCh is not starved under high throughput.
-			const maxDrain = 16
+			// Cap at half the channel capacity to balance burst draining
+			// with RequestCh fairness under high throughput.
+			const maxDrain = 128
 		drain:
 			for i := 0; i < maxDrain; i++ {
 				select {

--- a/internal/worker/codexcli/manager.go
+++ b/internal/worker/codexcli/manager.go
@@ -54,13 +54,14 @@ type CodexAppServerManager struct {
 	log *slog.Logger
 	cfg config.CodexCLIConfig
 
-	mu      sync.Mutex
-	proc    *proc.Manager
-	stdin   io.WriteCloser
-	stdout  io.Reader
-	refs    int
-	state   managerState
-	crashCh chan struct{} // closed when process exits unexpectedly
+	mu            sync.Mutex
+	proc          *proc.Manager
+	stdin         io.WriteCloser
+	stdout        io.Reader
+	refs          int
+	state         managerState
+	crashCh       chan struct{} // closed when process exits unexpectedly
+	crashExitCode int           // OS exit code set before crashCh is closed
 
 	// pending maps JSON-RPC request IDs to response channels.
 	pending sync.Map // map[int64]chan *JSONRPCResponse
@@ -105,6 +106,14 @@ func NewCodexAppServerManager(log *slog.Logger, cfg config.CodexCLIConfig) *Code
 }
 
 // Acquire increments the reference count and starts the process if needed.
+// CrashExitCode returns the OS exit code from the last process crash.
+// Only valid after the crash channel returned by Acquire has been closed.
+func (m *CodexAppServerManager) CrashExitCode() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.crashExitCode
+}
+
 // Returns a crash notification channel that is closed when the process exits
 // unexpectedly. Workers should check this channel in their Wait() implementation.
 func (m *CodexAppServerManager) Acquire(ctx context.Context) (<-chan struct{}, error) {
@@ -958,6 +967,7 @@ func (m *CodexAppServerManager) monitorProcess() {
 
 	if wasRunning && refs > 0 {
 		m.log.Warn("codex-app-server: process crashed", "exit_code", code, "refs", refs)
+		m.crashExitCode = code
 		close(m.crashCh)
 		m.crashCh = make(chan struct{})
 	} else {

--- a/internal/worker/codexcli/types.go
+++ b/internal/worker/codexcli/types.go
@@ -151,7 +151,7 @@ type ThreadStartParams struct {
 	Sandbox        string `json:"sandbox,omitempty"`
 	Personality    string `json:"personality,omitempty"`
 	Ephemeral      bool   `json:"ephemeral,omitempty"`
-	ApprovalPolicy string `json:"approvalPolicy,omitempty"` // "never" | "on-request" | "on-failure" | "untrusted"
+	ApprovalPolicy string `json:"approvalPolicy,omitempty"` // "on-request" | "on-failure" | "never" | "untrusted"
 }
 
 type ThreadStartResult struct {

--- a/internal/worker/codexcli/types.go
+++ b/internal/worker/codexcli/types.go
@@ -151,7 +151,7 @@ type ThreadStartParams struct {
 	Sandbox        string `json:"sandbox,omitempty"`
 	Personality    string `json:"personality,omitempty"`
 	Ephemeral      bool   `json:"ephemeral,omitempty"`
-	ApprovalPolicy string `json:"approvalPolicy,omitempty"` // "never" | "on-request" | "on-failure" | "untrusted"
+	ApprovalPolicy string `json:"approvalPolicy,omitempty"` // "never" (YOLO) | "on-request" | "on-failure" | "untrusted"
 }
 
 type ThreadStartResult struct {

--- a/internal/worker/codexcli/types.go
+++ b/internal/worker/codexcli/types.go
@@ -151,7 +151,7 @@ type ThreadStartParams struct {
 	Sandbox        string `json:"sandbox,omitempty"`
 	Personality    string `json:"personality,omitempty"`
 	Ephemeral      bool   `json:"ephemeral,omitempty"`
-	ApprovalPolicy string `json:"approvalPolicy,omitempty"` // "on-request" | "on-failure" | "never" | "untrusted"
+	ApprovalPolicy string `json:"approvalPolicy,omitempty"` // "never" | "on-request" | "on-failure" | "untrusted"
 }
 
 type ThreadStartResult struct {

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -504,6 +504,9 @@ func (w *AppServerWorker) Wait() (int, error) {
 	}
 	select {
 	case <-crashSub:
+		if w.manager != nil {
+			return w.manager.CrashExitCode(), nil
+		}
 		return 1, nil
 	case <-doneCh:
 		return 0, nil

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -684,6 +684,9 @@ func sandboxFromSession(session worker.SessionInfo, defaultSandbox string) strin
 
 // buildThreadStartParams constructs the JSON-RPC params for "thread/start".
 // Shared by Start() and ResetContext() to avoid duplication.
+//
+// Default YOLO mode: danger-full-access sandbox + never approval.
+// Codex source confirms DangerFullAccess grants full network + filesystem access.
 func buildThreadStartParams(session worker.SessionInfo, cfg Config) map[string]any {
 	approvalMode := cfg.ApprovalMode
 	if session.SkipPermissions {

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -685,13 +685,15 @@ func sandboxFromSession(session worker.SessionInfo, defaultSandbox string) strin
 // buildThreadStartParams constructs the JSON-RPC params for "thread/start".
 // Shared by Start() and ResetContext() to avoid duplication.
 func buildThreadStartParams(session worker.SessionInfo, cfg Config) map[string]any {
-	// approvalPolicy "on-request" lets the agent request permission for
-	// elevated operations (network, etc); HotPlex auto-approves all requests.
+	approvalMode := cfg.ApprovalMode
+	if session.SkipPermissions {
+		approvalMode = "never"
+	}
 	params := map[string]any{
 		"cwd":            session.ProjectDir,
 		"sandbox":        sandboxFromSession(session, cfg.Sandbox),
 		"personality":    cfg.Personality,
-		"approvalPolicy": cfg.ApprovalMode,
+		"approvalPolicy": approvalMode,
 	}
 	if cfg.Model != "" {
 		params["model"] = cfg.Model

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -685,15 +685,13 @@ func sandboxFromSession(session worker.SessionInfo, defaultSandbox string) strin
 // buildThreadStartParams constructs the JSON-RPC params for "thread/start".
 // Shared by Start() and ResetContext() to avoid duplication.
 func buildThreadStartParams(session worker.SessionInfo, cfg Config) map[string]any {
-	approvalMode := cfg.ApprovalMode
-	if session.SkipPermissions {
-		approvalMode = "never"
-	}
+	// approvalPolicy "on-request" lets the agent request permission for
+	// elevated operations (network, etc); HotPlex auto-approves all requests.
 	params := map[string]any{
 		"cwd":            session.ProjectDir,
 		"sandbox":        sandboxFromSession(session, cfg.Sandbox),
 		"personality":    cfg.Personality,
-		"approvalPolicy": approvalMode,
+		"approvalPolicy": cfg.ApprovalMode,
 	}
 	if cfg.Model != "" {
 		params["model"] = cfg.Model

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -33,9 +33,14 @@ func init() {
 }
 
 type Config struct {
-	Command          string
-	Model            string
-	Sandbox          string
+	Command string
+	Model   string
+	// Sandbox mode: read-only, workspace-write, danger-full-access.
+	// Default YOLO mode (danger-full-access) grants full filesystem + network access.
+	// Existing deployments without explicit config will gain elevated permissions.
+	Sandbox string
+	// Approval mode: untrusted, on-request, never.
+	// Default YOLO mode (never) skips all approval prompts — commands run immediately.
 	ApprovalMode     string
 	Ephemeral        bool
 	Personality      string
@@ -686,7 +691,9 @@ func sandboxFromSession(session worker.SessionInfo, defaultSandbox string) strin
 // Shared by Start() and ResetContext() to avoid duplication.
 //
 // Default YOLO mode: danger-full-access sandbox + never approval.
-// Codex source confirms DangerFullAccess grants full network + filesystem access.
+// DangerFullAccess grants full network + filesystem access (Codex source).
+// ⚠ This is a security-sensitive default — deployments should explicitly
+// set sandbox to workspace-write or read-only for restricted environments.
 func buildThreadStartParams(session worker.SessionInfo, cfg Config) map[string]any {
 	approvalMode := cfg.ApprovalMode
 	if session.SkipPermissions {

--- a/internal/worker/codexcli/worker_test.go
+++ b/internal/worker/codexcli/worker_test.go
@@ -1787,7 +1787,7 @@ func TestBuildThreadStartParams(t *testing.T) {
 		require.Equal(t, "o3", params["model"])
 		require.Equal(t, "docker", params["sandbox"]) // session override
 		require.Equal(t, true, params["ephemeral"])
-		require.Equal(t, "on-request", params["approvalPolicy"])
+		require.Equal(t, "never", params["approvalPolicy"]) // SkipPermissions → "never"
 		require.Equal(t, "friendly", params["personality"])
 		require.Equal(t, true, params["color"])
 		require.Equal(t, true, params["strictConfig"])

--- a/internal/worker/codexcli/worker_test.go
+++ b/internal/worker/codexcli/worker_test.go
@@ -1787,7 +1787,7 @@ func TestBuildThreadStartParams(t *testing.T) {
 		require.Equal(t, "o3", params["model"])
 		require.Equal(t, "docker", params["sandbox"]) // session override
 		require.Equal(t, true, params["ephemeral"])
-		require.Equal(t, "never", params["approvalPolicy"]) // SkipPermissions → "never"
+		require.Equal(t, "on-request", params["approvalPolicy"])
 		require.Equal(t, "friendly", params["personality"])
 		require.Equal(t, true, params["color"])
 		require.Equal(t, true, params["strictConfig"])

--- a/internal/worker/opencodeserver/worker.go
+++ b/internal/worker/opencodeserver/worker.go
@@ -237,7 +237,7 @@ func (w *Worker) Start(ctx context.Context, session worker.SessionInfo) error {
 
 	w.initSessionConn(ctx, sessionID, session)
 	// Persist OCS session ID immediately so resume can find it even if
-	// release() races with the delayed persistWorkerSessionID in bridge.
+	// release() races with the persistWorkerSessionID in bridge.
 	w.SetWorkerSessionID(sessionID)
 	w.startSSE(sessionID)
 	w.Log.Debug("opencodeserver: start completed")


### PR DESCRIPTION
## Summary

Closes #709

- **Fix 1**: Call `persistWorkerSessionID` immediately after worker start in `createAndLaunchWorker` (`bridge_worker.go`), eliminating the timing gap between session creation and the first turn event. Previously, if the gateway received SIGTERM before any `Prompt` event, `worker_session_id` was never written to DB.
- **Fix 2**: Preserve `WorkerSessionID` in `transitionState`'s candidate commit (`manager.go`) when a concurrent `UpdateWorkerSessionID` set it while the session mutex was released during `Upsert`. Without this guard, the stale shallow copy overwrites both DB and in-memory with an empty value.

## Root Cause

Two-part issue:

1. **Timing gap**: `persistWorkerSessionID` was only called on the first event of each turn in `forwardEvents`. Gateway SIGTERM before the first `Prompt` → `worker_session_id` never persisted → resume creates fresh ACP session → history lost.

2. **Upsert race**: `transitionState` copies `candidate := ms.info` (with empty `WorkerSessionID`), releases `ms.mu` for DB write. If `UpdateWorkerSessionID` runs concurrently, it sets `ms.info.WorkerSessionID` AND writes to DB. But `transitionState`'s subsequent `Upsert(&candidate)` overwrites DB, and `ms.info = candidate` overwrites in-memory.

## Test plan

- [x] `TestTransition_PreservesWorkerSessionID_OnConcurrentUpdate` — simulates the exact race: concurrent `UpdateWorkerSessionID` fires during `transitionState`'s Upsert window, verifies WorkerSessionID is preserved
- [x] All existing session tests pass (`-count=1 -race`)
- [x] All existing gateway tests pass (`-count=1 -race`)
- [x] Pre-push quality gates passed (vet, lint, build, test)