### PR TITLE
fix(acp): validate sessionId non-empty in NewSession and Prompt

### DIFF
--- a/internal/worker/acp/client.go
+++ b/internal/worker/acp/client.go
@@ -97,6 +97,9 @@ func (c *ACPClient) ResumeSession(ctx context.Context, sessionID, cwd string, mc
 // Prompt sends a user message to the active session and waits for the response.
 // Notifications received during the prompt are dispatched to NotificationCh.
 func (c *ACPClient) Prompt(ctx context.Context, sessionID, content string) (*PromptResult, error) {
+	if sessionID == "" {
+		return nil, fmt.Errorf("acp prompt: empty sessionId")
+	}
 	params := map[string]any{
 		"sessionId": sessionID,
 		"prompt": []map[string]string{
@@ -366,6 +369,9 @@ func (c *ACPClient) callSessionMethod(ctx context.Context, method string, params
 	var result SessionResult
 	if err := json.Unmarshal(resp.Result, &result); err != nil {
 		return nil, fmt.Errorf("acp %s: unmarshal: %w", label, err)
+	}
+	if result.SessionID == "" {
+		return nil, fmt.Errorf("acp %s: agent returned empty sessionId", label)
 	}
 	return &result, nil
 }


### PR DESCRIPTION
Resolves #728

## 根因

当 DB 中 `worker_session_id` 为空时（历史遗留 session，如 #710 修复前创建），ACP worker resume 路径调用 `forceNewSession()` → `NewSession()`。如果 ACP agent 返回空 `sessionId`，空值静默传播到 `Prompt(ctx, "", content)`，导致 hermes-agent 报 `prompt: session  not found`（双空格），后续 turn 返回空回复（`text_len=0`）。

## 修复

两处校验：

1. **`callSessionMethod`** — 校验 `SessionResult.SessionID` 非空，空值返回明确错误而非静默传播
2. **`Prompt`** — 防御性校验空 `sessionID`，避免发送无效 JSON-RPC 请求

## 测试

- `go test -count=1 -race ./internal/worker/acp/` ✅
- pre-push 质量门禁全通过（formatting, vet, mod verify, lint, build, tests）✅