### PR TITLE
docs(patrol): 2026-06-14 文档维护 — admin-api.md 同步 1:1 约束

### DIFF
--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -202,7 +202,7 @@ Bot 状态查询、配置管理和 Agent 配置文件操作端点。
 
 ### API Key 用户管理
 
-管理 API Key 到用户身份的映射，用于企业级多用户 Session 隔离。需要数据库支持（SQLite），未配置 DB resolver 时返回 `501 Not Implemented`。
+管理 API Key 到用户身份的映射，用于企业级多用户 Session 隔离。每个 `user_id` 与 API Key 为 **1:1 映射**（一个 user_id 仅能关联一个 API Key），创建或更新时若 user_id 已被其他映射占用则返回 `409 Conflict`。需要数据库支持（SQLite 或 PostgreSQL），未配置 DB resolver 时返回 `501 Not Implemented`。
 
 | 方法 | 路径 | Scope | 说明 |
 |------|------|-------|------|
@@ -212,11 +212,11 @@ Bot 状态查询、配置管理和 Agent 配置文件操作端点。
 | PATCH | `/admin/api-keys/{id}` | `admin:write` | 更新映射 |
 | DELETE | `/admin/api-keys/{id}` | `admin:write` | 删除映射 |
 
-**POST /admin/api-keys** — 创建 API Key → UserID 映射。JSON body 含 `user_id`（必填，最长 128 字符）和 `description`（可选，最长 512 字符）。API Key 由系统自动生成（32 字节随机 hex）。返回 `201 Created`。
+**POST /admin/api-keys** — 创建 API Key → UserID 映射。JSON body 含 `user_id`（必填，最长 128 字符）和 `description`（可选，最长 512 字符）。API Key 由系统自动生成（32 字节随机 hex）。返回 `201 Created`；若 `user_id` 已存在则返回 `409 Conflict`。
 
 **GET /admin/api-keys** — 返回所有映射列表，`api_key` 字段自动脱敏（仅显示前 8 + 后 4 位）。
 
-**PATCH /admin/api-keys/{id}`** — 更新指定映射的 `user_id` 和 `description`。
+**PATCH /admin/api-keys/{id}`** — 更新指定映射的 `user_id` 和 `description`。若新 `user_id` 与其他映射冲突则返回 `409 Conflict`。
 
 **DELETE /admin/api-keys/{id}`** — 物理删除映射，同时清除缓存的 resolver 条目。
 

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -212,13 +212,13 @@ Bot 状态查询、配置管理和 Agent 配置文件操作端点。
 | PATCH | `/admin/api-keys/{id}` | `admin:write` | 更新映射 |
 | DELETE | `/admin/api-keys/{id}` | `admin:write` | 删除映射 |
 
-**POST /admin/api-keys** — 创建 API Key → UserID 映射。JSON body 含 `user_id`（必填，最长 128 字符）和 `description`（可选，最长 512 字符）。API Key 由系统自动生成（32 字节随机 hex）。返回 `201 Created`；若 `user_id` 已存在则返回 `409 Conflict`。
+**POST /admin/api-keys** — 创建 API Key → UserID 映射。JSON body 含 `user_id`（必填，最长 128 字符）和 `description`（可选，最长 512 字符）。API Key 由系统自动生成（24 字节随机 hex）。返回 `201 Created`；若 `user_id` 已存在则返回 `409 Conflict`。
 
 **GET /admin/api-keys** — 返回所有映射列表，`api_key` 字段自动脱敏（仅显示前 8 + 后 4 位）。
 
-**PATCH /admin/api-keys/{id}`** — 更新指定映射的 `user_id` 和 `description`。若新 `user_id` 与其他映射冲突则返回 `409 Conflict`。
+**PATCH /admin/api-keys/{id}** — 更新指定映射的 `user_id` 和 `description`。若新 `user_id` 与其他映射冲突则返回 `409 Conflict`。
 
-**DELETE /admin/api-keys/{id}`** — 物理删除映射，同时清除缓存的 resolver 条目。
+**DELETE /admin/api-keys/{id}** — 物理删除映射，同时清除缓存的 resolver 条目。
 
 ## Gateway API 端点
 


### PR DESCRIPTION
## Summary

变更驱动巡逻：自 `fb857af1`(PR #730)以来 4 个提交，映射到文档影响分析。

**修复** `docs/reference/admin-api.md`，同步 PR #741 `fix(security): enforce 1:1 user_id to API key mapping` 引入的行为变更：

- 节首补充 `user_id` ↔ API Key **1:1 映射**约束 + `409 Conflict` 说明
- POST `/admin/api-keys` 补充 `409 Conflict` 响应（user_id 已存在）
- PATCH `/admin/api-keys/{id}` 补充 `409 Conflict` 响应（user_id 冲突）
- 顺带修正数据库后缀：SQLite → SQLite 或 PostgreSQL（migration 016 双方言）

## 影响判定（变更窗口其他提交）

| 提交 | 类型 | 文档动作 |
|------|------|---------|
| `5f84b7b5` release v1.29.0 | 版本号 | 无需 |
| `5c1ebc00` docs(patrol) #740 | 文档自身 | 已处理 |
| `10763824` config 拆分 + DRY #742 | 纯内部重构（零逻辑/配置项变更） | 无需 |
| `8dd4faa8` security 1:1 #741 | **行为变更** | ✅ 本次修复 |

security-model.md / security-hardening.md 描述的是 resolver 机制（未声明映射基数），对 1:1 约束仍准确，不需修改。

Closes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)