### PR TITLE
feat(codex): inject agent-configs as baseInstructions (#713)

### DIFF
--- a/internal/worker/codexcli/types.go
+++ b/internal/worker/codexcli/types.go
@@ -152,6 +152,14 @@ type ThreadStartParams struct {
 	Personality    string `json:"personality,omitempty"`
 	Ephemeral      bool   `json:"ephemeral,omitempty"`
 	ApprovalPolicy string `json:"approvalPolicy,omitempty"` // "never" (YOLO) | "on-request" | "on-failure" | "untrusted"
+
+	// Agent-configs injection. BaseInstructions carries the merged B/C channel
+	// system prompt from bridge.injectAgentConfig(). Mapped to the app-server
+	// thread/start "baseInstructions" field (ThreadStartParams.base_instructions
+	// in Rust). DeveloperInstructions is reserved for future use — higher
+	// priority than BaseInstructions when both are set.
+	BaseInstructions      string `json:"baseInstructions,omitempty"`
+	DeveloperInstructions string `json:"developerInstructions,omitempty"`
 }
 
 type ThreadStartResult struct {

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -83,6 +83,7 @@ func resolveConfig() Config {
 var _ worker.Worker = (*AppServerWorker)(nil)
 var _ worker.WorkerCommander = (*AppServerWorker)(nil)
 var _ worker.ControlRequester = (*AppServerWorker)(nil)
+var _ worker.SystemPromptUpdater = (*AppServerWorker)(nil)
 
 type appState int
 

--- a/internal/worker/codexcli/worker.go
+++ b/internal/worker/codexcli/worker.go
@@ -750,5 +750,13 @@ func buildThreadStartParams(session worker.SessionInfo, cfg Config) map[string]a
 	if cfg.ConfigProfile != "" {
 		params["profile"] = cfg.ConfigProfile
 	}
+	// Agent-configs injection: bridge.injectAgentConfig() writes the merged
+	// B/C channel prompt into session.SystemPrompt. Forward it as baseInstructions
+	// so codex app-server uses it as the system prompt base.
+	if session.SystemPrompt != "" {
+		params["baseInstructions"] = session.SystemPrompt
+	}
+	// developerInstructions is reserved for future use — higher priority than
+	// baseInstructions. Do not set until SessionInfo gains a corresponding field.
 	return params
 }

--- a/internal/worker/codexcli/worker_test.go
+++ b/internal/worker/codexcli/worker_test.go
@@ -1803,6 +1803,32 @@ func TestBuildThreadStartParams(t *testing.T) {
 		require.NotNil(t, params["additionalDirectories"])
 	})
 
+	t.Run("system prompt injected as baseInstructions", func(t *testing.T) {
+		t.Parallel()
+		params := buildThreadStartParams(
+			worker.SessionInfo{
+				ProjectDir:   "/tmp",
+				SystemPrompt: "You are a helpful assistant. Follow SOUL.md guidelines.",
+			},
+			Config{},
+		)
+		require.Equal(t, "You are a helpful assistant. Follow SOUL.md guidelines.", params["baseInstructions"])
+		_, hasDevInstr := params["developerInstructions"]
+		require.False(t, hasDevInstr, "developerInstructions should never be set by buildThreadStartParams")
+	})
+
+	t.Run("empty system prompt omits baseInstructions", func(t *testing.T) {
+		t.Parallel()
+		params := buildThreadStartParams(
+			worker.SessionInfo{ProjectDir: "/tmp"},
+			Config{},
+		)
+		_, hasBase := params["baseInstructions"]
+		require.False(t, hasBase, "baseInstructions should be absent when SystemPrompt is empty")
+		_, hasDev := params["developerInstructions"]
+		require.False(t, hasDev, "developerInstructions should never be set")
+	})
+
 	t.Run("no skip permissions uses config approval", func(t *testing.T) {
 		t.Parallel()
 		params := buildThreadStartParams(


### PR DESCRIPTION
## Summary

让 agent-configs（B/C 通道）体系在 Codex CLI Worker（`codex app-server` 模式）下生效。当前 `bridge.injectAgentConfig()` 写入的 `session.SystemPrompt` 未通过 JSON-RPC `thread/start` 传递给 `codex app-server`，导致 agent-configs 对 Codex Worker 完全不生效。

## Changes

- **`types.go`**: `ThreadStartParams` 新增 `BaseInstructions` + `DeveloperInstructions`（future use）字段
- **`worker.go`**: `buildThreadStartParams` 当 `session.SystemPrompt` 非空时注入 `baseInstructions` 参数
- **`worker_test.go`**: 新增 2 个测试用例覆盖有/无 SystemPrompt 场景

## Why safe

- `omitempty` 确保空字符串时不发送字段
- JSON-RPC server 端容忍未知字段（向后兼容旧版 app-server）
- 仅修改 `codexcli/` 包，其他 Worker 零影响
- `developerInstructions` 声明但未设置，保留给未来扩展

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)