### PR TITLE
feat(gateway): async history compression for session startup (#714)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 - [约定与规范](#约定与规范)
 - [项目结构](#项目结构)
-- [开发指南](#开发指南)
+- [开发指南](#开发指南)（含 [PR Review 修复循环](#pr-review-修复循环)）
 - [配置参考](#配置参考)
 - [命令参考](#命令参考)
 - [附录](#附录)
@@ -215,6 +215,31 @@ configs/   - 配置文件
 **平台分离**：
 - 使用 `*_unix.go` / `*_windows.go` build tags
 - CI 必须通过 Linux + macOS + Windows 三平台测试
+
+### PR Review 修复循环
+
+Review cron 是定时触发（30min），不是 push webhook。手动触发 + 轮询是可靠路径：
+
+```
+push → 轮询已有 review → 手动触发 → 轮询新 review → 修复 → push → 循环
+终止：无新代码缺陷 + PR approved
+```
+
+**去重**：webhook（CI 成功自动触发）与手动 `trigger` 共享同一 cron job，`RunningAtMs` CAS 保证同 job 不并发。**先轮询再触发**——若 webhook 已提交 review 则跳过触发。
+
+```bash
+# 检查已有 review（push 时间之后）
+gh api repos/hrygo/hotplex/pulls/{N}/reviews \
+  --jq '[.[] | select(.submitted_at > "{push_time}")] | length'
+
+# 手动触发（仅当无新 review 时）
+hotplex cron trigger pr-review-hotplex
+
+# 获取最新 review 内容
+gh api repos/hrygo/hotplex/pulls/{N}/reviews --jq 'max_by(.id) | .body'
+```
+
+**优先级**：P0/P1 必修 → P2 有价值修 / 大型提 Issue → P3 轻量修 / 忽略
 
 ---
 

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -67,6 +67,11 @@ type Bridge struct {
 	agentConfigExclude atomic.Value  // map[string][]string: platform → inject_exclude (global default at "" key)
 
 	accum map[string]*sessionAccumulator // per-session stats accumulator
+
+	// compressCache stores async compression results keyed by sessionID.
+	// Entries are invalidated when the latest turn's CreatedAt changes
+	// (turns are append-only, so timestamp stability implies content stability).
+	compressCache sync.Map // sessionID → *compressCacheEntry
 	// accumMu protects accum. RWMutex allows concurrent reads in getOrInitAccum
 	// fast path; write lock is used for create/delete/reset operations.
 	accumMu sync.RWMutex
@@ -688,6 +693,12 @@ func defaultBrainFn() compressorBrain {
 	return b
 }
 
+// compressCacheEntry stores the result of async history compression.
+type compressCacheEntry struct {
+	turns               []worker.ConversationTurn
+	latestTurnCreatedAt int64 // unix millis of the newest turn used; mismatch = stale
+}
+
 // buildNotifyEnvelope creates a synthetic Message event for user notifications.
 func buildNotifyEnvelope(sessionID, msg string, seq int64) *events.Envelope {
 	return events.NewEnvelope(aep.NewID(), sessionID, seq, events.Message, map[string]any{"content": msg})
@@ -754,10 +765,44 @@ func (b *Bridge) prepareWorkerInfo(sessionID, userID, workDir string, si *sessio
 			b.log.Warn("bridge: query turns for history recovery failed", "session_id", sessionID, "error", err)
 		} else if len(turns) > 0 {
 			compressor := NewHistoryCompressor(b.log, b.hub)
-			// Use shutdownCtx as parent: compression should survive user disconnect
-			// but still be cancelled on gateway shutdown to avoid blocking Shutdown().
-			result := compressor.CompressHistory(b.shutdownCtx, turns, sessionID, defaultBrainFn)
-			info.ConversationHistory = result.Turns
+			latestCreatedAt := turns[len(turns)-1].CreatedAt
+
+			// Check async compression cache: if turns haven't changed, reuse result.
+			if cached, ok := b.compressCache.Load(sessionID); ok {
+				if entry, ok := cached.(*compressCacheEntry); ok {
+					if entry.latestTurnCreatedAt == latestCreatedAt {
+						info.ConversationHistory = entry.turns
+						b.log.Debug("bridge: using cached compressed history",
+							"session_id", sessionID, "turns", len(entry.turns))
+					} else {
+						// Turn set changed - stale cache, invalidate.
+						b.compressCache.Delete(sessionID)
+					}
+				} else {
+					b.compressCache.Delete(sessionID)
+				}
+			}
+
+			// Cache miss: inject truncated history immediately (sub-ms),
+			// then fire async Brain compression for next resume.
+			if info.ConversationHistory == nil {
+				result := compressor.TruncateHistory(turns)
+				info.ConversationHistory = result.Turns
+				b.log.Debug("bridge: truncated history injected, scheduling async compression",
+					"session_id", sessionID, "turns", len(result.Turns))
+
+				b.fwdWg.Add(1)
+				go func() {
+					defer b.fwdWg.Done()
+					asyncResult := compressor.CompressHistory(b.shutdownCtx, turns, sessionID, defaultBrainFn)
+					if asyncResult.Compressed {
+						b.compressCache.Store(sessionID, &compressCacheEntry{
+							turns:               asyncResult.Turns,
+							latestTurnCreatedAt: latestCreatedAt,
+						})
+					}
+				}()
+			}
 		}
 	}
 

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -510,6 +510,7 @@ func (b *Bridge) ResetSession(ctx context.Context, sessionID string) error {
 		}
 	}
 	b.accumMu.Unlock()
+	b.compressCache.Delete(sessionID)
 
 	if !result.ConnReplaced {
 		return nil
@@ -649,6 +650,11 @@ func isWorkerInUseError(err error) bool {
 func (b *Bridge) Shutdown(ctx context.Context) {
 	b.MarkClosed()
 	b.WaitForwarders(ctx)
+	// Clear compressCache after all async compression goroutines have finished.
+	b.compressCache.Range(func(key, _ any) bool {
+		b.compressCache.Delete(key)
+		return true
+	})
 }
 
 // MarkClosed sets the closed flag and cancels the shutdown context so that:
@@ -791,6 +797,11 @@ func (b *Bridge) prepareWorkerInfo(sessionID, userID, workDir string, si *sessio
 				b.log.Debug("bridge: truncated history injected, scheduling async compression",
 					"session_id", sessionID, "turns", len(result.Turns))
 
+				// Skip async compression during shutdown to avoid spawning
+				// goroutines that fwdWg.Wait() must then wait for.
+				if b.closed.Load() {
+					return info
+				}
 				b.fwdWg.Add(1)
 				go func() {
 					defer b.fwdWg.Done()

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -259,6 +259,7 @@ func (b *Bridge) cleanupCrashedWorker(sessionID string, crashedWorker worker.Wor
 	b.accumMu.Lock()
 	delete(b.accum, sessionID)
 	b.accumMu.Unlock()
+	b.compressCache.Delete(sessionID)
 
 	b.crashTrackerMu.Lock()
 	delete(b.crashTracker, sessionID)

--- a/internal/gateway/history_compress.go
+++ b/internal/gateway/history_compress.go
@@ -65,18 +65,10 @@ func (c *HistoryCompressor) CompressHistory(
 	brainFn func() compressorBrain,
 ) CompressResult {
 	// 1. Filter empty-content turns and build preliminary list.
-	filtered := make([]turnWithChars, 0, len(turns))
+	filtered := filterEmptyTurns(turns)
 	totalChars := 0
-	for _, t := range turns {
-		if t.Content == "" {
-			continue
-		}
-		filtered = append(filtered, turnWithChars{
-			role:      t.Role,
-			content:   t.Content,
-			createdAt: t.CreatedAt,
-		})
-		totalChars += len(t.Content)
+	for _, t := range filtered {
+		totalChars += len(t.content)
 	}
 
 	if len(filtered) == 0 {
@@ -177,17 +169,7 @@ func (c *HistoryCompressor) CompressHistory(
 // fit within the character budget without calling Brain. Used for immediate
 // injection while async compression runs in the background.
 func (c *HistoryCompressor) TruncateHistory(turns []*eventstore.TurnRecord) CompressResult {
-	filtered := make([]turnWithChars, 0, len(turns))
-	for _, t := range turns {
-		if t.Content == "" {
-			continue
-		}
-		filtered = append(filtered, turnWithChars{
-			role:      t.Role,
-			content:   t.Content,
-			createdAt: t.CreatedAt,
-		})
-	}
+	filtered := filterEmptyTurns(turns)
 	if len(filtered) == 0 {
 		return CompressResult{}
 	}
@@ -269,6 +251,23 @@ type turnWithChars struct {
 	role      string
 	content   string
 	createdAt int64 // unix millis from TurnRecord.CreatedAt
+}
+
+// filterEmptyTurns filters out turns with empty content, converting
+// TurnRecord pointers to turnWithChars. Shared by CompressHistory and TruncateHistory.
+func filterEmptyTurns(turns []*eventstore.TurnRecord) []turnWithChars {
+	filtered := make([]turnWithChars, 0, len(turns))
+	for _, t := range turns {
+		if t.Content == "" {
+			continue
+		}
+		filtered = append(filtered, turnWithChars{
+			role:      t.Role,
+			content:   t.Content,
+			createdAt: t.CreatedAt,
+		})
+	}
+	return filtered
 }
 
 func sumChars(turns []turnWithChars) int {

--- a/internal/gateway/history_compress.go
+++ b/internal/gateway/history_compress.go
@@ -171,6 +171,29 @@ func (c *HistoryCompressor) CompressHistory(
 	}
 }
 
+// ─── Fast Path ────────────────────────────────────────────────────────
+
+// TruncateHistory is a fast (sub-millisecond) path that truncates turns to
+// fit within the character budget without calling Brain. Used for immediate
+// injection while async compression runs in the background.
+func (c *HistoryCompressor) TruncateHistory(turns []*eventstore.TurnRecord) CompressResult {
+	filtered := make([]turnWithChars, 0, len(turns))
+	for _, t := range turns {
+		if t.Content == "" {
+			continue
+		}
+		filtered = append(filtered, turnWithChars{
+			role:      t.Role,
+			content:   t.Content,
+			createdAt: t.CreatedAt,
+		})
+	}
+	if len(filtered) == 0 {
+		return CompressResult{}
+	}
+	return c.truncateResult(filtered)
+}
+
 // ─── Brain Interaction ────────────────────────────────────────────────
 
 func (c *HistoryCompressor) callBrain(

--- a/internal/gateway/history_compress_test.go
+++ b/internal/gateway/history_compress_test.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"sync"
+
 	"github.com/hrygo/hotplex/internal/brain"
 	"github.com/hrygo/hotplex/internal/eventstore"
+	"github.com/hrygo/hotplex/internal/worker"
 )
 
 // mockBrain implements compressorBrain for testing.
@@ -208,6 +211,129 @@ func TestCompressHistory_RecentTurnsExceedBudget(t *testing.T) {
 
 	require.False(t, result.Compressed)
 	require.True(t, result.FinalChars <= maxHistoryBytes)
+}
+
+func TestTruncateHistory_BasicTruncation(t *testing.T) {
+	t.Parallel()
+
+	c := NewHistoryCompressor(slog.Default(), nil)
+
+	// 20 turns × 4000 chars = 80k > 50k budget → should truncate.
+	turns := makeLargeTurns(20, 4000)
+
+	result := c.TruncateHistory(turns)
+
+	require.False(t, result.Compressed)
+	require.True(t, result.FinalChars <= maxHistoryBytes)
+	require.NotEmpty(t, result.Turns)
+	require.True(t, result.OriginalChars > maxHistoryBytes,
+		"original should exceed budget to test truncation")
+}
+
+func TestTruncateHistory_AllTurnsFit(t *testing.T) {
+	t.Parallel()
+
+	c := NewHistoryCompressor(slog.Default(), nil)
+
+	turns := []*eventstore.TurnRecord{
+		turn("user", "hello"),
+		turn("assistant", "hi"),
+		turn("user", "how are you?"),
+	}
+
+	result := c.TruncateHistory(turns)
+
+	require.False(t, result.Compressed)
+	require.Len(t, result.Turns, 3)
+	require.Equal(t, "hello", result.Turns[0].Content)
+}
+
+func TestTruncateHistory_EmptyTurns(t *testing.T) {
+	t.Parallel()
+
+	c := NewHistoryCompressor(slog.Default(), nil)
+
+	result := c.TruncateHistory(nil)
+	require.False(t, result.Compressed)
+	require.Empty(t, result.Turns)
+
+	// All turns have empty content.
+	turns := []*eventstore.TurnRecord{turn("user", ""), turn("assistant", "")}
+	result = c.TruncateHistory(turns)
+	require.False(t, result.Compressed)
+	require.Empty(t, result.Turns)
+}
+
+func TestTruncateHistory_FiltersEmptyContent(t *testing.T) {
+	t.Parallel()
+
+	c := NewHistoryCompressor(slog.Default(), nil)
+
+	turns := []*eventstore.TurnRecord{
+		turn("user", ""),
+		turn("assistant", "response"),
+		turn("user", ""),
+		turn("assistant", "response2"),
+	}
+
+	result := c.TruncateHistory(turns)
+	require.Len(t, result.Turns, 2)
+	require.Equal(t, "response", result.Turns[0].Content)
+	require.Equal(t, "response2", result.Turns[1].Content)
+}
+
+func TestTruncateHistory_PreservesChronologicalOrder(t *testing.T) {
+	t.Parallel()
+
+	c := NewHistoryCompressor(slog.Default(), nil)
+
+	// Create turns where only recent ones fit within budget.
+	turns := []*eventstore.TurnRecord{
+		turn("user", makeLargeString(30000)),
+		turn("assistant", makeLargeString(30000)),
+		turn("user", "recent1"),
+		turn("assistant", "recent2"),
+	}
+
+	result := c.TruncateHistory(turns)
+
+	// Result should be chronologically ordered (oldest first).
+	require.False(t, result.Compressed)
+	require.True(t, len(result.Turns) >= 2)
+	// Last turns should be the recent small ones.
+	last := result.Turns[len(result.Turns)-1]
+	require.Equal(t, "recent2", last.Content)
+}
+
+func TestCompressCache_InvalidationOnTurnChange(t *testing.T) {
+	t.Parallel()
+
+	// Simulate cache behavior: same latestTurnCreatedAt = cache hit,
+	// different = cache miss (invalidate).
+	cache := &sync.Map{}
+
+	entry1 := &compressCacheEntry{
+		turns:               []worker.ConversationTurn{{Role: "assistant", Content: "summary"}},
+		latestTurnCreatedAt: 1000,
+	}
+	cache.Store("s1", entry1)
+
+	// Same timestamp → hit.
+	if cached, ok := cache.Load("s1"); ok {
+		e := cached.(*compressCacheEntry)
+		require.Equal(t, int64(1000), e.latestTurnCreatedAt)
+		require.Len(t, e.turns, 1)
+	}
+
+	// Different timestamp → miss → invalidate.
+	if cached, ok := cache.Load("s1"); ok {
+		e := cached.(*compressCacheEntry)
+		if e.latestTurnCreatedAt != 2000 {
+			cache.Delete("s1")
+		}
+	}
+	_, ok := cache.Load("s1")
+	require.False(t, ok, "cache should be invalidated after timestamp mismatch")
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Closes #714

## 变更

| 文件 | 说明 |
|------|------|
| `history_compress.go` | 新增 `TruncateHistory` 快速路径（sub-ms，无 Brain 调用） |
| `bridge.go` | 新增 `compressCache sync.Map` + `prepareWorkerInfo` 异步压缩逻辑 |
| `history_compress_test.go` | 5 个 `TruncateHistory` 测试 + 1 个缓存失效测试 |
| `AGENTS.md` | 新增 PR Review 修复循环最佳实践（含去重感知） |

## 设计

```
首次 resume: QueryTurns → cache miss → TruncateHistory (sub-ms) → 注入 → 异步 Brain 压缩 → 缓存
后续 resume: QueryTurns → cache hit (latestTurnCreatedAt 匹配) → 直接使用缓存结果
turns 变更:  latestTurnCreatedAt 不匹配 → 缓存失效 → 重新走首次流程
```

**关键决策**：
- 缓存 key: `sessionID` + `latestTurnCreatedAt`（turns 只追加，时间戳不变 = 内容不变）
- 异步 goroutine 通过 `fwdWg` 跟踪，Shutdown 时自然等待
- `shutdownCtx` cancel 后异步压缩退出，不阻塞关闭

🤖 Generated with [Claude Code](https://claude.com/claude-code)