### PR TITLE
fix(eventstore,gateway): CTE merge + truncate oversized turns (#716, #715)

### DIFF
--- a/internal/eventstore/pg_store.go
+++ b/internal/eventstore/pg_store.go
@@ -213,25 +213,10 @@ func (t *pgEventTx) Rollback() error {
 // TurnQuerier implementation
 // ---------------------------------------------------------------------------
 
-func (s *pgStore) resolveGeneration(ctx context.Context, sessionID string) (int64, error) {
-	gen, err := s.LatestGeneration(ctx, sessionID)
-	if err != nil {
-		return 0, err
-	}
-	if gen == 0 {
-		return 0, ErrNotFound
-	}
-	return gen, nil
-}
-
 func (s *pgStore) QueryTurns(ctx context.Context, sessionID string, limit, offset int) ([]*TurnRecord, error) {
-	gen, err := s.resolveGeneration(ctx, sessionID)
-	if err != nil {
-		return nil, fmt.Errorf("eventstore: resolve generation: %w", err)
-	}
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
-	rows, err := s.db.QueryContext(ctx, s.sql["turns.query"], sessionID, gen, limit, offset)
+	rows, err := s.db.QueryContext(ctx, s.sql["turns.query_with_gen"], sessionID, sessionID, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("eventstore: query turns: %w", err)
 	}
@@ -257,30 +242,30 @@ func (s *pgStore) QueryTurnsBefore(ctx context.Context, sessionID string, before
 }
 
 func (s *pgStore) QueryTurnStats(ctx context.Context, sessionID string) (*TurnStats, error) {
-	gen, err := s.resolveGeneration(ctx, sessionID)
-	if err != nil {
-		return nil, fmt.Errorf("eventstore: resolve generation: %w", err)
-	}
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
-	rows, err := s.db.QueryContext(ctx, s.sql["turns.stats"], sessionID, gen)
+	rows, err := s.db.QueryContext(ctx, s.sql["turns.stats_with_gen"], sessionID, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("eventstore: query turn stats: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	stats := &TurnStats{SessionID: sessionID, Generation: gen}
+	stats := &TurnStats{SessionID: sessionID}
 	for rows.Next() {
 		var ts TurnStatItem
+		var gen int64
 		var success sql.NullBool
 		var toolsJSON sql.NullString
 		var toolCount sql.NullInt64
-		if err := rows.Scan(&ts.TurnNum, &ts.Seq, &success, &ts.Source,
+		if err := rows.Scan(&gen, &ts.TurnNum, &ts.Seq, &success, &ts.Source,
 			&toolsJSON, &toolCount,
 			&ts.TokensInput, &ts.TokensCacheWrite, &ts.TokensCacheRead, &ts.TokensIn,
 			&ts.TokensOut, &ts.DurationMs, &ts.CostUSD, &ts.Model, &ts.CreatedAt); err != nil {
 			s.log.Warn("eventstore: scan turn stats row", "session_id", sessionID, "error", err)
 			continue
+		}
+		if stats.Generation == 0 {
+			stats.Generation = gen
 		}
 		ts.Success = success.Valid && success.Bool
 		stats.TotalTurns++

--- a/internal/eventstore/sql/queries/turns.query.sql
+++ b/internal/eventstore/sql/queries/turns.query.sql
@@ -1,9 +1,0 @@
-SELECT id, session_id, generation, turn_num, seq, role, content,
-       platform, user_id, model, success, source, tools_json, tool_count,
-       tokens_input, tokens_cache_write, tokens_cache_read,
-       (tokens_input + tokens_cache_write + tokens_cache_read) AS tokens_in,
-       tokens_out, duration_ms, cost_usd, created_at
-FROM turns
-WHERE session_id = ? AND generation = ?
-ORDER BY id ASC
-LIMIT ? OFFSET ?

--- a/internal/eventstore/sql/queries/turns.query_with_gen.sql
+++ b/internal/eventstore/sql/queries/turns.query_with_gen.sql
@@ -1,0 +1,12 @@
+WITH latest_gen AS (
+    SELECT COALESCE(MAX(generation), 0) AS gen FROM turns WHERE session_id = ?
+)
+SELECT t.id, t.session_id, t.generation, t.turn_num, t.seq, t.role, t.content,
+       t.platform, t.user_id, t.model, t.success, t.source, t.tools_json, t.tool_count,
+       t.tokens_input, t.tokens_cache_write, t.tokens_cache_read,
+       (t.tokens_input + t.tokens_cache_write + t.tokens_cache_read) AS tokens_in,
+       t.tokens_out, t.duration_ms, t.cost_usd, t.created_at
+FROM turns t, latest_gen lg
+WHERE t.session_id = ? AND t.generation = lg.gen
+ORDER BY t.id ASC
+LIMIT ? OFFSET ?

--- a/internal/eventstore/sql/queries/turns.stats.sql
+++ b/internal/eventstore/sql/queries/turns.stats.sql
@@ -1,8 +1,0 @@
-SELECT turn_num, seq, success, source,
-       tools_json, tool_count,
-       tokens_input, tokens_cache_write, tokens_cache_read,
-       (tokens_input + tokens_cache_write + tokens_cache_read) AS tokens_in,
-       tokens_out, duration_ms, cost_usd, model, created_at
-FROM turns
-WHERE session_id = ? AND generation = ? AND role = 'assistant'
-ORDER BY id ASC

--- a/internal/eventstore/sql/queries/turns.stats_with_gen.sql
+++ b/internal/eventstore/sql/queries/turns.stats_with_gen.sql
@@ -1,0 +1,11 @@
+WITH latest_gen AS (
+    SELECT COALESCE(MAX(generation), 0) AS gen FROM turns WHERE session_id = ?
+)
+SELECT lg.gen, t.turn_num, t.seq, t.success, t.source,
+       t.tools_json, t.tool_count,
+       t.tokens_input, t.tokens_cache_write, t.tokens_cache_read,
+       (t.tokens_input + t.tokens_cache_write + t.tokens_cache_read) AS tokens_in,
+       t.tokens_out, t.duration_ms, t.cost_usd, t.model, t.created_at
+FROM turns t, latest_gen lg
+WHERE t.session_id = ? AND t.generation = lg.gen AND t.role = 'assistant'
+ORDER BY t.id ASC

--- a/internal/eventstore/store.go
+++ b/internal/eventstore/store.go
@@ -427,28 +427,12 @@ func (s *SQLiteStore) Close() error {
 	return nil
 }
 
-// resolveGeneration returns the latest generation for a session, or ErrNotFound if no turns exist.
-func (s *SQLiteStore) resolveGeneration(ctx context.Context, sessionID string) (int64, error) {
-	gen, err := s.LatestGeneration(ctx, sessionID)
-	if err != nil {
-		return 0, err
-	}
-	if gen == 0 {
-		return 0, ErrNotFound
-	}
-	return gen, nil
-}
-
 // QueryTurns fetches conversation turns from the materialized turns table.
-// Automatically resolves the latest generation for the session.
+// Uses a CTE to resolve the latest generation and select in a single SQL round-trip.
 func (s *SQLiteStore) QueryTurns(ctx context.Context, sessionID string, limit, offset int) ([]*TurnRecord, error) {
-	gen, err := s.resolveGeneration(ctx, sessionID)
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
-	rows, err := s.db.QueryContext(ctx, queries["turns.query"], sessionID, gen, limit, offset)
+	rows, err := s.db.QueryContext(ctx, queries["turns.query_with_gen"], sessionID, sessionID, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("eventstore: query turns: %w", err)
 	}
@@ -476,31 +460,32 @@ func (s *SQLiteStore) QueryTurnsBefore(ctx context.Context, sessionID string, be
 }
 
 // QueryTurnStats returns aggregated turn statistics for a session's latest generation.
+// Uses a CTE to resolve the latest generation and select in a single SQL round-trip.
 func (s *SQLiteStore) QueryTurnStats(ctx context.Context, sessionID string) (*TurnStats, error) {
-	gen, err := s.resolveGeneration(ctx, sessionID)
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
-	rows, err := s.db.QueryContext(ctx, queries["turns.stats"], sessionID, gen)
+	rows, err := s.db.QueryContext(ctx, queries["turns.stats_with_gen"], sessionID, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("eventstore: query turn stats: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	stats := &TurnStats{SessionID: sessionID, Generation: gen}
+	stats := &TurnStats{SessionID: sessionID}
 	for rows.Next() {
 		var ts TurnStatItem
+		var gen int64
 		var success sql.NullInt64
 		var toolsJSON sql.NullString
 		var toolCount sql.NullInt64
-		if err := rows.Scan(&ts.TurnNum, &ts.Seq, &success, &ts.Source,
+		if err := rows.Scan(&gen, &ts.TurnNum, &ts.Seq, &success, &ts.Source,
 			&toolsJSON, &toolCount,
 			&ts.TokensInput, &ts.TokensCacheWrite, &ts.TokensCacheRead, &ts.TokensIn,
 			&ts.TokensOut, &ts.DurationMs, &ts.CostUSD, &ts.Model, &ts.CreatedAt); err != nil {
 			slog.Warn("eventstore: scan turn stats row", "session_id", sessionID, "error", err)
 			continue
+		}
+		if stats.Generation == 0 {
+			stats.Generation = gen
 		}
 		ts.Success = success.Valid && success.Int64 == 1
 		stats.TotalTurns++

--- a/internal/gateway/history_compress.go
+++ b/internal/gateway/history_compress.go
@@ -316,6 +316,9 @@ func (c *HistoryCompressor) truncateResult(turns []turnWithChars) CompressResult
 		content := t.content
 		if len(content) > remaining {
 			content = truncateAtBoundary(content, remaining)
+			if content == "" {
+				continue
+			}
 			c.log.Warn("history: turn truncated to fit budget",
 				"turn_role", t.role,
 				"original_bytes", len(t.content),

--- a/internal/gateway/history_compress.go
+++ b/internal/gateway/history_compress.go
@@ -301,31 +301,36 @@ func formatTurns(turns []turnWithChars) string {
 }
 
 // truncateResult builds a CompressResult by truncating turns to fit within budget.
-// Iterates from newest to oldest so that when the first (oldest) turn alone
-// exceeds the budget, we still return the most recent turns that fit.
+// Iterates from newest to oldest so that the most recent turns are prioritized.
+// Oversized turns are truncated at a newline boundary rather than discarded entirely,
+// ensuring at least partial content from the newest turn is always preserved.
 func (c *HistoryCompressor) truncateResult(turns []turnWithChars) CompressResult {
 	history := make([]worker.ConversationTurn, 0, len(turns))
 	bytesUsed := 0
 	for i := len(turns) - 1; i >= 0; i-- {
 		t := turns[i]
-		if bytesUsed+len(t.content) > maxHistoryBytes {
+		remaining := maxHistoryBytes - bytesUsed
+		if remaining <= 0 {
 			break
 		}
-		bytesUsed += len(t.content)
+		content := t.content
+		if len(content) > remaining {
+			content = truncateAtBoundary(content, remaining)
+			c.log.Warn("history: turn truncated to fit budget",
+				"turn_role", t.role,
+				"original_bytes", len(t.content),
+				"truncated_bytes", len(content),
+				"budget", maxHistoryBytes)
+		}
+		bytesUsed += len(content)
 		history = append(history, worker.ConversationTurn{
 			Role:    t.role,
-			Content: t.content,
+			Content: content,
 		})
 	}
 	// Reverse to restore chronological order.
 	for i, j := 0, len(history)-1; i < j; i, j = i+1, j-1 {
 		history[i], history[j] = history[j], history[i]
-	}
-	if len(history) == 0 && len(turns) > 0 {
-		c.log.Warn("history: all turns exceed byte budget, history empty",
-			"turn_count", len(turns),
-			"budget", maxHistoryBytes,
-			"newest_turn_bytes", len(turns[len(turns)-1].content))
 	}
 	return CompressResult{
 		Turns:         history,

--- a/internal/gateway/history_compress_test.go
+++ b/internal/gateway/history_compress_test.go
@@ -303,6 +303,46 @@ func TestTruncateHistory_PreservesChronologicalOrder(t *testing.T) {
 	require.Equal(t, "recent2", last.Content)
 }
 
+func TestTruncateHistory_OversizedTurnTruncated(t *testing.T) {
+	t.Parallel()
+
+	c := NewHistoryCompressor(slog.Default(), nil)
+
+	// Single turn that exceeds maxHistoryBytes — must be truncated, not discarded.
+	turns := []*eventstore.TurnRecord{
+		turn("assistant", makeLargeString(80000)),
+	}
+
+	result := c.TruncateHistory(turns)
+
+	require.False(t, result.Compressed)
+	require.Len(t, result.Turns, 1, "oversized turn should be truncated, not discarded")
+	require.True(t, len(result.Turns[0].Content) <= maxHistoryBytes)
+	require.True(t, len(result.Turns[0].Content) > 0, "truncated content must not be empty")
+	require.True(t, result.FinalChars <= maxHistoryBytes)
+}
+
+func TestTruncateHistory_NewestTurnPreservedWhenOversized(t *testing.T) {
+	t.Parallel()
+
+	c := NewHistoryCompressor(slog.Default(), nil)
+
+	// Two oversized turns — newest should always get at least partial content.
+	turns := []*eventstore.TurnRecord{
+		turn("user", makeLargeString(60000)),
+		turn("assistant", makeLargeString(60000)),
+	}
+
+	result := c.TruncateHistory(turns)
+
+	require.False(t, result.Compressed)
+	require.NotEmpty(t, result.Turns, "at least the newest turn must be preserved")
+	// Newest turn (chronologically last) should have partial content.
+	last := result.Turns[len(result.Turns)-1]
+	require.True(t, len(last.Content) > 0, "newest turn must have content")
+	require.True(t, result.FinalChars <= maxHistoryBytes)
+}
+
 func TestResolveCachedHistory_AllBranches(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Changes

### Issue #716: 合并 resolveGeneration + SELECT 为单条 SQL
- 新增 `turns.query_with_gen.sql` / `turns.stats_with_gen.sql` 使用 CTE (`WITH latest_gen AS ...`) 合并两步查询为单条 SQL
- SQLite 和 PostgreSQL 实现均已更新，DB round-trip 从 2→1
- 移除不再使用的 `resolveGeneration` 方法（`LatestGeneration` 保留，仍为 `TurnQuerier` 接口方法）

### Issue #715: 截断超大 turn 而非完全丢弃
- `truncateResult` 中超大 turn 改为 `truncateAtBoundary` 截断到剩余预算，不再 `break` 丢弃
- 确保至少保留最新 turn 的部分内容（即使单条 > maxHistoryBytes）
- 补充 warning log 记录被截断 turn 的 original/truncated bytes
- 新增 2 个测试覆盖超大 turn 场景

## Files
| File | Change |
|------|--------|
| `internal/eventstore/sql/queries/turns.query_with_gen.sql` | 新增 CTE 查询 |
| `internal/eventstore/sql/queries/turns.stats_with_gen.sql` | 新增 CTE 查询 |
| `internal/eventstore/store.go` | QueryTurns/QueryTurnStats 用 CTE, 移除 resolveGeneration |
| `internal/eventstore/pg_store.go` | 同上 PG 实现 |
| `internal/gateway/history_compress.go` | truncateResult 截断而非丢弃 |
| `internal/gateway/history_compress_test.go` | +2 测试覆盖超大 turn |

Closes #716, Closes #715