### PR TITLE
fix(gateway): async history compression P2 fixes (#720)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,7 @@ Review cron 是定时触发（30min），不是 push webhook。手动触发 + �
 
 ```
 push → 轮询已有 review → 手动触发 → 轮询新 review → 修复 → push → 循环
-终止：无新代码缺陷 + PR approved
+终止：reviewer 无有价值的新发现（APPROVED 是必要条件，不是充分条件）
 ```
 
 **去重**：webhook（CI 成功自动触发）与手动 `trigger` 共享同一 cron job，`RunningAtMs` CAS 保证同 job 不并发。**先轮询再触发**——若 webhook 已提交 review 则跳过触发。

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -705,6 +705,26 @@ type compressCacheEntry struct {
 	latestTurnCreatedAt int64 // unix millis of the newest turn used; mismatch = stale
 }
 
+// resolveCachedHistory checks the compressCache for a valid cached result.
+// Returns (turns, true) on cache hit, (nil, false) on miss/stale/invalid.
+// Stale or invalid entries are cleaned up automatically.
+func (b *Bridge) resolveCachedHistory(sessionID string, latestCreatedAt int64) ([]worker.ConversationTurn, bool) {
+	cached, ok := b.compressCache.Load(sessionID)
+	if !ok {
+		return nil, false
+	}
+	entry, ok := cached.(*compressCacheEntry)
+	if !ok {
+		b.compressCache.Delete(sessionID)
+		return nil, false
+	}
+	if entry.latestTurnCreatedAt == latestCreatedAt {
+		return entry.turns, true
+	}
+	b.compressCache.Delete(sessionID)
+	return nil, false
+}
+
 // buildNotifyEnvelope creates a synthetic Message event for user notifications.
 func buildNotifyEnvelope(sessionID, msg string, seq int64) *events.Envelope {
 	return events.NewEnvelope(aep.NewID(), sessionID, seq, events.Message, map[string]any{"content": msg})
@@ -774,19 +794,10 @@ func (b *Bridge) prepareWorkerInfo(sessionID, userID, workDir string, si *sessio
 			latestCreatedAt := turns[len(turns)-1].CreatedAt
 
 			// Check async compression cache: if turns haven't changed, reuse result.
-			if cached, ok := b.compressCache.Load(sessionID); ok {
-				if entry, ok := cached.(*compressCacheEntry); ok {
-					if entry.latestTurnCreatedAt == latestCreatedAt {
-						info.ConversationHistory = entry.turns
-						b.log.Debug("bridge: using cached compressed history",
-							"session_id", sessionID, "turns", len(entry.turns))
-					} else {
-						// Turn set changed - stale cache, invalidate.
-						b.compressCache.Delete(sessionID)
-					}
-				} else {
-					b.compressCache.Delete(sessionID)
-				}
+			if cached, hit := b.resolveCachedHistory(sessionID, latestCreatedAt); hit {
+				info.ConversationHistory = cached
+				b.log.Debug("bridge: using cached compressed history",
+					"session_id", sessionID, "turns", len(cached))
 			}
 
 			// Cache miss: inject truncated history immediately (sub-ms),

--- a/internal/gateway/history_compress.go
+++ b/internal/gateway/history_compress.go
@@ -72,7 +72,7 @@ func (c *HistoryCompressor) CompressHistory(
 	}
 
 	if len(filtered) == 0 {
-		return CompressResult{}
+		return CompressResult{Turns: []worker.ConversationTurn{}}
 	}
 
 	// 2. Self-adaptive: skip compression for moderate overruns.
@@ -171,7 +171,7 @@ func (c *HistoryCompressor) CompressHistory(
 func (c *HistoryCompressor) TruncateHistory(turns []*eventstore.TurnRecord) CompressResult {
 	filtered := filterEmptyTurns(turns)
 	if len(filtered) == 0 {
-		return CompressResult{}
+		return CompressResult{Turns: []worker.ConversationTurn{}}
 	}
 	return c.truncateResult(filtered)
 }

--- a/internal/gateway/history_compress_test.go
+++ b/internal/gateway/history_compress_test.go
@@ -306,17 +306,15 @@ func TestTruncateHistory_PreservesChronologicalOrder(t *testing.T) {
 func TestResolveCachedHistory_AllBranches(t *testing.T) {
 	t.Parallel()
 
-	b := &Bridge{}
-
 	t.Run("cache miss", func(t *testing.T) {
-		t.Parallel()
+		b := &Bridge{}
 		turns, hit := b.resolveCachedHistory("miss-session", 1000)
 		require.False(t, hit)
 		require.Nil(t, turns)
 	})
 
 	t.Run("cache hit", func(t *testing.T) {
-		t.Parallel()
+		b := &Bridge{}
 		expected := []worker.ConversationTurn{{Role: "assistant", Content: "summary"}}
 		b.compressCache.Store("hit-session", &compressCacheEntry{
 			turns:               expected,
@@ -328,7 +326,7 @@ func TestResolveCachedHistory_AllBranches(t *testing.T) {
 	})
 
 	t.Run("stale cache invalidated", func(t *testing.T) {
-		t.Parallel()
+		b := &Bridge{}
 		b.compressCache.Store("stale-session", &compressCacheEntry{
 			turns:               []worker.ConversationTurn{{Role: "assistant", Content: "old"}},
 			latestTurnCreatedAt: 1000,
@@ -341,7 +339,7 @@ func TestResolveCachedHistory_AllBranches(t *testing.T) {
 	})
 
 	t.Run("invalid type deleted", func(t *testing.T) {
-		t.Parallel()
+		b := &Bridge{}
 		b.compressCache.Store("bad-type-session", "not-a-cache-entry")
 		turns, hit := b.resolveCachedHistory("bad-type-session", 1000)
 		require.False(t, hit)

--- a/internal/gateway/history_compress_test.go
+++ b/internal/gateway/history_compress_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"sync"
-
 	"github.com/hrygo/hotplex/internal/brain"
 	"github.com/hrygo/hotplex/internal/eventstore"
 	"github.com/hrygo/hotplex/internal/worker"
@@ -305,35 +303,52 @@ func TestTruncateHistory_PreservesChronologicalOrder(t *testing.T) {
 	require.Equal(t, "recent2", last.Content)
 }
 
-func TestCompressCache_InvalidationOnTurnChange(t *testing.T) {
+func TestResolveCachedHistory_AllBranches(t *testing.T) {
 	t.Parallel()
 
-	// Simulate cache behavior: same latestTurnCreatedAt = cache hit,
-	// different = cache miss (invalidate).
-	cache := &sync.Map{}
+	b := &Bridge{}
 
-	entry1 := &compressCacheEntry{
-		turns:               []worker.ConversationTurn{{Role: "assistant", Content: "summary"}},
-		latestTurnCreatedAt: 1000,
-	}
-	cache.Store("s1", entry1)
+	t.Run("cache miss", func(t *testing.T) {
+		t.Parallel()
+		turns, hit := b.resolveCachedHistory("miss-session", 1000)
+		require.False(t, hit)
+		require.Nil(t, turns)
+	})
 
-	// Same timestamp → hit.
-	if cached, ok := cache.Load("s1"); ok {
-		e := cached.(*compressCacheEntry)
-		require.Equal(t, int64(1000), e.latestTurnCreatedAt)
-		require.Len(t, e.turns, 1)
-	}
+	t.Run("cache hit", func(t *testing.T) {
+		t.Parallel()
+		expected := []worker.ConversationTurn{{Role: "assistant", Content: "summary"}}
+		b.compressCache.Store("hit-session", &compressCacheEntry{
+			turns:               expected,
+			latestTurnCreatedAt: 1000,
+		})
+		turns, hit := b.resolveCachedHistory("hit-session", 1000)
+		require.True(t, hit)
+		require.Equal(t, expected, turns)
+	})
 
-	// Different timestamp → miss → invalidate.
-	if cached, ok := cache.Load("s1"); ok {
-		e := cached.(*compressCacheEntry)
-		if e.latestTurnCreatedAt != 2000 {
-			cache.Delete("s1")
-		}
-	}
-	_, ok := cache.Load("s1")
-	require.False(t, ok, "cache should be invalidated after timestamp mismatch")
+	t.Run("stale cache invalidated", func(t *testing.T) {
+		t.Parallel()
+		b.compressCache.Store("stale-session", &compressCacheEntry{
+			turns:               []worker.ConversationTurn{{Role: "assistant", Content: "old"}},
+			latestTurnCreatedAt: 1000,
+		})
+		turns, hit := b.resolveCachedHistory("stale-session", 2000)
+		require.False(t, hit)
+		require.Nil(t, turns)
+		_, exists := b.compressCache.Load("stale-session")
+		require.False(t, exists, "stale entry should be deleted")
+	})
+
+	t.Run("invalid type deleted", func(t *testing.T) {
+		t.Parallel()
+		b.compressCache.Store("bad-type-session", "not-a-cache-entry")
+		turns, hit := b.resolveCachedHistory("bad-type-session", 1000)
+		require.False(t, hit)
+		require.Nil(t, turns)
+		_, exists := b.compressCache.Load("bad-type-session")
+		require.False(t, exists, "invalid entry should be deleted")
+	})
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #720

PR #717 Round 2 review P2 findings:

- **P2-1**: TruncateHistory/CompressHistory return empty slice instead of nil — prevents unnecessary async compression goroutine + Brain API call when all turns have empty content
- **P2-2**: Extract `resolveCachedHistory` method from `prepareWorkerInfo` with full test coverage (cache hit / stale miss / type invalidation / pure miss)

**变更文件**:
- `internal/gateway/history_compress.go` — empty slice 替代 nil
- `internal/gateway/bridge.go` — 提取 `resolveCachedHistory` 方法
- `internal/gateway/history_compress_test.go` — 4 个分支测试