### PR TITLE
fix(codexcli): prevent idle drain deadlock holding manager mutex

### DIFF
--- a/internal/worker/codexcli/manager.go
+++ b/internal/worker/codexcli/manager.go
@@ -995,14 +995,34 @@ func (m *CodexAppServerManager) startIdleDrainLocked() {
 		"period", m.cfg.IdleDrainPeriod)
 	m.idleTimer = time.AfterFunc(m.cfg.IdleDrainPeriod, func() {
 		m.mu.Lock()
-		defer m.mu.Unlock()
-
-		if m.refs == 0 && m.state == stateRunning && m.proc != nil {
-			m.log.Info("codex-app-server: idle drain expired, killing process")
-			_ = m.proc.Kill()
-			// monitorProcess will set state to stateIdle and clean up.
+		if m.idleTimer == nil {
+			// Timer was already stopped (e.g. by KillIfIdle or Acquire).
+			m.mu.Unlock()
+			return
 		}
+		shouldKill := m.refs == 0 && m.state == stateRunning && m.pgid > 0
+		pgid := m.pgid
+		m.mu.Unlock()
+
+		if shouldKill {
+			m.log.Info("codex-app-server: idle drain expired, killing process")
+			// Use ForceKill + ForceKillTree instead of m.proc.Kill() to avoid
+			// deadlock: proc.Manager.Kill() acquires proc.mu and calls
+			// cmd.Wait(), which blocks until the child exits. Meanwhile
+			// monitorProcess's Wait() already holds proc.mu inside its own
+			// cmd.Wait() call. Kill() would block on proc.mu.Lock() while
+			// holding m.mu, making the entire manager unusable. ForceKill
+			// sends SIGKILL by PGID without touching proc.mu, so
+			// monitorProcess's Wait() observes the exit and runs cleanup.
+			_ = proc.ForceKill(pgid)
+			proc.ForceKillTree(pgid, m.log)
+			// monitorProcess will observe the exit, set state to stateIdle,
+			// and clean up.
+		}
+
+		m.mu.Lock()
 		m.idleTimer = nil
+		m.mu.Unlock()
 	})
 }
 


### PR DESCRIPTION
Resolves #726

## 根因

`startIdleDrainLocked()` 的 timer callback 在 `m.mu` (CodexAppServerManager mutex) 持有状态下调用 `m.proc.Kill()`。`proc.Manager.Kill()` 需要获取 `proc.mu`（进程管理器 mutex），然后调用 `cmd.Wait()` 阻塞等待进程退出。但 `monitorProcess` 的 `Wait()` 已经持有 `proc.mu` 并阻塞在 `cmd.Wait()` 上。

**结果**：Kill() 永远等不到 `proc.mu`，`m.mu` 永远不释放 → 整个 `CodexAppServerManager` 死锁。SIGKILL 从未发送（因为 Kill() 卡在拿锁上），进程一直活着，所有后续 `Acquire()` 调用阻塞在 `m.mu.Lock()` 上。

## 因果链

1. app-server 进程启动后，`monitorProcess` 持有 `proc.mu` 阻塞在 `cmd.Wait()`
2. session terminated → `Release()` refs=0 → idle drain timer (30min) 启动
3. idle drain 触发 → 持有 `m.mu` → 调 `m.proc.Kill()` → 阻塞在 `proc.mu.Lock()`
4. 飞书新消息到达 → `Acquire()` → `m.mu.Lock()` → **死锁**
5. 整个 codex_cli manager 不可用，直到外部手动 kill 进程

## 修复

与 `KillIfIdle()` 使用相同模式：
1. 在 `m.mu` 下快照 `shouldKill` + `pgid`
2. **释放 `m.mu`**
3. 用 `proc.ForceKill(pgid)` + `proc.ForceKillTree(pgid)` 直接 SIGKILL（不经过 `proc.Manager.Kill()` 的 mutex）
4. 重新获取 `m.mu` 设置 `m.idleTimer = nil`

`monitorProcess` 异步检测到进程退出，设置 `stateIdle` 并清理。

## 验证

- `go build` ✅
- `go test -count=1 -race` ✅
- `golangci-lint` ✅
- pre-commit hooks (gofmt + lint) ✅
- pre-push gates (vet + verify + lint + build + test) ✅