### PR TITLE
WebChat 多租户 spec ②：per-workspace agent-configs 两层继承

### DIFF
--- a/.agents/rules/agentconfig.md
+++ b/.agents/rules/agentconfig.md
@@ -29,3 +29,11 @@ paths:
 - 限制：单文件 8KB / 总量 40KB | YAML frontmatter 自动剥离
 - 安全：`ValidateBotName(botName)` 防路径穿越（含 `"."` / `".."` 检查）
 - 注入排除：`injectExclude` 按文件名（大小写不敏感）跳过加载；3 级配置（bot → platform → global），nil 继承，空 slice 覆盖清空
+
+**双轨（spec ②）**：WebChat 多租户轨与 Message Channel 轨隔离解析，互不污染。
+
+- **Message Channel 轨**（Slack/Feishu）：`Load` 三级 fallback（全局 → 平台 → Bot），如上，零改动。
+- **WebChat 轨**：`LoadForWorkspace(dir, platform, overrides, injectExclude...)` 两层继承——团队默认（`Load` base）→ workspace overrides 逐文件覆盖（命中即终止，空值继承默认，`injectExclude` 优先级最高）。
+- **workspace overrides**：DB JSON flat map（`workspaces.agent_config_overrides` 列，复用 spec ① 无新迁移），`ValidateOverrides` 校验键白名单/类型/size（PATCH 写入侧 + Bridge 读取侧复用同一函数）。
+- **分流判据**：`injectAgentConfig` 以 `workspaceOverrides != nil` 区分双轨；`Bridge.resolveWorkspaceOverrides(workspaceID)` 按 `workspace_id` 解析（空 → nil → Message Channel 轨）。3 个 worker 启动调用点（StartSession / resume / fresh-start）+ ResetSession 均经此 helper。
+- **不可覆盖**：`META-COGNITION.md` 不在 5 文件白名单（SOUL/AGENTS/SKILLS/USER/MEMORY），PATCH 拒、`applyOverrides` 忽略，物理不可覆盖。

--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ __pycache__
 !.agents/skills/hotplex-*/
 .agents/skills/hotplex-docs-patrol/.patrol-baseline
 .agent/
+.omo/
 /skills/
 skills-lock.json
 .agents/scheduled_tasks.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@
 - `config/` - Viper 配置 + 热重载 + 继承 + 审计/回滚。消息层共享默认值（WorkerType, STT, TTS）通过 `FillFrom()` 传播到平台配置。三级优先级：platform > messaging > Default()。多 bot 支持：`SlackBotConfig`/`FeishuBotConfig` + `normalizeSlackBots`/`normalizeFeishuBots` 向后兼容归一化
 - `security/` - API Key 认证（`Authenticator`）、Bot ID 提取（`BotIDFromRequest`）、SSRF 防护、路径安全
 - `skills/` - Skills 发现
-- `metrics/` - Prometheus 指标
+- `observability/` - Prometheus 指标 + OpenTelemetry 分布式追踪（30+ 指标、W3C TraceContext 传播、`sync.Once` 懒注册 + noop 降级）
 - `service/` - 跨平台系统服务管理（systemd/launchd/SCM）
 - `eventstore/` - 会话事件持久化 + delta 聚合
 - `updater/` - 自更新（GitHub API、sha256 校验、原子替换）

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -271,6 +271,7 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		CronEnv:            buildCronEnv(cfg),
 		MCPConfigJSON:      buildMCPConfigJSON(cfg),
 		AgentConfigExclude: buildAgentConfigExclude(cfg),
+		WSStore:            stores.wsStore,
 	})
 
 	skillsLocator := skills.NewLocator(log, cfg.Skills.CacheTTL)

--- a/docs/specs/WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md
@@ -125,6 +125,8 @@ WebChat 会话当前 `botName=""`（`bridge_worker.go:333` 注释），走 `plat
 | 单文件 | ≤ 8 000 chars | `agentconfig.MaxFileChars`（`loader.go:34`） |
 | 总量 | ≤ 40 000 chars | `agentconfig.MaxTotalChars`（`loader.go:37`） |
 
+> **合并截断提示**：上表约束由 PATCH 入口 `ValidateOverrides` 校验 override 自身。合并 team default 后总量可能超 `MaxTotalChars`（team default 单文件可达 ~39000 chars），此时 `LoadForWorkspace` 的 `enforceTotalLimit` 按字段顺序静默截断（`slog.Warn`）。PATCH 侧无法预知 team default 大小，该截断对用户不可见——属 defense-in-depth 权衡（见 §5 `LoadForWorkspace`）。
+
 ---
 
 ## 5. 两层继承解析（LoadForWorkspace）

--- a/docs/specs/WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md
@@ -125,7 +125,7 @@ WebChat 会话当前 `botName=""`（`bridge_worker.go:333` 注释），走 `plat
 | 单文件 | ≤ 8 000 chars | `agentconfig.MaxFileChars`（`loader.go:34`） |
 | 总量 | ≤ 40 000 chars | `agentconfig.MaxTotalChars`（`loader.go:37`） |
 
-> **合并截断提示**：上表约束由 PATCH 入口 `ValidateOverrides` 校验 override 自身。合并 team default 后总量可能超 `MaxTotalChars`（team default 单文件可达 ~39000 chars），此时 `LoadForWorkspace` 的 `enforceTotalLimit` 按字段顺序静默截断（`slog.Warn`）。PATCH 侧无法预知 team default 大小，该截断对用户不可见——属 defense-in-depth 权衡（见 §5 `LoadForWorkspace`）。
+> **合并截断提示（defense-in-depth）**：上表约束由 PATCH 入口 `ValidateOverrides` 校验 override 自身。`LoadForWorkspace` 的 `enforceTotalLimit` 对合并结果再校验 `MaxTotalChars`——在当前常量下（单文件 ≤ `MaxFileChars`=8000，5 文件合并 ≤ 40000 = `MaxTotalChars`，且 `applyOverrides` 是替换非追加）经 `LoadForWorkspace` 实际不可触发，仅作 future 常量调整的边界 guard。若触发则按字段顺序静默截断（`slog.Warn`），PATCH 侧无法预知 team default 合并大小。
 
 ---
 

--- a/docs/specs/WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md
@@ -87,7 +87,7 @@ WebChat 会话当前 `botName=""`（`bridge_worker.go:333` 注释），走 `plat
 | 解析入口 | **新增 `LoadForWorkspace` 独立函数** | 双轨物理隔离最彻底；`Load` 零改动向后兼容；符合 spec ① §5「接口扩展而非替换」 |
 | JSON 结构 | **flat map**（文件名 → 内容） | 键即文件名，与 `resolveFile`/`injectExclude` 按文件名模型零映射成本 |
 | admin 锁定机制 | **不做**（YAGNI） | 第一版全开放；未来如需「锁定 AGENTS.md」可增量加 `locked_files` 字段 |
-| 数据流载体 | `workerLaunchParams` 携带已解析 `workspaceOverrides map` | 保持 `injectAgentConfig` 纯函数（无 store 依赖），与现有设计一致 |
+| 数据流载体 | `workerLaunchParams` 携带已解析 `workspaceOverrides map` | 保持 `injectAgentConfig` 纯函数（不查 store）；解析集中在 bridge helper（Bridge 加窄接口 `WSStore` 依赖，因 resume/fresh-start 在 bridge 内部触发） |
 
 ---
 
@@ -203,11 +203,18 @@ type workerLaunchParams struct {
 }
 ```
 
-### 7.3 调用方填充 overrides
+### 7.3 Bridge 统一解析 overrides（helper）
 
-- **CreateSession**（`api.go`）：已在 spec ① 查 workspace 取 `work_dir`（`api.go:266-276`），顺手取 `AgentConfigOverrides` → 解析为 `map[string]string` → 填入 `workerLaunchParams.WorkspaceOverrides`。
-- **resume 路径**（worker 重启）：从 `session.workspace_id` 查 workspace 取 overrides 填入。具体调用点在实现计划细化。
-- 解析失败（DB 中 JSON 损坏）：`log.Warn` + 降级为 `nil`（走团队默认 `Load`），不阻断 worker 启动。
+代码精读发现：`createAndLaunchWorker` 有 **3 个调用点**——StartSession（`bridge.go:189`）、resume（`bridge.go:297`）、fresh-start（`bridge_worker.go:213`）。其中 resume 与 fresh-start 在 **Bridge 内部触发**（worker 崩溃恢复 / 重连），不经 `api.go`。故 overrides 解析必须由 Bridge 自己完成，不能依赖外部调用方（如 `CreateSession`）传入。
+
+方案：Bridge 新增**窄接口**依赖 + helper，3 点统一调用：
+
+- **窄接口** `WorkspaceOverridesReader`：仅需 `GetWorkspaceByID(ctx, id) (*session.Workspace, error)`（复用 spec ① `WorkspaceReader` 思路，`api.go:50`）。
+- **`BridgeDeps.WSStore`**（`deps.go:22` 加字段）：`gateway_run.go:260` NewBridge 传 `deps.WorkspaceStore`（spec ① 已有，`gateway_run.go:78`）。
+- **helper `b.resolveWorkspaceOverrides(workspaceID string) map[string]string`**：`workspaceID == ""` → `nil`（Message Channel 轨）；否则查 WSStore → `ValidateOverrides`（§8.2）解析 → 失败 `log.Warn` + 返回 `nil`（降级团队默认，不阻断 worker 启动）。
+- **3 个调用点统一**：`workspaceOverrides: b.resolveWorkspaceOverrides(<wid>)`，其中 `<wid>` 取自 `p.WorkspaceID`（StartSession，`worker.SessionStartParams.WorkspaceID` 已有，`worker.go:106`）或 `si.WorkspaceID`（resume/fresh-start，`session.SessionInfo.WorkspaceID` 已有，`manager.go:227`）。
+
+**`api.go CreateSession` 无需改动**：workspace 查询已在（`api.go:248`），`p.WorkspaceID` 已填，overrides 解析集中在 bridge helper。
 
 ### 7.4 `injectAgentConfig` 分流
 
@@ -226,9 +233,9 @@ func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botName, 
 
 `createAndLaunchWorker:82` 透传 `params.workspaceOverrides`。
 
-### 7.5 设计选择：传 map 而非 workspaceID
+### 7.5 设计选择：workerLaunchParams 携带已解析 map
 
-保持 `injectAgentConfig` **纯函数**（无 store 依赖，易测试），与现有设计一致。调用方负责查询解析；`Bridge` 不新增 workspace store 依赖。
+`workerLaunchParams.WorkspaceOverrides` 是**已解析的 `map[string]string`**（由 §7.3 helper 填充），而非 workspaceID。这保持 `injectAgentConfig` **纯函数**（不查 store、不解析 JSON，易测试）——store 查询与 JSON 解析集中在 bridge helper，`injectAgentConfig` 只做「有 overrides → `LoadForWorkspace`，无 → `Load`」的分流。
 
 ---
 
@@ -341,12 +348,13 @@ func ValidateOverrides(raw string) (map[string]string, error)
 |---|---|
 | `internal/agentconfig/loader.go` | 新增 `LoadForWorkspace` + `applyOverrides` |
 | `internal/agentconfig/validate.go`（新） | `ValidateOverrides`（JSON/键/类型/size 校验） |
-| `internal/agentconfig/loader_test.go`（新或扩展） | `LoadForWorkspace` + 回归测试 |
-| `internal/gateway/bridge_worker.go` | `workerLaunchParams` 加 `workspaceOverrides`；`injectAgentConfig` 签名 + 分流；`:82` 透传 |
-| `internal/gateway/api.go` | `CreateSession` 取 workspace overrides → 解析 → 填 params |
-| `internal/gateway/bridge.go` / resume 路径 | worker 重启时填 workspace overrides（实现计划细化调用点） |
+| `internal/agentconfig/loader_test.go`（扩展） | `LoadForWorkspace` + `ValidateOverrides` + `Load` 回归测试 |
+| `internal/gateway/deps.go` | `BridgeDeps` 加 `WSStore WorkspaceOverridesReader` 字段 |
+| `internal/gateway/bridge.go` | 新增 `WorkspaceOverridesReader` 接口 + `resolveWorkspaceOverrides` helper；StartSession(:189)/resume(:297) 调用点填 `workspaceOverrides` |
+| `internal/gateway/bridge_worker.go` | `workerLaunchParams` 加 `workspaceOverrides`；fresh-start(:213) 调用点填；`injectAgentConfig` 签名 + 分流；`:82` 透传 |
+| `cmd/hotplex/gateway_run.go` | NewBridge 调用(:260) 传 `WSStore: deps.WorkspaceStore` |
 | `internal/gateway/workspace_handlers.go` | PATCH `agent_config_overrides` 加三层校验 |
-| `internal/gateway/workspace_handlers_test.go`（新或扩展） | PATCH 校验测试 |
+| `internal/gateway/workspace_handlers_test.go`（扩展） | PATCH 校验测试 |
 
 **无新迁移**（复用 spec ① `017_multitenancy_tables.sql:23` 的 `agent_config_overrides` 列）。
 

--- a/docs/specs/WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md
@@ -1,0 +1,382 @@
+# WebChat 多租户 spec ②：per-workspace agent-configs 自定义（两层继承）
+
+**日期**: 2026-06-16
+**状态**: Draft（待实现计划）
+**分支**: main · **基线**: spec ① 已合入（[PR #746](https://github.com/hrygo/hotplex/pull/746)，`44f461ff`）
+**范围**: WebChat 轨 agent-configs 从全局/Bot 级共享升级为 **per-workspace 两层继承**（团队默认 → workspace 自定义）
+**关联设计**: [`WebChat-Multitenancy-Foundation-Design-Spec.md`](./WebChat-Multitenancy-Foundation-Design-Spec.md)（spec ①）、[`WebChat-Multitenancy-Roadmap-Spec.md`](./WebChat-Multitenancy-Roadmap-Spec.md)（路线图 §4 spec ②）
+**作者**: brainstorming session → 设计文档
+
+---
+
+## 目录
+
+- [1. 背景与现状](#1-背景与现状)
+- [2. 目标与非目标](#2-目标与非目标)
+- [3. 关键决策汇总](#3-关键决策汇总)
+- [4. 数据模型与 JSON Schema](#4-数据模型与-json-schema)
+- [5. 两层继承解析（LoadForWorkspace）](#5-两层继承解析loadforworkspace)
+- [6. 双轨隔离](#6-双轨隔离)
+- [7. 数据流打通](#7-数据流打通)
+- [8. PATCH 校验与 API](#8-patch-校验与-api)
+- [9. META-COGNITION 约束与安全](#9-meta-cognition-约束与安全)
+- [10. 错误码](#10-错误码)
+- [11. 测试策略](#11-测试策略)
+- [12. 受影响文件清单](#12-受影响文件清单)
+- [13. 后续 spec 路线](#13-后续-spec-路线)
+
+---
+
+## 1. 背景与现状
+
+spec ①（地基）已交付真实用户身份、workspace 实体、会话隔离与多租户配额框架，并为 spec ② 预留了关键扩展点：
+
+| 预留点 | 现状 | 证据 |
+|---|---|---|
+| `workspaces.agent_config_overrides` 列 | 已建（TEXT，spec ① 留 NULL） | `internal/session/sql/migrations/017_multitenancy_tables.sql:23` |
+| `Workspace.AgentConfigOverrides` Go 字段 | 已声明，原样存取 | `internal/session/multitenancy_store.go:18`（`GetWorkspaceByID` :211 / `UpdateWorkspace` :244） |
+| workspace PATCH 接受该字段 | 已通，**无任何校验** | `internal/gateway/workspace_handlers.go:130,162-163` |
+
+**当前 agent-configs 注入链（spec ① 未改动，仍是 Message Channel 轨的三级 fallback）**：
+
+```
+workerLaunchParams{platform, botName, injectExclude}          // bridge_worker.go:31-40（无 workspace 维度）
+  → createAndLaunchWorker (bridge_worker.go:82)
+    → injectAgentConfig(info, platform, botName, botID, exclude)  // bridge_worker.go:328-364
+      → agentconfig.Load(dir, platform, botName, exclude...)      // loader.go:53
+        → resolveFile: bot → platform → global（每文件命中即终止） // loader.go:177-216
+      → BuildSystemPrompt(configs) → info.SystemPrompt            // prompt.go:24
+```
+
+WebChat 会话当前 `botName=""`（`bridge_worker.go:333` 注释），走 `platform="webchat"` → global。**`workerLaunchParams` 完全无 workspace 概念**——这是 spec ② 要打通的核心。
+
+**核心结论**：agent-configs 解析目前是单一目录三级 fallback，无 per-workspace 维度。spec ② 在不动 Message Channel 轨的前提下，为 WebChat 轨新增独立的 workspace 级配置继承路径。
+
+---
+
+## 2. 目标与非目标
+
+### 2.1 目标（本 spec 范围）
+
+1. **workspace 级 agent-configs 定制**：WebChat 轨每个 workspace 拥有独立的 SOUL/AGENTS/SKILLS/USER/MEMORY 覆盖，覆盖团队默认。
+2. **两层继承**：团队默认（全局目录）→ workspace 自定义（DB JSON），逐文件覆盖。
+3. **双轨隔离**：Message Channel 轨（Slack/Feishu）的三级 fallback 链零改动。
+4. **META-COGNITION 不可覆盖**：Worker 身份边界由 go:embed 强制注入，workspace 无法触及。
+5. **校验闭环**：workspace PATCH 对 `agent_config_overrides` 做 JSON/键白名单/size 三层校验。
+
+### 2.2 非目标（明确排除）
+
+| 项 | 归属 |
+|---|---|
+| WebChat 前端配置编辑 UI | spec ⑥ |
+| admin 锁定某些文件禁止 workspace 覆盖 | YAGNI，未来增量（§3 决策 5） |
+| per-user 层（用户级配置） | 永不（spec ① §2.4 拍板两层，无 per-user） |
+| Message Channel 引入 workspace 配置 | 永不（双轨完全隔离） |
+| workspace 级 worker 选择 | spec ③（独立 spec） |
+| 配置版本控制 / 变更审计 | YAGNI |
+
+---
+
+## 3. 关键决策汇总
+
+| 决策点 | 选择 | 理由 |
+|---|---|---|
+| 存储形式 | **DB JSON**（`agent_config_overrides` 列，spec ① 已建） | WebChat 用户经浏览器无法写服务器文件系统；spec ⑥ 前端编辑 UI 必须走 API→DB；per-workspace 隔离由 `owner_user_id` 天然保证；备份/迁移随 DB |
+| 继承语义 | **逐文件覆盖**（命中即终止） | 与现有 `resolveFile` 语义完全一致；可预测；不叠加突破 40KB 总量上限 |
+| 可覆盖范围 | **全部 5 文件**（SOUL/AGENTS/SKILLS/USER/MEMORY） | 与团队默认文件集合一致；受信用户（admin 邀请制）对自己 workspace 负责；底线由 META-COGNITION 保证 |
+| 解析入口 | **新增 `LoadForWorkspace` 独立函数** | 双轨物理隔离最彻底；`Load` 零改动向后兼容；符合 spec ① §5「接口扩展而非替换」 |
+| JSON 结构 | **flat map**（文件名 → 内容） | 键即文件名，与 `resolveFile`/`injectExclude` 按文件名模型零映射成本 |
+| admin 锁定机制 | **不做**（YAGNI） | 第一版全开放；未来如需「锁定 AGENTS.md」可增量加 `locked_files` 字段 |
+| 数据流载体 | `workerLaunchParams` 携带已解析 `workspaceOverrides map` | 保持 `injectAgentConfig` 纯函数（无 store 依赖），与现有设计一致 |
+
+---
+
+## 4. 数据模型与 JSON Schema
+
+### 4.1 列与结构
+
+复用 spec ① 已建列，**无新迁移**：
+
+- `workspaces.agent_config_overrides TEXT`（nullable，JSON 字符串）
+- `Workspace.AgentConfigOverrides string`（Go，原样存取，`multitenancy_store.go:18`）
+
+### 4.2 JSON Schema：flat map
+
+```json
+{
+  "SOUL.md":   "你是一个资深 Go 工程师，重视简洁与可读性...",
+  "AGENTS.md": "本项目使用 tab 缩进；测试用 testify/require...",
+  "SKILLS.md": "可调用 /commit、/review 等技能...",
+  "USER.md":   "用户偏好简洁回复，中文沟通",
+  "MEMORY.md": "上周讨论了 session key 改造方案..."
+}
+```
+
+- **键**：文件名，大小写敏感，限定白名单 `{"SOUL.md","AGENTS.md","SKILLS.md","USER.md","MEMORY.md"}`（即 `loader.go:121` 的 `configFiles`）。
+- **值**：文件内容字符串。不经过 `stripFrontmatter`（DB 是用户/API 直接编辑的内容，非文件场景）；`<` 注入防护由 `BuildSystemPrompt` 的 `sanitize()` 统一执行（`prompt.go:126`）。
+- **空值语义**：`{"SOUL.md":""}` 与缺省 `SOUL.md` 键等价——该文件继承团队默认（逐文件覆盖仅对非空值生效）。
+
+### 4.3 size 约束
+
+与 loader 完全一致，PATCH 入口强制校验：
+
+| 约束 | 值 | 常量 |
+|---|---|---|
+| 单文件 | ≤ 8 000 chars | `agentconfig.MaxFileChars`（`loader.go:34`） |
+| 总量 | ≤ 40 000 chars | `agentconfig.MaxTotalChars`（`loader.go:37`） |
+
+---
+
+## 5. 两层继承解析（LoadForWorkspace）
+
+### 5.1 函数签名（新增，`internal/agentconfig/loader.go`）
+
+```go
+// LoadForWorkspace resolves agent configs for the WebChat track using two-level
+// inheritance: team defaults (from dir) → workspace overrides (DB JSON).
+//
+// Team defaults are loaded via Load with botName="" (WebChat sessions don't select
+// a bot, spec ① §2.4). Each non-empty override entry replaces the corresponding
+// team-default field. injectExclude takes highest priority: an excluded file is
+// never injected even if overridden.
+//
+// The Message Channel track continues to call Load directly; this function is
+// WebChat-only and never alters Load's behavior.
+func LoadForWorkspace(dir, platform string, overrides map[string]string, injectExclude ...string) (*AgentConfigs, error)
+```
+
+### 5.2 解析逻辑
+
+```
+1. base := Load(dir, platform, "", injectExclude...)     // 团队默认，复用现有三级 fallback
+2. for file ∈ configFiles (SOUL/AGENTS/SKILLS/USER/MEMORY):
+     v := overrides[file]
+     if v != "" && !shouldExclude(file, injectExclude):
+         base.<field> = v                                  // 逐文件覆盖
+3. return base
+```
+
+- **白名单过滤**：overrides 中不在 `configFiles` 的键静默忽略（防御性，PATCH 入口已拒未知键，此处为纵深防御）。
+- **exclude 优先级最高**：被 `injectExclude` 命中的文件，即使 override 了也不注入（与现有 `Load` 的 exclude 语义一致，`loader.go:72-75`）。
+- **产出直接喂 `BuildSystemPrompt`**：组装逻辑零改动，META-COGNITION 仍由 `buildHotplexMetacognition()` 独立注入首位（§9）。
+
+### 5.3 错误降级
+
+- `Load`（团队默认）失败：返回 error（与现有行为一致，由 `injectAgentConfig` 记日志并跳过注入）。
+- overrides 解析在调用方完成（见 §7），`LoadForWorkspace` 收到的已是 `map[string]string`，无 JSON 解析失败路径。
+
+---
+
+## 6. 双轨隔离
+
+| 轨 | 解析路径 | 触发条件 |
+|---|---|---|
+| **WebChat** | `LoadForWorkspace(dir, "webchat", overrides, exclude...)` | `workspaceOverrides != nil` |
+| **Message Channel**（Slack/Feishu） | `Load(dir, platform, botName, exclude...)`（不变） | `workspaceOverrides == nil` |
+
+**隔离保证**：
+- `Load` 函数体、签名、所有现有调用方（Slack/Feishu 适配器、cron executor 等）零改动。
+- `LoadForWorkspace` 是 WebChat 专属新增，内部以 `Load` 为底座，不引入任何 Message Channel 会走的代码路径。
+- 单元测试须显式回归 `Load` 行为不变（§11）。
+
+---
+
+## 7. 数据流打通
+
+### 7.1 注入时机：每次 worker 启动
+
+与现有 `Load` 一致——`injectAgentConfig` 在每次 `createAndLaunchWorker`（`bridge_worker.go:82`）调用时执行，覆盖**新建**与 **resume 重启**两条路径。因此 workspace overrides 每次 worker 启动重新解析，天然反映最新配置（配置仅在 session 初始化 / `/reset` 生效，运行中改不立即生效的语义不变，见 CLAUDE.md「配置热更新」）。
+
+### 7.2 `workerLaunchParams` 扩展
+
+```go
+type workerLaunchParams struct {
+    ctx                context.Context
+    wt                 worker.WorkerType
+    workerInfo         worker.SessionInfo
+    platform           string
+    botID              string
+    botName            string
+    forwardOpts        *forwardOpts
+    injectExclude      []string
+    workspaceOverrides map[string]string // 新增：WebChat 轨 workspace 配置覆盖；nil = Message Channel 轨走 Load
+}
+```
+
+### 7.3 调用方填充 overrides
+
+- **CreateSession**（`api.go`）：已在 spec ① 查 workspace 取 `work_dir`（`api.go:266-276`），顺手取 `AgentConfigOverrides` → 解析为 `map[string]string` → 填入 `workerLaunchParams.WorkspaceOverrides`。
+- **resume 路径**（worker 重启）：从 `session.workspace_id` 查 workspace 取 overrides 填入。具体调用点在实现计划细化。
+- 解析失败（DB 中 JSON 损坏）：`log.Warn` + 降级为 `nil`（走团队默认 `Load`），不阻断 worker 启动。
+
+### 7.4 `injectAgentConfig` 分流
+
+```go
+func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botName, botID string, injectExclude []string, workspaceOverrides map[string]string) {
+    // ... 现有 agentConfigDir == "" / exclude 校验不变 ...
+    var configs *agentconfig.AgentConfigs
+    if workspaceOverrides != nil {
+        configs, err = agentconfig.LoadForWorkspace(b.agentConfigDir, platform, workspaceOverrides, injectExclude...)
+    } else {
+        configs, err = agentconfig.Load(b.agentConfigDir, platform, botName, injectExclude...)
+    }
+    // ... 现有 BuildSystemPrompt → info.SystemPrompt 不变 ...
+}
+```
+
+`createAndLaunchWorker:82` 透传 `params.workspaceOverrides`。
+
+### 7.5 设计选择：传 map 而非 workspaceID
+
+保持 `injectAgentConfig` **纯函数**（无 store 依赖，易测试），与现有设计一致。调用方负责查询解析；`Bridge` 不新增 workspace store 依赖。
+
+---
+
+## 8. PATCH 校验与 API
+
+### 8.1 三层校验（当前 `workspace_handlers.go:162-163` 零校验）
+
+`PATCH /api/workspaces/{id}` 的 `agent_config_overrides` 字段补充：
+
+1. **JSON 解析**：`json.Unmarshal([]byte(raw), &m)` 失败 → 400 `INVALID_CONFIG_JSON`。
+2. **键白名单**：遍历 `m`，键不在 `agentconfig.KnownFiles()`（`loader.go:124`）→ 400 `UNKNOWN_CONFIG_FILE`（含未知键列表）。
+3. **值类型 + size**：值非 `string` → 400；单值 `len > MaxFileChars` 或总量 `sum > MaxTotalChars` → 400 `CONFIG_TOO_LARGE`。
+
+校验通过后存原始 JSON 字符串（`UpdateWorkspace` 原样存，不变）。
+
+### 8.2 校验函数位置
+
+新增 `internal/agentconfig/validate.go`（或 loader.go 内）：
+
+```go
+// ValidateOverrides parses raw JSON and validates keys/types/sizes.
+// Returns the parsed map on success, or an error describing the first violation.
+func ValidateOverrides(raw string) (map[string]string, error)
+```
+
+`workspace_handlers.go` PATCH 调用它；`CreateSession`/resume 路径的解析也复用（统一入口，避免重复逻辑）。
+
+### 8.3 API 契约
+
+`PATCH /api/workspaces/{id}` body（spec ① 已有，本 spec 补校验）：
+
+```json
+{ "agent_config_overrides": "{\"SOUL.md\":\"...\",\"USER.md\":\"...\"}" }
+```
+
+- 字段是 **JSON 字符串**（嵌套 JSON），与 `Workspace.AgentConfigOverrides string` 存储一致。
+- **清除语义（两层，须区分）**：
+  - **字段层级**（整个 `agent_config_overrides`）：空 JSON 对象 `"{}"` = 清除所有覆盖（全继承团队默认）；省略字段或空字符串 `""` = 不更新（保持原值，与 spec ① PATCH `if req.AgentConfigOverrides != ""` 语义一致，`workspace_handlers.go:162`）。
+  - **文件层级**（JSON 内单个键）：`{"SOUL.md":""}` 与缺省 `SOUL.md` 键等价——该文件继承团队默认（见 §4.2、§5.2，逐文件覆盖仅对非空值生效）。
+
+---
+
+## 9. META-COGNITION 约束与安全
+
+### 9.1 META-COGNITION 不可覆盖（物理保证）
+
+- `META-COGNITION.md` 经 `prompt.go:9` go:embed，在 `BuildSystemPrompt` 内由 `buildHotplexMetacognition()`（`prompt.go:116`）独立注入为 B 通道 `<hotplex>` 首位。
+- 它**不在 `configFiles` 白名单**（`loader.go:121` 仅 5 文件），故：
+  - PATCH 校验阶段：`META-COGNITION.md` 键被白名单拒绝 → 400。
+  - `LoadForWorkspace` 阶段：即使 overrides 含该键，白名单过滤静默忽略。
+- workspace overrides 只能改 `AgentConfigs` 的 5 字段，无法触及 META-COGNITION。
+
+### 9.2 B/C 通道约束
+
+- `BuildSystemPrompt` 的 B/C 通道组装逻辑（`prompt.go:33-83`）零改动。
+- workspace 可覆盖 B 通道文件（SOUL/AGENTS/SKILLS）与 C 通道文件（USER/MEMORY），但 B 通道「无条件覆盖 C 通道」的冲突法则由 `BuildSystemPrompt` 的 XML 结构（`<directives>` 先于 `<context>`）保证，不受 overrides 来源影响。
+
+### 9.3 XML 注入防护
+
+所有 overrides 值经 `sanitize()`（`prompt.go:126`）转义保留标签（`agent-configuration`/`directives`/`persona` 等，`prompt.go:118-121`），与现有文件内容同等防护。
+
+---
+
+## 10. 错误码
+
+沿用项目 `AppError{Code,...}` 模式（`.agents/rules/golang.md`）。新增：
+
+| Code | HTTP | 场景 |
+|---|---|---|
+| `INVALID_CONFIG_JSON` | 400 | `agent_config_overrides` 非合法 JSON |
+| `UNKNOWN_CONFIG_FILE` | 400 | overrides 含非白名单键 |
+| `CONFIG_TOO_LARGE` | 400 | 单文件 > 8KB 或总量 > 40KB |
+| `INVALID_CONFIG_VALUE` | 400 | overrides 值类型非 string |
+
+配额/归属错误复用 spec ① 已有码（`WORKSPACE_FORBIDDEN` 等）。
+
+---
+
+## 11. 测试策略
+
+遵循项目规范（`CLAUDE.md` + `.agents/rules/golang.md`）：table-driven + `testify/require` + `t.Parallel()`，单模块 ≤5s（`-count=1 -race`），禁 `time.Sleep`。
+
+### 11.1 单元测试
+
+| 模块 | 要点 |
+|---|---|
+| `LoadForWorkspace` | 全覆盖（5 文件全 override）/ 部分覆盖（仅 SOUL）/ 全继承（overrides 空）/ exclude 与 override 交互（exclude 优先）/ 白名单过滤（未知键忽略）/ 空值不覆盖 |
+| `ValidateOverrides` | 合法 JSON / 非法 JSON / 未知键 / 值类型错误 / 单文件超 8KB / 总量超 40KB / 空字符串 |
+| `Load` 回归 | 现有三级 fallback 测试零改动通过（双轨隔离证据） |
+| `BuildSystemPrompt` | overrides 经 LoadForWorkspace 产出后，META-COGNITION 仍首位、B/C 结构正确 |
+
+### 11.2 集成测试（隔离核心）
+
+构造两个 workspace 各自不同 overrides，断言：
+- 各自 session 的 `info.SystemPrompt` 反映各自 overrides。
+- 一个 workspace 改 overrides 不影响另一个。
+- workspace 无 overrides 时注入纯团队默认。
+- Message Channel 轨 session（`workspaceOverrides=nil`）注入与 spec ① 完全一致。
+
+### 11.3 PATCH 校验测试
+
+- 合法 flat map → 200 + 存储正确。
+- 非法 JSON / 未知键（如 `META-COGNITION.md`、`foo.md`）/ 超 size / 值类型错误 → 对应 400 + DB 未修改。
+
+---
+
+## 12. 受影响文件清单
+
+| 文件 | 改动类型 |
+|---|---|
+| `internal/agentconfig/loader.go` | 新增 `LoadForWorkspace` + `applyOverrides` |
+| `internal/agentconfig/validate.go`（新） | `ValidateOverrides`（JSON/键/类型/size 校验） |
+| `internal/agentconfig/loader_test.go`（新或扩展） | `LoadForWorkspace` + 回归测试 |
+| `internal/gateway/bridge_worker.go` | `workerLaunchParams` 加 `workspaceOverrides`；`injectAgentConfig` 签名 + 分流；`:82` 透传 |
+| `internal/gateway/api.go` | `CreateSession` 取 workspace overrides → 解析 → 填 params |
+| `internal/gateway/bridge.go` / resume 路径 | worker 重启时填 workspace overrides（实现计划细化调用点） |
+| `internal/gateway/workspace_handlers.go` | PATCH `agent_config_overrides` 加三层校验 |
+| `internal/gateway/workspace_handlers_test.go`（新或扩展） | PATCH 校验测试 |
+
+**无新迁移**（复用 spec ① `017_multitenancy_tables.sql:23` 的 `agent_config_overrides` 列）。
+
+（精确行号在实现计划 phase 细化。）
+
+---
+
+## 13. 后续 spec 路线
+
+本 spec（spec ②）落地后，按路线图 §3 阶段 B/C 推进：
+
+- **spec ③**（workspace 级 worker 选择）：与 spec ② 共享 `workerLaunchParams` 的 workspace 数据流扩展（本 spec 搭建 workspace 配置注入管道，spec ③ 的 `worker_preference` 可复用同一打通路径）。`CreateSession` 已消费 `worker_preference`（`api.go:266-276`），spec ③ 主要补白名单校验。
+- **spec ④**（OAuth/SSO）：独立，与本 spec 无依赖。
+- **spec ⑥**（前端一等公民化）：消费本 spec 的 `agent_config_overrides` PATCH API，提供 workspace 配置编辑 UI。
+
+---
+
+## 附录 A：与 spec ① 的衔接
+
+| spec ① 预留点 | spec ② 消费方式 |
+|---|---|
+| `workspaces.agent_config_overrides` 列 | 存 flat map JSON |
+| `Workspace.AgentConfigOverrides` 字段 | store 原样存取，PATCH 校验后写入 |
+| workspace PATCH 接受该字段 | 补三层校验（§8） |
+| `workerLaunchParams` 无 workspace 维度 | 加 `workspaceOverrides map`（§7.2） |
+| `injectAgentConfig` 无 workspace 分流 | 加 `LoadForWorkspace` 分支（§7.4） |
+
+## 附录 B：固化参数（非 Open Question）
+
+1. **JSON 结构**：flat map（文件名 → 内容），已定（§3）。
+2. **size 上限**：复用 `MaxFileChars=8000` / `MaxTotalChars=40000`，已定。
+3. **未知键策略**：PATCH 拒绝（400），`LoadForWorkspace` 忽略（纵深防御），已定。
+4. **空值语义**：等价缺省，继承团队默认，已定。

--- a/docs/specs/WebChat-Multitenancy-Roadmap-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-Roadmap-Spec.md
@@ -1,7 +1,7 @@
 # WebChat 一等公民化与多租户路线图
 
 **日期**: 2026-06-16
-**状态**: spec ① 已合入（[PR #746](https://github.com/hrygo/hotplex/pull/746)，`44f461ff`）；spec ② 实现完成待 review（[PR #748](https://github.com/hrygo/hotplex/pull/748)）；③-⑥ 待逐个 brainstorm
+**状态**: spec ① 已合入（[PR #746](https://github.com/hrygo/hotplex/pull/746)，`44f461ff`）；spec ② 已合入（[PR #748](https://github.com/hrygo/hotplex/pull/748)）；③-⑥ 待逐个 brainstorm
 **分支**: main · **基线版本**: v1.29.0 (fb857af1)
 **关联设计**: [`WebChat-Multitenancy-Foundation-Design-Spec.md`](./WebChat-Multitenancy-Foundation-Design-Spec.md)（spec ①）
 
@@ -81,7 +81,7 @@ PR #746 最新 review（基线 `68b1660`）早于 R6，其 **P1 阻塞项已在 
 
 | spec | 标题 | 依赖 | 核心改动 |
 |---|---|---|---|
-| ② | per-workspace agent-configs 自定义 | ① | ✅ 实现完成待 review（[PR #748](https://github.com/hrygo/hotplex/pull/748)）：`LoadForWorkspace` 双轨隔离 + Bridge `WSStore` helper + PATCH 三层校验，[设计](./WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md) |
+| ② | per-workspace agent-configs 自定义 | ① | ✅ 已合入（[PR #748](https://github.com/hrygo/hotplex/pull/748)）：`LoadForWorkspace` 双轨隔离 + Bridge `WSStore` helper + PATCH 三层校验，[设计](./WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md) |
 | ③ | workspace 级 worker 选择 | ① | worker_type fallback 链（WebChat 轨：团队默认 → workspace）+ API，填充 `workspaces.worker_preference` |
 | ④ | OAuth/SSO provider 落地 | ① | `IdentityProvider` 第二实现（飞书/Slack/OIDC） |
 
@@ -211,8 +211,8 @@ PR #746 最新 review（基线 `68b1660`）早于 R6，其 **P1 阻塞项已在 
 ## 7. 推进节奏
 
 - 每个 spec 独立 brainstorm → 设计文档（`docs/specs/`）→ writing-plans → 实现。
-- spec ① 已合入（PR #746）。spec ② 实现完成待 review（PR #748）。spec ③④ 可并行启动。
+- spec ① 已合入（PR #746）。spec ② 已合入（PR #748）。spec ③④ 可并行启动。
 - spec ⑥ 在 ②③④就绪后启动。
 - 路线图文档随各 spec 推进更新状态。
 
-**下一步**：PR #748（spec ②）待 review 合入 → 启动 spec ③④ brainstorm（workspace 级 worker 选择 / OAuth SSO，互不依赖可并行；spec ③ `CreateSession` 已消费 `worker_preference`，主要补白名单校验，工作量最小）。spec ⑤⑥ 待 ③④ 就绪。spec ① 剩余增量（迁移验证 / 旧 webchat 会话清理 / e2e）可穿插提交。
+**下一步**：spec ② 已合入（PR #748）→ 启动 spec ③④ brainstorm（workspace 级 worker 选择 / OAuth SSO，互不依赖可并行；spec ③ `CreateSession` 已消费 `worker_preference`，主要补白名单校验，工作量最小）。spec ⑤⑥ 待 ③④ 就绪。spec ① 剩余增量（迁移验证 / 旧 webchat 会话清理 / e2e）可穿插提交。

--- a/docs/specs/WebChat-Multitenancy-Roadmap-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-Roadmap-Spec.md
@@ -1,7 +1,7 @@
 # WebChat 一等公民化与多租户路线图
 
 **日期**: 2026-06-16
-**状态**: spec ① 实现完成 Phase 0-7 + review 修复 R4-R9（[PR #746](https://github.com/hrygo/hotplex/pull/746)，P1 阻塞项已修待 re-review）；②-⑥ 待逐个 brainstorm
+**状态**: spec ① 已合入（[PR #746](https://github.com/hrygo/hotplex/pull/746)，`44f461ff`）；spec ② 实现完成待 review（[PR #748](https://github.com/hrygo/hotplex/pull/748)）；③-⑥ 待逐个 brainstorm
 **分支**: main · **基线版本**: v1.29.0 (fb857af1)
 **关联设计**: [`WebChat-Multitenancy-Foundation-Design-Spec.md`](./WebChat-Multitenancy-Foundation-Design-Spec.md)（spec ①）
 
@@ -54,11 +54,11 @@
 
 ## 3. 阶段规划
 
-### 阶段 A：地基（spec ① 实现完成，待合入）
+### 阶段 A：地基（spec ① 已合入）
 
 | spec | 标题 | 状态 | 文档 |
 |---|---|---|---|
-| ① | 身份 + workspace + 隔离 | ✅ 实现完成 Phase 0-7 + review 修复 R4-R9（[PR #746](https://github.com/hrygo/hotplex/pull/746)，待 re-review） | [foundation-design](./WebChat-Multitenancy-Foundation-Design-Spec.md) |
+| ① | 身份 + workspace + 隔离 | ✅ 已合入（[PR #746](https://github.com/hrygo/hotplex/pull/746)，`44f461ff`） | [foundation-design](./WebChat-Multitenancy-Foundation-Design-Spec.md) |
 
 阶段 A 已交付（PR #746）：WebChat 后端具备真实用户身份、workspace 实体、会话隔离（ListSessions SQL 级 workspace 过滤 + authorizeSession 二次校验）、多租户配额（PoolManager 全局 + per-user + per-workspace 三层并发）。`make check` 通过。剩余增量（迁移验证测试 / 旧 webchat 会话清理 / e2e 集成测试）作为 spec ① 后续提交，不阻塞阶段 B 启动。
 
@@ -81,7 +81,7 @@ PR #746 最新 review（基线 `68b1660`）早于 R6，其 **P1 阻塞项已在 
 
 | spec | 标题 | 依赖 | 核心改动 |
 |---|---|---|---|
-| ② | per-workspace agent-configs 自定义 | ① | 改造 `loader.go`，WebChat 轨走两层（团队默认 → workspace 自定义） |
+| ② | per-workspace agent-configs 自定义 | ① | ✅ 实现完成待 review（[PR #748](https://github.com/hrygo/hotplex/pull/748)）：`LoadForWorkspace` 双轨隔离 + Bridge `WSStore` helper + PATCH 三层校验，[设计](./WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md) |
 | ③ | workspace 级 worker 选择 | ① | worker_type fallback 链（WebChat 轨：团队默认 → workspace）+ API，填充 `workspaces.worker_preference` |
 | ④ | OAuth/SSO provider 落地 | ① | `IdentityProvider` 第二实现（飞书/Slack/OIDC） |
 
@@ -211,8 +211,8 @@ PR #746 最新 review（基线 `68b1660`）早于 R6，其 **P1 阻塞项已在 
 ## 7. 推进节奏
 
 - 每个 spec 独立 brainstorm → 设计文档（`docs/specs/`）→ writing-plans → 实现。
-- spec ① 已实现完成（Phase 0-7，PR #746），合入后启动 spec ②③④（可并行）。
+- spec ① 已合入（PR #746）。spec ② 实现完成待 review（PR #748）。spec ③④ 可并行启动。
 - spec ⑥ 在 ②③④就绪后启动。
 - 路线图文档随各 spec 推进更新状态。
 
-**下一步**：PR #746 re-review 合入（P1 AttachWorker race 已在 R6 修复，R7 安全/质量加固，R8 剩余 P3 + conn.go 自死锁）→ 启动 spec ②③④ brainstorm（per-workspace agent-configs / workspace 级 worker 选择 / OAuth SSO，三者互不依赖可并行）。spec ① 剩余增量（迁移验证 / 旧 webchat 会话清理 / e2e）可穿插提交。
+**下一步**：PR #748（spec ②）待 review 合入 → 启动 spec ③④ brainstorm（workspace 级 worker 选择 / OAuth SSO，互不依赖可并行；spec ③ `CreateSession` 已消费 `worker_preference`，主要补白名单校验，工作量最小）。spec ⑤⑥ 待 ③④ 就绪。spec ① 剩余增量（迁移验证 / 旧 webchat 会话清理 / e2e）可穿插提交。

--- a/docs/superpowers/plans/2026-06-16-webchat-multitenancy-spec2-per-workspace-agent-configs.md
+++ b/docs/superpowers/plans/2026-06-16-webchat-multitenancy-spec2-per-workspace-agent-configs.md
@@ -1,0 +1,1019 @@
+# WebChat 多租户 spec ②（per-workspace agent-configs）实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 WebChat 轨的 agent-configs（SOUL/AGENTS/SKILLS/USER/MEMORY）支持 per-workspace 两层继承（团队默认 → workspace 自定义），同一团队不同 workspace 各自定制，互不影响；Message Channel 轨行为零变化。
+
+**Architecture:** `agentconfig` 包新增 `LoadForWorkspace`（复用 `Load` 取团队默认，再逐文件覆盖）+ `ValidateOverrides`（JSON/键/类型/size 校验）。`gateway` 包给 `Bridge` 加窄接口 `WorkspaceOverridesReader` 依赖 + `resolveWorkspaceOverrides` helper，在 3 个 worker 启动调用点（StartSession / resume / fresh-start）统一解析 workspace overrides；`workerLaunchParams` 携带已解析 map，`injectAgentConfig` 纯函数分流（有 overrides → `LoadForWorkspace`，无 → `Load`）。`workspace_handlers` PATCH 补三层校验。复用 spec ① `agent_config_overrides` 列，无新迁移。
+
+**Tech Stack:** Go 1.22+、`encoding/json`、`testify/require`（table-driven + `t.Parallel()`）、`httptest`。
+
+**关联设计:** [`../specs/WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md`](../specs/WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md)
+
+**验收方式:** Go 单元 + 集成测试（`-count=1 -race`，单模块 ≤5s）。核心：两 workspace 不同 overrides → 各自 session 注入不同 system prompt；`Load` 与 Message Channel 轨行为零变化。
+
+---
+
+## 关键设计决策（执行时不可偏离）
+
+| 决策 | 值 | 来源 |
+|---|---|---|
+| 存储形式 | DB JSON flat map（`agent_config_overrides` 列，spec ① 已建） | spec §3/§4 |
+| 继承语义 | 逐文件覆盖（命中即终止，与 `resolveFile` 一致） | spec §3/§5 |
+| 可覆盖范围 | 全部 5 文件；`META-COGNITION.md` 不在白名单，物理不可覆盖 | spec §3/§9 |
+| 解析入口 | 新增 `LoadForWorkspace` 独立函数；`Load` 零改动 | spec §3/§6 |
+| 数据流 | Bridge 加窄接口 `WSStore` + helper；`workerLaunchParams` 携已解析 map；`injectAgentConfig` 纯函数 | spec §7 |
+| 清除语义 | `"{}"` = 清除覆盖；`""`/省略 = 不更新（与 spec ① PATCH 一致） | spec §8.3 |
+| 未知键 | PATCH 拒绝（400）；`LoadForWorkspace` 忽略（纵深防御） | spec §5/§8 |
+
+## 文件结构
+
+| 文件 | 责任 | 改动 |
+|---|---|---|
+| `internal/agentconfig/validate.go` | `ValidateOverrides` + sentinel errors | 新建 |
+| `internal/agentconfig/validate_test.go` | 校验单测 | 新建 |
+| `internal/agentconfig/loader.go` | `LoadForWorkspace` + `applyOverrides` | 修改 |
+| `internal/agentconfig/loader_test.go` | `LoadForWorkspace` 单测 + `Load` 回归 | 扩展 |
+| `internal/gateway/deps.go` | `WorkspaceOverridesReader` 接口 + `BridgeDeps.WSStore` | 修改 |
+| `internal/gateway/bridge.go` | `Bridge.wsStore` 字段 + NewBridge 注入 + 2 调用点接线 | 修改 |
+| `internal/gateway/bridge_worker.go` | `resolveWorkspaceOverrides` helper + `workerLaunchParams` 字段 + `injectAgentConfig` 分流 + 2 调用点接线 | 修改 |
+| `internal/gateway/bridge_worker_test.go` | helper 单测（mock WSStore） | 新建 |
+| `cmd/hotplex/gateway_run.go` | NewBridge（:260）传 `WSStore` | 修改 |
+| `internal/gateway/workspace_handlers.go` | PATCH 三层校验 | 修改 |
+| `internal/gateway/workspace_handlers_test.go` | PATCH 校验测试 | 扩展 |
+
+## 依赖方向
+
+```
+cmd/hotplex ──▶ gateway ──▶ agentconfig   (单向，已有)
+```
+
+`agentconfig` 包不依赖 `gateway`/`session`（`ValidateOverrides`/`LoadForWorkspace` 是纯函数）。`gateway` 依赖 `agentconfig`（已存在）+ `session`（`WorkspaceOverridesReader` 返回 `*session.Workspace`，已存在）。
+
+## 测试规范（所有任务通用）
+
+- table-driven + `testify/require` + `t.Parallel()`
+- 禁 `time.Sleep`；单模块 ≤5s（`-count=1 -race`）
+- 临时目录用 `t.TempDir()`；文件写入用现有 `writeFile(t, dir, name, content)` helper（见 `loader_test.go`）
+
+---
+
+## Task 1: `ValidateOverrides` + sentinel errors（agentconfig 包）
+
+**Files:**
+- Create: `internal/agentconfig/validate.go`
+- Test: `internal/agentconfig/validate_test.go`
+
+- [ ] **Step 1: 写失败测试**
+
+创建 `internal/agentconfig/validate_test.go`：
+
+```go
+package agentconfig
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr error // sentinel; nil expects success
+		want    map[string]string
+	}{
+		{
+			name: "empty raw returns nil map",
+			raw:  "",
+			want: nil,
+		},
+		{
+			name: "valid flat map with subset of files",
+			raw:  `{"SOUL.md":"persona","USER.md":"profile"}`,
+			want: map[string]string{"SOUL.md": "persona", "USER.md": "profile"},
+		},
+		{
+			name:    "invalid JSON",
+			raw:     `{not json`,
+			wantErr: ErrInvalidConfigJSON,
+		},
+		{
+			name:    "unknown key rejected",
+			raw:     `{"META-COGNITION.md":"x"}`,
+			wantErr: ErrUnknownConfigFile,
+		},
+		{
+			name:    "unknown arbitrary key rejected",
+			raw:     `{"foo.md":"x"}`,
+			wantErr: ErrUnknownConfigFile,
+		},
+		{
+			name:    "non-string value rejected",
+			raw:     `{"SOUL.md":123}`,
+			wantErr: ErrInvalidConfigValue,
+		},
+		{
+			name:    "single file exceeds MaxFileChars",
+			raw:     `{"SOUL.md":"` + strings.Repeat("a", MaxFileChars+1) + `"}`,
+			wantErr: ErrConfigTooLarge,
+		},
+		{
+			name:    "total exceeds MaxTotalChars",
+			raw:     `{"SOUL.md":"` + strings.Repeat("a", MaxTotalChars+1) + `"}`,
+			wantErr: ErrConfigTooLarge,
+		},
+		{
+			name: "empty object clears overrides",
+			raw:  `{}`,
+			want: map[string]string{},
+		},
+		{
+			name: "all five known files accepted",
+			raw:  `{"SOUL.md":"s","AGENTS.md":"a","SKILLS.md":"k","USER.md":"u","MEMORY.md":"m"}`,
+			want: map[string]string{"SOUL.md": "s", "AGENTS.md": "a", "SKILLS.md": "k", "USER.md": "u", "MEMORY.md": "m"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidateOverrides(tt.raw)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: 运行测试验证失败**
+
+Run: `go test ./internal/agentconfig/ -run TestValidateOverrides -count=1`
+Expected: 编译失败 / FAIL（`ValidateOverrides` 及 sentinel errors 未定义）。
+
+- [ ] **Step 3: 实现 `ValidateOverrides`**
+
+创建 `internal/agentconfig/validate.go`：
+
+```go
+package agentconfig
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for agent-config override validation (spec ② §10).
+var (
+	ErrInvalidConfigJSON  = errors.New("agentconfig: invalid config JSON")
+	ErrUnknownConfigFile  = errors.New("agentconfig: unknown config file")
+	ErrConfigTooLarge     = errors.New("agentconfig: config exceeds size limit")
+	ErrInvalidConfigValue = errors.New("agentconfig: invalid config value")
+)
+
+// ValidateOverrides parses raw JSON into a flat map of config-file-name → content
+// and validates keys (against configFiles), value types (must be string), and size
+// limits (MaxFileChars per file, MaxTotalChars total). Returns the parsed map on
+// success. Empty raw ("") returns (nil, nil) meaning "no overrides".
+//
+// Used by the workspace PATCH handler (write-time validation) and Bridge's
+// resolveWorkspaceOverrides (read-time parsing). META-COGNITION.md is not in
+// configFiles, so it is rejected here — workspace overrides cannot touch it.
+func ValidateOverrides(raw string) (map[string]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidConfigJSON, err)
+	}
+	known := make(map[string]struct{}, len(configFiles))
+	for _, f := range configFiles {
+		known[f] = struct{}{}
+	}
+	out := make(map[string]string, len(m))
+	var total int
+	for k, v := range m {
+		if _, ok := known[k]; !ok {
+			return nil, fmt.Errorf("%w: %q", ErrUnknownConfigFile, k)
+		}
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("%w: %q must be a string", ErrInvalidConfigValue, k)
+		}
+		if len(s) > MaxFileChars {
+			return nil, fmt.Errorf("%w: %q is %d chars, max %d", ErrConfigTooLarge, k, len(s), MaxFileChars)
+		}
+		total += len(s)
+		out[k] = s
+	}
+	if total > MaxTotalChars {
+		return nil, fmt.Errorf("%w: total %d chars exceeds max %d", ErrConfigTooLarge, total, MaxTotalChars)
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: 运行测试验证通过**
+
+Run: `go test ./internal/agentconfig/ -run TestValidateOverrides -count=1 -race`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add internal/agentconfig/validate.go internal/agentconfig/validate_test.go
+git commit -m "feat(agentconfig): ValidateOverrides for per-workspace config (spec ②)"
+```
+
+---
+
+## Task 2: `LoadForWorkspace` + `applyOverrides`（agentconfig 包）
+
+**Files:**
+- Modify: `internal/agentconfig/loader.go`（追加函数）
+- Test: `internal/agentconfig/loader_test.go`（追加测试）
+
+- [ ] **Step 1: 写失败测试**
+
+追加到 `internal/agentconfig/loader_test.go` 末尾：
+
+```go
+func TestLoadForWorkspace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil overrides inherits team defaults", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "team-soul")
+		writeFile(t, dir, "AGENTS.md", "team-rules")
+
+		cfg, err := LoadForWorkspace(dir, "webchat", nil)
+		require.NoError(t, err)
+		require.Equal(t, "team-soul", cfg.Soul)
+		require.Equal(t, "team-rules", cfg.Agents)
+	})
+
+	t.Run("override replaces team default per-file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "team-soul")
+		writeFile(t, dir, "AGENTS.md", "team-rules")
+
+		overrides := map[string]string{"SOUL.md": "ws-soul"}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides)
+		require.NoError(t, err)
+		require.Equal(t, "ws-soul", cfg.Soul)         // overridden
+		require.Equal(t, "team-rules", cfg.Agents)    // inherited
+	})
+
+	t.Run("empty override value inherits team default", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "team-soul")
+
+		overrides := map[string]string{"SOUL.md": ""}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides)
+		require.NoError(t, err)
+		require.Equal(t, "team-soul", cfg.Soul) // empty value does not override
+	})
+
+	t.Run("override without team default applies", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir() // no team files
+
+		overrides := map[string]string{"USER.md": "ws-user"}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides)
+		require.NoError(t, err)
+		require.Equal(t, "ws-user", cfg.User)
+	})
+
+	t.Run("injectExclude wins over override", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "team-soul")
+
+		overrides := map[string]string{"SOUL.md": "ws-soul"}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides, "SOUL.md")
+		require.NoError(t, err)
+		require.Empty(t, cfg.Soul) // excluded even though overridden
+	})
+
+	t.Run("unknown override keys ignored (defense-in-depth)", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		overrides := map[string]string{"META-COGNITION.md": "evil", "foo.md": "x", "SOUL.md": "ws-soul"}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides)
+		require.NoError(t, err)
+		require.Equal(t, "ws-soul", cfg.Soul)
+		// unknown keys silently ignored; META-COGNITION never appears in AgentConfigs
+	})
+
+	t.Run("platform-level team default resolves before override", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "webchat/AGENTS.md", "webchat-team-rules") // platform-level
+
+		overrides := map[string]string{"SOUL.md": "ws-soul"}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides)
+		require.NoError(t, err)
+		require.Equal(t, "ws-soul", cfg.Soul)                  // override
+		require.Equal(t, "webchat-team-rules", cfg.Agents)     // platform-level team default
+	})
+}
+```
+
+- [ ] **Step 2: 运行测试验证失败**
+
+Run: `go test ./internal/agentconfig/ -run TestLoadForWorkspace -count=1`
+Expected: 编译失败（`LoadForWorkspace` 未定义）。
+
+- [ ] **Step 3: 实现 `LoadForWorkspace` + `applyOverrides`**
+
+在 `internal/agentconfig/loader.go` 末尾（`IsEmpty` 方法后）追加：
+
+```go
+// LoadForWorkspace resolves WebChat-track agent configs via two-level inheritance:
+// team defaults (loaded from dir via Load with botName="") → workspace overrides.
+//
+// Each non-empty override entry replaces the corresponding team-default field.
+// injectExclude has highest priority: an excluded file is never injected even if
+// overridden. Unknown override keys are silently ignored (defense-in-depth —
+// ValidateOverrides rejects them at write time).
+//
+// The Message Channel track calls Load directly; this function is WebChat-only.
+// See design spec §5.
+func LoadForWorkspace(dir, platform string, overrides map[string]string, injectExclude ...string) (*AgentConfigs, error) {
+	base, err := Load(dir, platform, "", injectExclude...)
+	if err != nil {
+		return nil, err
+	}
+	applyOverrides(base, overrides, injectExclude)
+	return base, nil
+}
+
+// applyOverrides applies per-file overrides onto base in place. Only keys in
+// configFiles are applied; empty values do not override; excluded files are skipped.
+func applyOverrides(base *AgentConfigs, overrides map[string]string, injectExclude []string) {
+	set := func(baseName, val string, target *string) {
+		if val == "" || shouldExclude(baseName, injectExclude) {
+			return
+		}
+		*target = val
+	}
+	for k, v := range overrides {
+		switch k {
+		case "SOUL.md":
+			set(k, v, &base.Soul)
+		case "AGENTS.md":
+			set(k, v, &base.Agents)
+		case "SKILLS.md":
+			set(k, v, &base.Skills)
+		case "USER.md":
+			set(k, v, &base.User)
+		case "MEMORY.md":
+			set(k, v, &base.Memory)
+		}
+	}
+}
+```
+
+- [ ] **Step 4: 运行测试验证通过**
+
+Run: `go test ./internal/agentconfig/ -count=1 -race`
+Expected: PASS（含 `TestLoadForWorkspace` 全部子测试 + `TestLoad` 等现有测试回归通过——`Load` 行为零变化）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add internal/agentconfig/loader.go internal/agentconfig/loader_test.go
+git commit -m "feat(agentconfig): LoadForWorkspace two-level inheritance (spec ②)"
+```
+
+---
+
+## Task 3: `WorkspaceOverridesReader` 接口 + `BridgeDeps.WSStore`（gateway 包）
+
+**Files:**
+- Modify: `internal/gateway/deps.go`（`BridgeDeps` 加字段 + 接口定义）
+- Modify: `internal/gateway/bridge.go`（`Bridge.wsStore` 字段 + NewBridge 注入）
+- Test: `internal/gateway/bridge_worker_test.go`（新建，helper 单测；Task 4 加 helper 本体）
+
+> 本 task 只加接口 + 字段 + 注入接线，helper 本体在 Task 4（与 injectAgentConfig 分流一起，因 helper 与 injectAgentConfig 都在 bridge_worker.go，紧邻）。本 task 的测试在 Task 4 完成后才能跑通——故 Task 3 步骤 4 改为编译验证，Task 4 步骤 4 一起跑 helper 测试。
+
+- [ ] **Step 1: 加接口 + BridgeDeps 字段**
+
+在 `internal/gateway/deps.go` 顶部 import 区确认有 `context` 与 `session`（若无可参考同文件其他类型引用；该文件已为 gateway 包内部，`session` 通常已引用）。在 `BridgeDeps` struct 末尾（`AgentConfigExclude` 字段后）追加字段，并在文件合适位置定义接口：
+
+```go
+// WorkspaceOverridesReader is the narrow workspace-store subset Bridge needs to
+// resolve per-workspace agent-config overrides (spec ② §7.3). Kept separate from
+// session.UserWorkspaceStore so tests mock a single method.
+type WorkspaceOverridesReader interface {
+	GetWorkspaceByID(ctx context.Context, id string) (*session.Workspace, error)
+}
+```
+
+`BridgeDeps` 末尾追加：
+
+```go
+	WSStore WorkspaceOverridesReader // WebChat per-workspace agent-config overrides (spec ②); nil = disabled
+```
+
+若 `deps.go` 未 import `context`/`session`，补 import。若不确定，运行 `go build ./internal/gateway/` 按报错补。
+
+- [ ] **Step 2: Bridge struct 加字段 + NewBridge 注入**
+
+在 `internal/gateway/bridge.go` 的 `Bridge` struct（:42 起）中，`agentConfigDir` 字段附近追加：
+
+```go
+	wsStore            WorkspaceOverridesReader // per-workspace agent-config overrides resolver (spec ②); nil = Message Channel track
+```
+
+在 `NewBridge`（:96 起）的 `&Bridge{...}` 初始化块中（`agentConfigDir: deps.AgentConfigDir,` 行附近）追加：
+
+```go
+		wsStore:            deps.WSStore,
+```
+
+- [ ] **Step 3: 编译验证**
+
+Run: `go build ./internal/gateway/ ./cmd/hotplex/`
+Expected: PASS。`BridgeDeps.WSStore` 与 `Bridge.wsStore` 字段新增但本 task 未被读取（helper 在 Task 4）——Go struct 字段允许未被使用，不报错。`cmd/hotplex` 的 NewBridge 调用尚未传 `WSStore`，零值为 nil，编译通过（`BridgeDeps` 字段在字面量中可省略）。
+
+- [ ] **Step 4: 暂不提交**（与 Task 4 合并提交，保持每次提交可编译可测试）
+
+---
+
+## Task 4: `resolveWorkspaceOverrides` helper + `workerLaunchParams` + `injectAgentConfig` 分流 + 调用点接线
+
+**Files:**
+- Modify: `internal/gateway/bridge_worker.go`（helper + workerLaunchParams + injectAgentConfig + :82 + fresh-start :213）
+- Modify: `internal/gateway/bridge.go`（StartSession :189 + resume :297 调用点）
+- Test: `internal/gateway/bridge_worker_test.go`（新建）
+
+- [ ] **Step 1: 写 helper 失败测试**
+
+创建 `internal/gateway/bridge_worker_test.go`（`testLogger` 在本文件内定义；若 gateway 包已有同名 helper，执行时将其删除并复用现有那个）：
+
+```go
+package gateway
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/agentconfig"
+	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/worker"
+)
+
+// testLogger returns a minimal logger for bridge unit tests. If the gateway
+// package already defines a *slog.Logger test helper, delete this and reuse it.
+func testLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	return slog.Default()
+}
+
+// stubWSStore implements WorkspaceOverridesReader for bridge helper tests.
+type stubWSStore struct {
+	ws  *session.Workspace
+	err error
+}
+
+func (s *stubWSStore) GetWorkspaceByID(_ context.Context, _ string) (*session.Workspace, error) {
+	return s.ws, s.err
+}
+
+// newBridgeForOverrideTest builds a minimal Bridge with only wsStore + log set,
+// enough to exercise resolveWorkspaceOverrides without the full dependency graph.
+func newBridgeForOverrideTest(t *testing.T, ws *session.Workspace, err error) *Bridge {
+	t.Helper()
+	return &Bridge{
+		log:     testLogger(t),
+		wsStore: &stubWSStore{ws: ws, err: err},
+	}
+}
+
+func TestResolveWorkspaceOverrides(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty workspace id returns nil", func(t *testing.T) {
+		t.Parallel()
+		b := newBridgeForOverrideTest(t, nil, nil)
+		require.Nil(t, b.resolveWorkspaceOverrides(""))
+	})
+
+	t.Run("nil wsStore returns nil", func(t *testing.T) {
+		t.Parallel()
+		b := &Bridge{log: testLogger(t)} // wsStore zero-value nil
+		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+	})
+
+	t.Run("valid overrides parsed", func(t *testing.T) {
+		t.Parallel()
+		ws := &session.Workspace{ID: "ws-1", AgentConfigOverrides: `{"SOUL.md":"x","USER.md":"y"}`}
+		b := newBridgeForOverrideTest(t, ws, nil)
+		got := b.resolveWorkspaceOverrides("ws-1")
+		require.Equal(t, map[string]string{"SOUL.md": "x", "USER.md": "y"}, got)
+	})
+
+	t.Run("empty overrides string returns nil", func(t *testing.T) {
+		t.Parallel()
+		ws := &session.Workspace{ID: "ws-1", AgentConfigOverrides: ""}
+		b := newBridgeForOverrideTest(t, ws, nil)
+		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+	})
+
+	t.Run("store error degrades to nil", func(t *testing.T) {
+		t.Parallel()
+		b := newBridgeForOverrideTest(t, nil, errors.New("boom"))
+		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+	})
+
+	t.Run("invalid JSON degrades to nil", func(t *testing.T) {
+		t.Parallel()
+		ws := &session.Workspace{ID: "ws-1", AgentConfigOverrides: `{bad`}
+		b := newBridgeForOverrideTest(t, ws, nil)
+		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+	})
+}
+
+// testLogger returns a minimal slog.Logger for bridge tests. If gateway package
+// already has a test helper returning *slog.Logger, prefer it; otherwise use slog.Default.
+// (If a name clash occurs, rename this helper.)
+```
+
+> **注意 `testLogger`：** 若 gateway 包测试已有返回 `*slog.Logger` 的 helper（grep `func.*Logger.*testing.T` in `internal/gateway/*_test.go`），复用它并删除本文件中的 `testLogger`；否则在本文件追加：
+> ```go
+> import "log/slog"
+> func testLogger(t *testing.T) *slog.Logger { t.Helper(); return slog.Default() }
+> ```
+
+- [ ] **Step 2: 运行测试验证失败**
+
+Run: `go test ./internal/gateway/ -run TestResolveWorkspaceOverrides -count=1`
+Expected: 编译失败（`resolveWorkspaceOverrides` 未定义）。
+
+- [ ] **Step 3: 实现 helper + workerLaunchParams + injectAgentConfig 分流**
+
+**3a.** 在 `internal/gateway/bridge_worker.go` 的 `workerLaunchParams` struct（:31 起）末尾追加字段：
+
+```go
+	workspaceOverrides map[string]string // WebChat per-workspace config overrides (spec ②); nil = Message Channel track → Load
+```
+
+**3b.** 在 `bridge_worker.go` 中 `injectAgentConfig` 上方追加 helper：
+
+```go
+// resolveWorkspaceOverrides fetches a workspace's agent-config overrides and parses
+// them. Returns nil for empty workspaceID (Message Channel track) or nil wsStore, and
+// degrades to nil (team defaults) on any fetch/parse error — never blocks worker launch.
+// See design spec §7.3.
+func (b *Bridge) resolveWorkspaceOverrides(workspaceID string) map[string]string {
+	if workspaceID == "" || b.wsStore == nil {
+		return nil
+	}
+	ws, err := b.wsStore.GetWorkspaceByID(context.Background(), workspaceID)
+	if err != nil {
+		b.log.Warn("bridge: fetch workspace overrides failed, degrading to team defaults",
+			"workspace_id", workspaceID, "err", err)
+		return nil
+	}
+	overrides, err := agentconfig.ValidateOverrides(ws.AgentConfigOverrides)
+	if err != nil {
+		b.log.Warn("bridge: parse workspace overrides failed, degrading to team defaults",
+			"workspace_id", workspaceID, "err", err)
+		return nil
+	}
+	return overrides
+}
+```
+
+**3c.** 改 `injectAgentConfig` 签名（:328）加 `workspaceOverrides map[string]string` 末参，并在 `agentconfig.Load` 调用处分流。当前 :341 一行：
+
+```go
+	configs, err := agentconfig.Load(b.agentConfigDir, platform, botName, injectExclude...)
+```
+
+替换为：
+
+```go
+	var configs *agentconfig.AgentConfigs
+	if workspaceOverrides != nil {
+		configs, err = agentconfig.LoadForWorkspace(b.agentConfigDir, platform, workspaceOverrides, injectExclude...)
+	} else {
+		configs, err = agentconfig.Load(b.agentConfigDir, platform, botName, injectExclude...)
+	}
+```
+
+并修改函数签名行（:328）：
+
+```go
+func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botName, botID string, injectExclude []string, workspaceOverrides map[string]string) {
+```
+
+> 注意：`botName` 在 `workspaceOverrides != nil` 分支不再传给 Load（LoadForWorkspace 内部用 `botName=""`）。这正确——WebChat 会话不选 Bot（spec ① §2.4）。
+
+**3d.** 改 `createAndLaunchWorker`（:82）透传：
+
+当前 :82：
+```go
+	b.injectAgentConfig(&params.workerInfo, params.platform, params.botName, params.botID, params.injectExclude)
+```
+改为：
+```go
+	b.injectAgentConfig(&params.workerInfo, params.platform, params.botName, params.botID, params.injectExclude, params.workspaceOverrides)
+```
+
+- [ ] **Step 4: 接线 3 个调用点填 workspaceOverrides**
+
+**4a.** `internal/gateway/bridge.go` StartSession（:189 起 `workerLaunchParams{...}`）末尾（`injectExclude: p.InjectExclude,` 后）追加：
+
+```go
+		workspaceOverrides: b.resolveWorkspaceOverrides(p.WorkspaceID),
+```
+
+**4b.** `internal/gateway/bridge.go` resume（:297 起 `workerLaunchParams{...}`）末尾（`forwardOpts: &opts,` 后）追加：
+
+```go
+		workspaceOverrides: b.resolveWorkspaceOverrides(si.WorkspaceID),
+```
+
+**4c.** `internal/gateway/bridge_worker.go` fresh-start（:213 起 `workerLaunchParams{...}`）末尾（`injectExclude: nil,` 后）追加：
+
+```go
+		workspaceOverrides: b.resolveWorkspaceOverrides(si.WorkspaceID),
+```
+
+- [ ] **Step 5: 运行 helper 测试 + 全 gateway 编译**
+
+Run: `go test ./internal/gateway/ -run TestResolveWorkspaceOverrides -count=1 -race`
+Expected: PASS。
+
+Run: `go build ./internal/gateway/`
+Expected: PASS（3 调用点接线后编译通过）。
+
+- [ ] **Step 6: 回归现有 gateway 测试**
+
+Run: `go test ./internal/gateway/ -count=1 -race -short`
+Expected: PASS（Message Channel 轨行为零变化；workspaceOverrides 在非 WebChat 会话为 nil → 走原 Load 路径）。
+
+- [ ] **Step 7: 提交（Task 3 + Task 4 合并）**
+
+```bash
+git add internal/gateway/deps.go internal/gateway/bridge.go internal/gateway/bridge_worker.go internal/gateway/bridge_worker_test.go
+git commit -m "feat(gateway): bridge resolves per-workspace agent-config overrides (spec ②)
+
+BridgeDeps 加窄接口 WSStore + resolveWorkspaceOverrides helper；3 个 worker
+启动调用点（StartSession/resume/fresh-start）统一解析 workspace overrides；
+workerLaunchParams 携已解析 map；injectAgentConfig 纯函数分流 LoadForWorkspace/Load。"
+```
+
+---
+
+## Task 5: NewBridge 调用点传 `WSStore`（cmd/hotplex）
+
+**Files:**
+- Modify: `cmd/hotplex/gateway_run.go:260`（NewBridge 调用）
+
+- [ ] **Step 1: 传入 WSStore**
+
+在 `cmd/hotplex/gateway_run.go` 的 `gateway.NewBridge(gateway.BridgeDeps{...})` 调用块（:260 起）末尾（`AgentConfigExclude: buildAgentConfigExclude(cfg),` 后）追加：
+
+```go
+		WSStore:            deps.WorkspaceStore,
+```
+
+> `deps.WorkspaceStore` 已存在（`gateway_run.go:78` `GatewayDeps.WorkspaceStore session.UserWorkspaceStore`），且 `session.UserWorkspaceStore` 含 `GetWorkspaceByID`，满足 `WorkspaceOverridesReader` 接口（结构化类型匹配，无需显式适配）。
+
+- [ ] **Step 2: 编译验证全项目**
+
+Run: `go build ./...`
+Expected: PASS。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add cmd/hotplex/gateway_run.go
+git commit -m "feat(cmd): wire WorkspaceStore into Bridge for spec ② overrides"
+```
+
+---
+
+## Task 6: PATCH 三层校验（gateway 包）
+
+**Files:**
+- Modify: `internal/gateway/workspace_handlers.go`（Update 方法 :162-164）
+- Test: `internal/gateway/workspace_handlers_test.go`（追加）
+
+- [ ] **Step 1: 写失败测试**
+
+追加到 `internal/gateway/workspace_handlers_test.go`。先加一个 helper（若文件无类似 PATCH helper）：
+
+```go
+func (e *testAuthEnv) patchWorkspace(t *testing.T, cookie, id, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPatch, "/api/workspaces/"+id, bytes.NewReader([]byte(body)))
+	req.SetPathValue("id", id)
+	req.Header.Set("Cookie", cookie)
+	w := httptest.NewRecorder()
+	e.wsHandlers.Update(w, req)
+	return w
+}
+```
+
+追加测试函数：
+
+```go
+func TestWorkspace_PatchAgentConfigOverrides_Validation(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	cookie := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+	ws := env.createWorkspace(t, cookie, "proj", "/tmp/hotplex-ws-patch")
+
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "valid overrides accepted",
+			body:       `{"agent_config_overrides":"{\"SOUL.md\":\"x\",\"USER.md\":\"y\"}"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "empty object clears overrides",
+			body:       `{"agent_config_overrides":"{}"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid JSON rejected",
+			body:       `{"agent_config_overrides":"{not json"}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "INVALID_CONFIG_JSON",
+		},
+		{
+			name:       "unknown key rejected",
+			body:       `{"agent_config_overrides":"{\"META-COGNITION.md\":\"x\"}"}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "UNKNOWN_CONFIG_FILE",
+		},
+		{
+			name:       "non-string value rejected",
+			body:       `{"agent_config_overrides":"{\"SOUL.md\":123}"}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "INVALID_CONFIG_VALUE",
+		},
+		{
+			name:       "oversized file rejected",
+			body:       `{"agent_config_overrides":"{\"SOUL.md\":\"" + strings.Repeat("a", 8001) + "\"}"}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "CONFIG_TOO_LARGE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			w := env.patchWorkspace(t, cookie, ws.ID, tt.body)
+			require.Equal(t, tt.wantStatus, w.Code, "body=%s", w.Body.String())
+			if tt.wantCode != "" {
+				require.Contains(t, w.Body.String(), tt.wantCode)
+			}
+		})
+	}
+}
+
+// TestWorkspace_PatchAgentConfigOverrides_Persists verifies a valid override is
+// stored and round-trips through Get.
+func TestWorkspace_PatchAgentConfigOverrides_Persists(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	cookie := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+	ws := env.createWorkspace(t, cookie, "proj", "/tmp/hotplex-ws-persist")
+
+	w := env.patchWorkspace(t, cookie, ws.ID, `{"agent_config_overrides":"{\"SOUL.md\":\"ws-soul\"}"}`)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Get round-trips the stored JSON
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+ws.ID, nil)
+	req.SetPathValue("id", ws.ID)
+	req.Header.Set("Cookie", cookie)
+	gr := httptest.NewRecorder()
+	env.wsHandlers.Get(gr, req)
+	require.Equal(t, http.StatusOK, gr.Code)
+	require.Contains(t, gr.Body.String(), `"SOUL.md":"ws-soul"`)
+}
+```
+
+> **import：** 测试文件顶部补 `"strings"`（若未有）。
+
+- [ ] **Step 2: 运行测试验证失败**
+
+Run: `go test ./internal/gateway/ -run TestWorkspace_PatchAgentConfigOverrides -count=1`
+Expected: 部分 FAIL——当前 :162-164 无校验，非法 JSON / 未知键 / 超 size / 类型错误 均返回 200 而非 400。
+
+- [ ] **Step 3: 实现三层校验**
+
+在 `internal/gateway/workspace_handlers.go` 顶部 import 区加 `"github.com/hrygo/hotplex/internal/agentconfig"`（`errors` 已在文件 import 中）。
+
+替换 `Update` 方法中 :162-164 三行：
+
+```go
+	if req.AgentConfigOverrides != "" {
+		ws.AgentConfigOverrides = req.AgentConfigOverrides
+	}
+```
+
+为：
+
+```go
+	if req.AgentConfigOverrides != "" {
+		if _, err := agentconfig.ValidateOverrides(req.AgentConfigOverrides); err != nil {
+			switch {
+			case errors.Is(err, agentconfig.ErrInvalidConfigJSON):
+				writeAppError(w, http.StatusBadRequest, "INVALID_CONFIG_JSON", err.Error())
+			case errors.Is(err, agentconfig.ErrUnknownConfigFile):
+				writeAppError(w, http.StatusBadRequest, "UNKNOWN_CONFIG_FILE", err.Error())
+			case errors.Is(err, agentconfig.ErrConfigTooLarge):
+				writeAppError(w, http.StatusBadRequest, "CONFIG_TOO_LARGE", err.Error())
+			default:
+				writeAppError(w, http.StatusBadRequest, "INVALID_CONFIG_VALUE", err.Error())
+			}
+			return
+		}
+		ws.AgentConfigOverrides = req.AgentConfigOverrides
+	}
+```
+
+- [ ] **Step 4: 运行测试验证通过**
+
+Run: `go test ./internal/gateway/ -run TestWorkspace_PatchAgentConfigOverrides -count=1 -race`
+Expected: PASS（全部子测试）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add internal/gateway/workspace_handlers.go internal/gateway/workspace_handlers_test.go
+git commit -m "feat(gateway): validate workspace agent_config_overrides on PATCH (spec ②)"
+```
+
+---
+
+## Task 7: 端到端隔离集成测试（两 workspace 不同 overrides）
+
+**Files:**
+- Test: `internal/gateway/api_workspace_session_test.go`（扩展）或新建 `internal/gateway/bridge_overrides_integration_test.go`
+
+> 此测试验证完整链路：workspace overrides → bridge helper → LoadForWorkspace → 不同 system prompt。因 `injectAgentConfig` 依赖 `agentConfigDir` 文件 + worker 启动，纯单测较重；采用「直接验证 LoadForWorkspace 与 helper 组合」的轻量集成。
+
+- [ ] **Step 1: 写集成测试**
+
+新建 `internal/gateway/bridge_overrides_integration_test.go`（复用 Task 4 `bridge_worker_test.go` 中定义的 `testLogger` 与 `stubWSStore`，同包无需重复定义）：
+
+```go
+package gateway
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/agentconfig"
+	"github.com/hrygo/hotplex/internal/session"
+)
+
+// TestBridge_TwoWorkspaces_DifferentOverrides verifies the core spec ② invariant:
+// two workspaces with different overrides produce different system prompts, and
+// neither pollutes the other nor the team default.
+func TestBridge_TwoWorkspaces_DifferentOverrides(t *testing.T) {
+	t.Parallel()
+
+	// Team defaults on disk (global level).
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("team-rules"), 0o644))
+
+	wsA := &session.Workspace{ID: "ws-a", AgentConfigOverrides: `{"SOUL.md":"persona-A"}`}
+	wsB := &session.Workspace{ID: "ws-b", AgentConfigOverrides: `{"SOUL.md":"persona-B"}`}
+	storeA := &stubWSStore{ws: wsA}
+	storeB := &stubWSStore{ws: wsB}
+
+	promptA := buildPromptFor(t, dir, storeA, "ws-a")
+	promptB := buildPromptFor(t, dir, storeB, "ws-b")
+
+	require.Contains(t, promptA, "persona-A")
+	require.NotContains(t, promptA, "persona-B")
+	require.Contains(t, promptB, "persona-B")
+	require.NotContains(t, promptB, "persona-A")
+	// Both inherit team default AGENTS.md
+	require.Contains(t, promptA, "team-rules")
+	require.Contains(t, promptB, "team-rules")
+}
+
+// TestBridge_WorkspaceWithoutOverrides_InheritsTeamDefault verifies a workspace
+// with empty overrides falls fully back to team defaults.
+func TestBridge_WorkspaceWithoutOverrides_InheritsTeamDefault(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SOUL.md"), []byte("team-soul"), 0o644))
+
+	ws := &session.Workspace{ID: "ws-x", AgentConfigOverrides: ""}
+	store := &stubWSStore{ws: ws}
+
+	prompt := buildPromptFor(t, dir, store, "ws-x")
+	require.Contains(t, prompt, "team-soul")
+}
+
+// buildPromptFor exercises the same data path as injectAgentConfig:
+// resolveWorkspaceOverrides → LoadForWorkspace → BuildSystemPrompt.
+func buildPromptFor(t *testing.T, dir string, store *stubWSStore, workspaceID string) string {
+	t.Helper()
+	b := &Bridge{log: testLogger(t), wsStore: store, agentConfigDir: dir}
+	overrides := b.resolveWorkspaceOverrides(workspaceID)
+	require.NotNil(t, overrides)
+	cfg, err := agentconfig.LoadForWorkspace(dir, "webchat", overrides)
+	require.NoError(t, err)
+	return agentconfig.BuildSystemPrompt(cfg)
+}
+```
+
+- [ ] **Step 2: 运行测试**
+
+Run: `go test ./internal/gateway/ -run TestBridge_TwoWorkspaces -count=1 -race` 和 `go test ./internal/gateway/ -run TestBridge_WorkspaceWithoutOverrides -count=1 -race`
+Expected: PASS。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add internal/gateway/bridge_overrides_integration_test.go
+git commit -m "test(gateway): two-workspace agent-config isolation (spec ② e2e)"
+```
+
+---
+
+## Task 8: 全量质量门禁
+
+- [ ] **Step 1: 格式 + vet + mod**
+
+Run: `make fmt && go vet ./... && go mod verify`
+Expected: 无变更 / PASS。
+
+- [ ] **Step 2: lint**
+
+Run: `make lint`
+Expected: PASS（关注 agentconfig/gateway 新代码）。
+
+- [ ] **Step 3: 全量测试（含 race）**
+
+Run: `make test`
+Expected: PASS。重点确认：
+- `./internal/agentconfig/` 全绿（`TestValidateOverrides` / `TestLoadForWorkspace` / `TestLoad` 回归）
+- `./internal/gateway/` 全绿（`TestResolveWorkspaceOverrides` / `TestWorkspace_PatchAgentConfigOverrides*` / `TestBridge_TwoWorkspaces*` / 现有 workspace/auth/session 测试回归）
+
+- [ ] **Step 4: 完整 CI 等价**
+
+Run: `make check`
+Expected: PASS。
+
+- [ ] **Step 5: （可选）手动 curl 冒烟（需 gateway 运行）**
+
+```bash
+# 创建 workspace、登录 cookie 后：
+curl -X PATCH localhost:PORT/api/workspaces/<id> \
+  -H "Cookie: <cookie>" \
+  -d '{"agent_config_overrides":"{\"SOUL.md\":\"test-persona\"}"}'
+# 期望 200；再用该 workspace 创建 session，观察日志 "agent config injected" + prompt 含 test-persona
+```
+
+> 若无运行环境，跳过此步——Task 1-7 的自动化测试已覆盖正确性。
+
+---
+
+## 完成标准
+
+- [ ] `ValidateOverrides` + `LoadForWorkspace` 实现并通过单测
+- [ ] `Load` 与 Message Channel 轨现有测试零回归（双轨隔离证据）
+- [ ] Bridge 3 个 worker 启动调用点统一经 `resolveWorkspaceOverrides` 解析 overrides
+- [ ] `injectAgentConfig` 按 `workspaceOverrides` 分流，纯函数
+- [ ] `cmd/hotplex` 注入 `WSStore`，全项目编译通过
+- [ ] PATCH `agent_config_overrides` 三层校验（JSON/键/类型/size）
+- [ ] 两 workspace 不同 overrides 端到端隔离测试通过
+- [ ] `make check` 全绿
+- [ ] 每个任务独立 commit，提交信息符合项目规范

--- a/internal/agentconfig/loader.go
+++ b/internal/agentconfig/loader.go
@@ -305,10 +305,7 @@ func applyOverrides(base *AgentConfigs, overrides map[string]string, injectExclu
 		if val == "" || shouldExclude(baseName, injectExclude) {
 			return
 		}
-		// Strip frontmatter defensively — overrides are API-edited content that may
-		// be pasted from files; the file track strips via Load, this mirrors it so
-		// raw --- blocks never leak into the system prompt. See spec §4.2.
-		*target = stripFrontmatter(val)
+		*target = val
 	}
 	for k, v := range overrides {
 		switch k {
@@ -346,9 +343,6 @@ func enforceTotalLimit(c *AgentConfigs) {
 	for _, f := range fields {
 		n := len(*f.target)
 		if rem := MaxTotalChars - total; n > rem {
-			if rem < 0 {
-				rem = 0
-			}
 			slog.Warn("agentconfig: merged config exceeds total limit after overrides, truncated",
 				"file", f.name, "original", n, "remaining", rem, "limit", MaxTotalChars)
 			*f.target = (*f.target)[:rem]

--- a/internal/agentconfig/loader.go
+++ b/internal/agentconfig/loader.go
@@ -277,3 +277,47 @@ func (c *AgentConfigs) IsEmpty() bool {
 	return c.Soul == "" && c.Agents == "" && c.Skills == "" &&
 		c.User == "" && c.Memory == ""
 }
+
+// LoadForWorkspace resolves WebChat-track agent configs via two-level inheritance:
+// team defaults (loaded from dir via Load with botName="") → workspace overrides.
+//
+// Each non-empty override entry replaces the corresponding team-default field.
+// injectExclude has highest priority: an excluded file is never injected even if
+// overridden. Unknown override keys are silently ignored (defense-in-depth —
+// ValidateOverrides rejects them at write time).
+//
+// The Message Channel track calls Load directly; this function is WebChat-only.
+// See design spec §5.
+func LoadForWorkspace(dir, platform string, overrides map[string]string, injectExclude ...string) (*AgentConfigs, error) {
+	base, err := Load(dir, platform, "", injectExclude...)
+	if err != nil {
+		return nil, err
+	}
+	applyOverrides(base, overrides, injectExclude)
+	return base, nil
+}
+
+// applyOverrides applies per-file overrides onto base in place. Only keys in
+// configFiles are applied; empty values do not override; excluded files are skipped.
+func applyOverrides(base *AgentConfigs, overrides map[string]string, injectExclude []string) {
+	set := func(baseName, val string, target *string) {
+		if val == "" || shouldExclude(baseName, injectExclude) {
+			return
+		}
+		*target = val
+	}
+	for k, v := range overrides {
+		switch k {
+		case "SOUL.md":
+			set(k, v, &base.Soul)
+		case "AGENTS.md":
+			set(k, v, &base.Agents)
+		case "SKILLS.md":
+			set(k, v, &base.Skills)
+		case "USER.md":
+			set(k, v, &base.User)
+		case "MEMORY.md":
+			set(k, v, &base.Memory)
+		}
+	}
+}

--- a/internal/agentconfig/loader.go
+++ b/internal/agentconfig/loader.go
@@ -294,6 +294,7 @@ func LoadForWorkspace(dir, platform string, overrides map[string]string, injectE
 		return nil, err
 	}
 	applyOverrides(base, overrides, injectExclude)
+	enforceTotalLimit(base)
 	return base, nil
 }
 
@@ -304,7 +305,10 @@ func applyOverrides(base *AgentConfigs, overrides map[string]string, injectExclu
 		if val == "" || shouldExclude(baseName, injectExclude) {
 			return
 		}
-		*target = val
+		// Strip frontmatter defensively — overrides are API-edited content that may
+		// be pasted from files; the file track strips via Load, this mirrors it so
+		// raw --- blocks never leak into the system prompt. See spec §4.2.
+		*target = stripFrontmatter(val)
 	}
 	for k, v := range overrides {
 		switch k {
@@ -319,5 +323,37 @@ func applyOverrides(base *AgentConfigs, overrides map[string]string, injectExclu
 		case "MEMORY.md":
 			set(k, v, &base.Memory)
 		}
+	}
+}
+
+// enforceTotalLimit truncates merged config fields so the combined size stays within
+// MaxTotalChars. Load already enforces this on team defaults, but overrides can grow
+// individual fields beyond the budget (write-side ValidateOverrides caps each override
+// at MaxFileChars, not the merged total); this re-checks the merged result as
+// defense-in-depth. Truncates in field order (SOUL→AGENTS→SKILLS→USER→MEMORY).
+func enforceTotalLimit(c *AgentConfigs) {
+	fields := []struct {
+		name   string
+		target *string
+	}{
+		{"SOUL.md", &c.Soul},
+		{"AGENTS.md", &c.Agents},
+		{"SKILLS.md", &c.Skills},
+		{"USER.md", &c.User},
+		{"MEMORY.md", &c.Memory},
+	}
+	total := 0
+	for _, f := range fields {
+		n := len(*f.target)
+		if rem := MaxTotalChars - total; n > rem {
+			if rem < 0 {
+				rem = 0
+			}
+			slog.Warn("agentconfig: merged config exceeds total limit after overrides, truncated",
+				"file", f.name, "original", n, "remaining", rem, "limit", MaxTotalChars)
+			*f.target = (*f.target)[:rem]
+			n = rem
+		}
+		total += n
 	}
 }

--- a/internal/agentconfig/loader_test.go
+++ b/internal/agentconfig/loader_test.go
@@ -443,3 +443,86 @@ func TestLoadWithInjectExclude(t *testing.T) {
 		require.Equal(t, "Rules.", cfg.Agents)
 	})
 }
+
+func TestLoadForWorkspace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil overrides inherits team defaults", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "team-soul")
+		writeFile(t, dir, "AGENTS.md", "team-rules")
+
+		cfg, err := LoadForWorkspace(dir, "webchat", nil)
+		require.NoError(t, err)
+		require.Equal(t, "team-soul", cfg.Soul)
+		require.Equal(t, "team-rules", cfg.Agents)
+	})
+
+	t.Run("override replaces team default per-file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "team-soul")
+		writeFile(t, dir, "AGENTS.md", "team-rules")
+
+		overrides := map[string]string{"SOUL.md": "ws-soul"}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides)
+		require.NoError(t, err)
+		require.Equal(t, "ws-soul", cfg.Soul)      // overridden
+		require.Equal(t, "team-rules", cfg.Agents) // inherited
+	})
+
+	t.Run("empty override value inherits team default", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "team-soul")
+
+		overrides := map[string]string{"SOUL.md": ""}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides)
+		require.NoError(t, err)
+		require.Equal(t, "team-soul", cfg.Soul) // empty value does not override
+	})
+
+	t.Run("override without team default applies", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir() // no team files
+
+		overrides := map[string]string{"USER.md": "ws-user"}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides)
+		require.NoError(t, err)
+		require.Equal(t, "ws-user", cfg.User)
+	})
+
+	t.Run("injectExclude wins over override", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "SOUL.md", "team-soul")
+
+		overrides := map[string]string{"SOUL.md": "ws-soul"}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides, "SOUL.md")
+		require.NoError(t, err)
+		require.Empty(t, cfg.Soul) // excluded even though overridden
+	})
+
+	t.Run("unknown override keys ignored (defense-in-depth)", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		overrides := map[string]string{"META-COGNITION.md": "evil", "foo.md": "x", "SOUL.md": "ws-soul"}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides)
+		require.NoError(t, err)
+		require.Equal(t, "ws-soul", cfg.Soul)
+		// unknown keys silently ignored; META-COGNITION never appears in AgentConfigs
+	})
+
+	t.Run("platform-level team default resolves before override", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "webchat/AGENTS.md", "webchat-team-rules") // platform-level
+
+		overrides := map[string]string{"SOUL.md": "ws-soul"}
+		cfg, err := LoadForWorkspace(dir, "webchat", overrides)
+		require.NoError(t, err)
+		require.Equal(t, "ws-soul", cfg.Soul)              // override
+		require.Equal(t, "webchat-team-rules", cfg.Agents) // platform-level team default
+	})
+}

--- a/internal/agentconfig/loader_test.go
+++ b/internal/agentconfig/loader_test.go
@@ -526,3 +526,33 @@ func TestLoadForWorkspace(t *testing.T) {
 		require.Equal(t, "webchat-team-rules", cfg.Agents) // platform-level team default
 	})
 }
+
+func TestLoadForWorkspaceStripsFrontmatterOnOverride(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir() // no team files
+
+	// Override pasted with YAML frontmatter (e.g. copied from a file) must be
+	// stripped before injection, mirroring the file track's Load behavior.
+	overrides := map[string]string{"SOUL.md": "---\nversion: 1\n---\nsoul-body"}
+	cfg, err := LoadForWorkspace(dir, "webchat", overrides)
+	require.NoError(t, err)
+	require.Equal(t, "soul-body", cfg.Soul)
+}
+
+func TestEnforceTotalLimit(t *testing.T) {
+	t.Parallel()
+
+	// enforceTotalLimit is defense-in-depth: under the 5-file whitelist with
+	// MaxFileChars=8000, overrides can never push the merged total past
+	// MaxTotalChars=40000 via LoadForWorkspace (5*8000=40000). This unit test
+	// constructs an over-budget config directly to verify the truncation guard.
+	over := strings.Repeat("a", MaxTotalChars)
+	cfg := &AgentConfigs{Soul: over, Agents: over} // 2 * MaxTotalChars
+
+	enforceTotalLimit(cfg)
+
+	total := len(cfg.Soul) + len(cfg.Agents) + len(cfg.Skills) + len(cfg.User) + len(cfg.Memory)
+	require.LessOrEqual(t, total, MaxTotalChars)
+	require.Equal(t, MaxTotalChars, len(cfg.Soul)) // first field consumes full budget
+	require.Empty(t, cfg.Agents)                   // subsequent fields truncated to 0
+}

--- a/internal/agentconfig/loader_test.go
+++ b/internal/agentconfig/loader_test.go
@@ -527,18 +527,6 @@ func TestLoadForWorkspace(t *testing.T) {
 	})
 }
 
-func TestLoadForWorkspaceStripsFrontmatterOnOverride(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir() // no team files
-
-	// Override pasted with YAML frontmatter (e.g. copied from a file) must be
-	// stripped before injection, mirroring the file track's Load behavior.
-	overrides := map[string]string{"SOUL.md": "---\nversion: 1\n---\nsoul-body"}
-	cfg, err := LoadForWorkspace(dir, "webchat", overrides)
-	require.NoError(t, err)
-	require.Equal(t, "soul-body", cfg.Soul)
-}
-
 func TestEnforceTotalLimit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agentconfig/validate.go
+++ b/internal/agentconfig/validate.go
@@ -1,8 +1,18 @@
 package agentconfig
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
+)
+
+// Sentinel errors for agent-config override validation (spec ② §10).
+var (
+	ErrInvalidConfigJSON  = errors.New("agentconfig: invalid config JSON")
+	ErrUnknownConfigFile  = errors.New("agentconfig: unknown config file")
+	ErrConfigTooLarge     = errors.New("agentconfig: config exceeds size limit")
+	ErrInvalidConfigValue = errors.New("agentconfig: invalid config value")
 )
 
 // ValidateBotName checks that name contains no path separators or traversal
@@ -16,4 +26,46 @@ func ValidateBotName(name string) error {
 		return fmt.Errorf("%w: %q: path traversal not allowed", ErrInvalidBotName, name)
 	}
 	return nil
+}
+
+// ValidateOverrides parses raw JSON into a flat map of config-file-name → content
+// and validates keys (against configFiles), value types (must be string), and size
+// limits (MaxFileChars per file, MaxTotalChars total). Returns the parsed map on
+// success. Empty raw ("") returns (nil, nil) meaning "no overrides".
+//
+// Used by the workspace PATCH handler (write-time validation) and Bridge's
+// resolveWorkspaceOverrides (read-time parsing). META-COGNITION.md is not in
+// configFiles, so it is rejected here — workspace overrides cannot touch it.
+func ValidateOverrides(raw string) (map[string]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidConfigJSON, err)
+	}
+	known := make(map[string]struct{}, len(configFiles))
+	for _, f := range configFiles {
+		known[f] = struct{}{}
+	}
+	out := make(map[string]string, len(m))
+	var total int
+	for k, v := range m {
+		if _, ok := known[k]; !ok {
+			return nil, fmt.Errorf("%w: %q", ErrUnknownConfigFile, k)
+		}
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("%w: %q must be a string", ErrInvalidConfigValue, k)
+		}
+		if len(s) > MaxFileChars {
+			return nil, fmt.Errorf("%w: %q is %d chars, max %d", ErrConfigTooLarge, k, len(s), MaxFileChars)
+		}
+		total += len(s)
+		out[k] = s
+	}
+	if total > MaxTotalChars {
+		return nil, fmt.Errorf("%w: total %d chars exceeds max %d", ErrConfigTooLarge, total, MaxTotalChars)
+	}
+	return out, nil
 }

--- a/internal/agentconfig/validate_test.go
+++ b/internal/agentconfig/validate_test.go
@@ -51,11 +51,11 @@ func TestValidateOverrides(t *testing.T) {
 			raw:     `{"SOUL.md":"` + strings.Repeat("a", MaxFileChars+1) + `"}`,
 			wantErr: ErrConfigTooLarge,
 		},
-		{
-			name:    "total exceeds MaxTotalChars",
-			raw:     `{"SOUL.md":"` + strings.Repeat("a", MaxTotalChars+1) + `"}`,
-			wantErr: ErrConfigTooLarge,
-		},
+		// The total-limit branch (sum > MaxTotalChars) is unreachable under the current
+		// 5-file whitelist with MaxFileChars=8000: max sum = 5*8000 = 40000 = MaxTotalChars,
+		// never exceeds. The check in validate.go is defense-in-depth (matches loader.go's
+		// Load total budget) and activates only if configFiles grows or MaxFileChars rises.
+		// The per-file case above covers the oversized-input rejection path.
 		{
 			name: "empty object clears overrides",
 			raw:  `{}`,

--- a/internal/agentconfig/validate_test.go
+++ b/internal/agentconfig/validate_test.go
@@ -1,0 +1,83 @@
+package agentconfig
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr error // sentinel; nil expects success
+		want    map[string]string
+	}{
+		{
+			name: "empty raw returns nil map",
+			raw:  "",
+			want: nil,
+		},
+		{
+			name: "valid flat map with subset of files",
+			raw:  `{"SOUL.md":"persona","USER.md":"profile"}`,
+			want: map[string]string{"SOUL.md": "persona", "USER.md": "profile"},
+		},
+		{
+			name:    "invalid JSON",
+			raw:     `{not json`,
+			wantErr: ErrInvalidConfigJSON,
+		},
+		{
+			name:    "unknown key rejected",
+			raw:     `{"META-COGNITION.md":"x"}`,
+			wantErr: ErrUnknownConfigFile,
+		},
+		{
+			name:    "unknown arbitrary key rejected",
+			raw:     `{"foo.md":"x"}`,
+			wantErr: ErrUnknownConfigFile,
+		},
+		{
+			name:    "non-string value rejected",
+			raw:     `{"SOUL.md":123}`,
+			wantErr: ErrInvalidConfigValue,
+		},
+		{
+			name:    "single file exceeds MaxFileChars",
+			raw:     `{"SOUL.md":"` + strings.Repeat("a", MaxFileChars+1) + `"}`,
+			wantErr: ErrConfigTooLarge,
+		},
+		{
+			name:    "total exceeds MaxTotalChars",
+			raw:     `{"SOUL.md":"` + strings.Repeat("a", MaxTotalChars+1) + `"}`,
+			wantErr: ErrConfigTooLarge,
+		},
+		{
+			name: "empty object clears overrides",
+			raw:  `{}`,
+			want: map[string]string{},
+		},
+		{
+			name: "all five known files accepted",
+			raw:  `{"SOUL.md":"s","AGENTS.md":"a","SKILLS.md":"k","USER.md":"u","MEMORY.md":"m"}`,
+			want: map[string]string{"SOUL.md": "s", "AGENTS.md": "a", "SKILLS.md": "k", "USER.md": "u", "MEMORY.md": "m"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidateOverrides(tt.raw)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/cli/checkers/AGENTS.md
+++ b/internal/cli/checkers/AGENTS.md
@@ -1,0 +1,64 @@
+# checkers — Diagnostic Checks for `hotplex doctor`
+
+## OVERVIEW
+25 self-registering diagnostic checks across 9 categories. Each check implements `cli.Checker`, returns a single `cli.Diagnostic`, and registers itself in `init()` via `cli.DefaultRegistry.Register`. Powers `hotplex doctor [--fix]`.
+
+## STRUCTURE
+```
+checkers/
+  config.go          # 5 config.* checks: exists, syntax, required, values, env_vars
+  agentconfig.go     # 3 agent_config checks: suffix_deprecated, directory_structure, global_files
+  dependencies.go    # 2 checks: worker_binary, sqlite_path
+  environment.go     # 3 checks: go_version, os_arch, build_tools
+  messaging.go       # 3 checks: slack_creds, feishu_creds, multi_bot_config
+  runtime.go         # 4 checks: disk_space, port_available, orphan_pids, data_dir_writable
+  security.go        # 3 checks: admin_token, file_permissions, env_in_git
+  stt.go             # 1 check: stt.runtime (Python deps, ONNX model)
+  tts.go             # 1 check: tts.runtime (Edge-TTS, ffmpeg)
+  disk_unix.go       # syscall.Statfs for disk_space (build: darwin/linux)
+  disk_windows.go    # GetDiskFreeSpaceEx for disk_space (build: windows)
+  *_test.go          # table-driven, one per checker file
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Add a check | new `<name>.go` | Define type, implement `Name/Category/Check`, register in `init()` |
+| Checker contract | `../checker.go:29` | `Check(ctx) Diagnostic` (singular, not a slice) |
+| Set config path | `config.go:20` | `SetConfigPath()` gates all `config.*` checks; `loadConfig()` returns `(nil,nil)` when unset |
+| Multi-bot credential check | `config.go:177` | `config.required` walks `bots[]` arrays (single-bot fallback at line 194) |
+| Auto-fix callback | `config.go:70` | `FixFunc` field; `fixConfigExists`, `fixConfigValues`, `fixEnvVars` write back to disk |
+| Agent-config layout | `agentconfig.go` | Detects deprecated `SOUL.slack.md` suffix; validates dir tree against `validConfigFiles` map |
+| Disk space platform split | `disk_unix.go` / `disk_windows.go` | Build-tagged; both export the symbol `runtime.diskSpaceChecker` calls into |
+| STT/TTS install fix | `stt.go` / `tts.go` | `FixFunc` shells out to `pip install` (uses `os/exec`, the one allowed binary path) |
+
+## KEY PATTERNS
+
+**Checker shape (config.go:36)**
+```go
+type configExistsChecker struct{}
+func (c configExistsChecker) Name() string     { return "config.exists" }
+func (c configExistsChecker) Category() string { return "config" }
+func (c configExistsChecker) Check(ctx context.Context) cli.Diagnostic { ... }
+func init() { cli.DefaultRegistry.Register(configExistsChecker{}) }
+```
+
+**One init, many registers (agentconfig.go:87)**
+- A single `init()` may register multiple related checkers; keep co-located checkers in one `init`.
+
+**Name / Category convention**
+- Name: `<category>.<check>` dotted lowercase (e.g. `runtime.port_available`).
+- Category: one of `config`, `agent_config`, `dependencies`, `environment`, `messaging`, `runtime`, `security`, `stt`, `tts`.
+
+**FixFunc discipline**
+- Set `FixHint` (human text) on every Warn/Fail; set `FixFunc` only when an idempotent auto-fix exists. `doctor --fix` invokes FixFunc and ignores the returned error path on success.
+
+**Platform-specific helpers**
+- Keep syscall code in `*_unix.go` / `*_windows.go`; never call `syscall.Statfs` directly in a checker body.
+
+## ANTI-PATTERNS
+- ❌ Return `[]Diagnostic` — the interface returns ONE `Diagnostic`. Emit multiple aspects by widening `Detail`/`Message`, or split into separate checkers.
+- ❌ Register at runtime or in `TestMain` — `init()` only; tests inject state via unexported struct fields (e.g. `agentConfigSuffixChecker{dir}`).
+- ❌ Read config without guarding `configPath == ""` — `loadConfig()` already returns `(nil,nil)`, prefer it over `config.Load` directly.
+- ❌ Skip `FixHint` on Warn/Fail — every negative result needs a remediation pointer.
+- ❌ Hardcode platform paths — use `config.HotplexHome()` and `filepath.Join`.

--- a/internal/cli/cron/AGENTS.md
+++ b/internal/cli/cron/AGENTS.md
@@ -1,0 +1,60 @@
+# cron — Out-of-Process Client for `hotplex cron`
+
+## OVERVIEW
+Package `croncli` is the persistence + control layer used by the `hotplex cron` cobra subcommands (`create`/`update`/`delete`/`get`/`list`/`trigger`/`history`, wired in `cmd/hotplex/cron_*.go`). It opens the same store the running gateway uses, mutates jobs, then pokes the gateway via SIGHUP or the admin HTTP API so the in-process scheduler picks up changes. All job/schedule types come from parent package `internal/cron/`.
+
+## STRUCTURE
+```
+cron/
+  client.go          # 458 lines: OpenStore, ResolveJob, ParseSchedule, PrepareJobForCreate, TriggerViaAdmin, NotifyGateway, formatters
+  client_test.go     # ParseSchedule + PrepareJobForCreate tests
+  signal_unix.go     # sendReloadSignal → syscall.Kill(SIGHUP)   (build: darwin/linux)
+  signal_windows.go  # sendReloadSignal → error (Windows has no SIGHUP) (build: windows)
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Open store (sqlite or postgres) | `client.go:37` | `OpenStore`: `dbutil.ParseDialect` → run session migrations → construct `cron.NewSQLiteStore` or `cron.NewPGStore`; returns cleanup func |
+| Resolve id-or-name | `client.go:71` | `ResolveJob`: try `Get(id)` then `GetByName` |
+| Parse `--schedule` | `client.go:84` | `ParseSchedule`: `cron:` / `every:` / `at:`; `at:+1h30m` relative form clamped to `[1m, 72h]` |
+| Build a job from flags | `client.go:192` | `PrepareJobForCreate`: validates bot name, resolves platform, sets defaults (`MaxRuns=10`, `ExpiresAt=+24h` for recurring), assigns ID + initial `NextRunAtMs` |
+| Platform routing resolution | `client.go:158` | `resolvePlatform`: CLI flags > `GATEWAY_PLATFORM`/`GATEWAY_CHANNEL_ID`/`GATEWAY_THREAD_ID` env > default `"cron"` (no delivery) |
+| Enforce max jobs | `client.go:261` | `CheckMaxJobs`: reads `cfg.Cron.MaxJobs` (default 50), skips on config/store errors |
+| Trigger via admin API | `client.go:281` | `TriggerViaAdmin`: POST `/admin/cron/jobs/{id}/run` with `Bearer` admin token; reads gateway's actual config path from PID file |
+| History query | `client.go:330` | `QueryHistory`: `eventstore.TurnQuerier.QueryTurnStats` keyed by `job.SessionKey()` |
+| Notify gateway of changes | `client.go:340` | `NotifyGateway`: read PID state → `sendReloadSignal(pid)`; no-op when gateway down |
+| Formatting helpers | `client.go:419+` | `FormatSchedule`, `FormatTimeMs`, `FormatDurationMs`, `FormatCost` (USD, 4dp) |
+
+## KEY PATTERNS
+
+**Type re-export (client.go:31)**
+```go
+type (
+    Store   = cron.Store
+    CronJob = cron.CronJob
+)
+```
+Callers import only `croncli`; the parent `internal/cron` stays the single source of job semantics.
+
+**Schedule kinds (mirrors `internal/cron.ScheduleKind`)**
+- `cron:<expr>` — 5-field cron expression
+- `every:<duration>` — minimum 1 minute (`parseDurationMs` rejects `<60s`)
+- `at:<RFC3339>` or `at:+<dur>` — one-shot; relative clamped to 72h
+
+**Two ways to fire a job**
+- `TriggerViaAdmin` — HTTP POST; works while gateway runs, returns `202`/`404`/`503`.
+- `NotifyGateway` — SIGHUP reload after create/update/delete; CLI calls both as needed.
+
+**Config path reconciliation**
+- When `--config` is unset or equals `config.DefaultConfigPath`, `TriggerViaAdmin`/`gatewayConfigPath` consult the PID file to load the SAME `.env` the running gateway uses — avoids picking up a stale dev config.
+
+**Safe env loading**
+- `loadEnvFile` mirrors the slack package: skip protected keys, never overwrite existing env.
+
+## ANTI-PATTERNS
+- ❌ Re-implement schedule parsing or job validation — delegate to `internal/cron` (`cron.ValidateJob`, `cron.NextRun`, `cron.GenerateJobID`).
+- ❌ Write to the store without calling `NotifyGateway` afterward — the running scheduler won't see the change until reload.
+- ❌ Assume SIGHUP works on Windows — `signal_windows.go` returns an error; surface it and tell users to restart.
+- ❌ Trust `--config` blindly when the gateway is running — prefer `gatewayConfigPath()` from the PID file.
+- ❌ Construct platform keys ad hoc — use `resolvePlatform` so env-derived baseline + CLI override compose correctly.

--- a/internal/cli/onboard/AGENTS.md
+++ b/internal/cli/onboard/AGENTS.md
@@ -1,0 +1,56 @@
+# onboard — Interactive Setup Wizard for `hotplex onboard`
+
+## OVERVIEW
+Multi-step interactive wizard producing `config.yaml` + `.env` + agent-config skeletons. Drives platform credential collection, STT/TTS preflight, optional service install, and binary install. Supports `--non-interactive` for CI. The `templates/` subdir (SOUL/AGENTS/SKILLS/USER/MEMORY .md files) has its **own AGENTS.md** and is out of scope here.
+
+## STRUCTURE
+```
+onboard/
+  wizard.go                # 1320 lines: Run() entry, step flow, all prompts, ExistingConfig detection
+  templates.go             # BuildConfigYAML: YAML-AST mutation of embedded configs/config.yaml; GenerateSecret
+  agentconfig_templates.go # go:embed templates/*.md + guides/*.md; DefaultTemplates(), ShowPlatformGuide()
+  yamlutil.go              # yaml.Node helpers: lookupKey/lookupPath/setScalar/setBool/setStringList/replaceBlock
+  wizard_test.go           # flow tests
+  wizard_coverage_test.go  # branch coverage
+  templates/               # EMBEDDED — has its own AGENTS.md, do not document here
+  guides/                  # slack.md, feishu.md platform setup guides (embedded, printed to stderr)
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Entry point | `wizard.go:168` | `Run(ctx, WizardOptions) (*WizardResult, error)` |
+| Options struct | `wizard.go:35` | `NonInteractive`, `Force`, `EnableSlack`, `EnableFeishu`, `InstallService`, `ServiceLevel`, `SlackAllowFrom`, policy fields |
+| Detect existing state | `wizard.go:77` | `detectExistingConfig` scans config.yaml + .env; `SlackReady()`/`FeishuReady()` predicates |
+| Step list (interactive) | `wizard.go:407` | `buildSteps()`: required config, worker dep, messaging, agent-config, STT, TTS, service, binary |
+| Non-interactive platform | `wizard.go:315` | `buildPlatformNonInteractive` materializes opts → `messagingPlatformConfig` |
+| Config generation | `templates.go:43` | `BuildConfigYAML`: returns embedded YAML verbatim when no mutation needed (preserves comments), else AST-mutates |
+| Keep-existing platform block | `templates.go:54` + `yamlutil.go:101` | `replaceBlock` deep-copies prior Slack/Feishu block when user chose "keep" |
+| Agent-config templates | `agentconfig_templates.go:10` | `//go:embed templates/*.md`; `DefaultTemplates()` returns the 5 canonical files |
+| Platform guides | `agentconfig_templates.go:45` | `//go:embed guides/*.md`; `ShowPlatformGuide("slack")` prints to stderr |
+| Prompt primitives | `wizard.go:1043+` | `promptWithValidation`, `promptChoice`, `promptYesNo`, `promptWithDefault`, `promptCommaList` |
+| STT/TTS install fix | `wizard.go:887` / `:895` | `installSTTDeps` / `installTTSDeps` shell out to pip (only allowed exec path besides `claude`) |
+
+## KEY PATTERNS
+
+**WizardResult step accumulation (wizard.go:291)**
+- Each step returns a `StepResult`; `WizardResult.add()` appends; `hasFail()` short-circuits downstream steps.
+
+**Config-aware credential preservation**
+- `readExistingEnvValue` / `readExistingConfigValue` / `readExistingEnvCredentials` (wizard.go:537+) prefill prompts so re-runs don't wipe secrets.
+
+**YAML AST mutation over string replace**
+- `templates.go` parses embedded `configs/config.yaml` into `yaml.Node`, walks via `lookupPath`, mutates with `setBool/setScalar/setStringList`. Never `sed`/regex on YAML source — comments would be lost and indentation is unsafe.
+
+**Env file write merge**
+- `buildEnvContent` (wizard.go:779) reads existing `.env`, preserves unknown keys, appends generated `HOTPLEX_ADMIN_TOKEN_1` and platform creds; `GenerateSecret()` (templates.go:139) yields 32-byte base64.
+
+**Non-interactive determinism**
+- With `NonInteractive=true` the wizard skips all `prompt*` calls; `EnableSlack`/`EnableFeishu` flags and `*Policy`/`*AllowFrom` fields fully specify output. Required-field gaps become failing `StepResult`s instead of prompts.
+
+## ANTI-PATTERNS
+- ❌ Mutate `configs/config.yaml` via string ops — go through `yamlutil.go` AST helpers.
+- ❌ Print setup guides to stdout — `ShowPlatformGuide` writes to stderr so pipes/JSON output stay clean.
+- ❌ Read templates via `os.ReadFile` — they are `go:embed`-ed; use `readTemplate` / `templateFS`.
+- ❌ Add a new step without wiring it into both `buildSteps()` (interactive) and the non-interactive path.
+- ❌ Forget the `templates/` subdir has its own AGENTS.md — edit that file for template content, not here.

--- a/internal/cli/output/AGENTS.md
+++ b/internal/cli/output/AGENTS.md
@@ -1,0 +1,49 @@
+# output — Terminal Rendering for `doctor` / `onboard`
+
+## OVERVIEW
+ANSI-aware human output plus a JSON envelope for machine consumers. Renders `cli.Diagnostic` results (doctor), wizard step UI (onboard), and the `JSONReport` consumed by `--output json`. All color output is gated on `IsTTY` so pipes and logs stay clean.
+
+## STRUCTURE
+```
+output/
+  printer.go      # PrintDiagnostic (✓/⚠/✗ + category + fix hint), PrintSummary (counts)
+  report.go       # JSONReport / JSONSummary / WriteJSON for --output json
+  theme.go        # ANSI helpers (Bold/Dim/Green/...) + wizard UI builders (SectionHeader, StepLine, CommandBox, NoteBox)
+  tty.go          # IsTTY via go-isatty
+  printer_test.go # PrintDiagnostic/PrintSummary tests
+  report_test.go  # JSONReport tests
+  theme_test.go   # theme + UI builder tests
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Render one diagnostic | `printer.go:20` | `PrintDiagnostic(out, d, verbose)`: picks symbol+color by `d.Status`, prints `FixHint` line |
+| Summary line | `printer.go:60` | `PrintSummary(pass,warn,fail,fixable)` — colored bold when TTY |
+| Machine output | `report.go:24` | `NewJSONReport(version, diags)` tallies statuses; `WriteJSON` encodes with 2-space indent |
+| Status symbol | `theme.go:43` | `StatusSymbol("pass"|"warn"|"fail"|"skip")` → colored glyph |
+| Wizard step line | `theme.go:65` | `StepLine(name, status, detail)` |
+| Section / note / command boxes | `theme.go:59` / `:87` / `:74` | `SectionHeader`, `NoteBox`, `CommandBox` (numbered next-steps) |
+| Raw ANSI styles | `theme.go:10+` | `Style`, `Bold`, `Dim`, `Green`, `Yellow`, `Red`, `Cyan`, `Sprintf`, `Fprintf` |
+| TTY detection | `tty.go:11` | `IsTTY(w)` — returns false for non-`*os.File` writers |
+
+## KEY PATTERNS
+
+**Color is TTY-gated, not flag-gated**
+- `PrintDiagnostic`/`PrintSummary` call `IsTTY(out)` and strip ANSI when false. Don't add a `--no-color` flag; redirecting output is the contract.
+
+**Two render targets, one diagnostic slice**
+- Human: `PrintDiagnostic` per item + `PrintSummary` footer.
+- Machine: `NewJSONReport(...)` → `WriteJSON`. Both consume the same `[]cli.Diagnostic` from `DefaultRegistry.All()`.
+
+**ANSI code constants live in one place**
+- `ansiReset/Bold/Dim/Green/Yellow/Red/Cyan` are private to the package; callers use `Bold(...)`/`Green(...)` so reset tags can never be forgotten.
+
+**Wizard UI is composable**
+- `SectionHeader`, `StepLine`, `ConfigLine`, `CommandBox`, `NoteBox`, `Fdivider` return strings; the wizard concatenates and prints them. No direct `fmt.Fprintln` inside builders.
+
+## ANTI-PATTERNS
+- ❌ Emit ANSI escapes directly — go through `theme.go` helpers so resets always balance.
+- ❌ Add table/yaml renderers here without a TTY gate — current contract is human + JSON only; new formats must respect `IsTTY`.
+- ❌ Print diagnostics with `fmt.Println` from `cmd/hotplex` — call `output.PrintDiagnostic` so verbose/fix-hint behavior stays uniform.
+- ❌ Hardcode status glyphs — use `StatusSymbol`, so `skip`/`warn` stay consistent across doctor and wizard.

--- a/internal/cli/slack/AGENTS.md
+++ b/internal/cli/slack/AGENTS.md
@@ -1,0 +1,56 @@
+# slack — Slack API Client Wrappers for `hotplex slack`
+
+## OVERVIEW
+Thin, context-aware wrappers around `github.com/slack-go/slack` used by the `hotplex slack` cobra subcommands (which live in `cmd/hotplex/slack_*.go`). Package name is `slackcli` to avoid collision with the upstream library. All functions take a pre-built `*slack.Client`; config/env resolution happens in `LoadConfigAndClient`.
+
+## STRUCTURE
+```
+slack/
+  client.go      # NewClient, ResolveChannel/ResolveThreadTS, LoadConfigAndClient, loadEnvFile
+  message.go     # SendMessage, UpdateMessage, ScheduleMessage  (+ SendResult)
+  channels.go    # ListChannels (paginated, types filter)        (+ ChannelInfo)
+  bookmark.go    # AddBookmark, ListBookmarks, RemoveBookmark    (+ BookmarkResult)
+  upload.go      # UploadFile with MaxSize guard                 (+ UploadParams/UploadResult)
+  download.go    # DownloadFile (MkdirAll + cleanup on failure)
+  delete.go      # DeleteFile
+  react.go       # AddReaction, RemoveReaction
+  client_test.go # NewClient + env-load tests
+  delete_test.go # DeleteFile validation
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Build a client from config | `client.go:40` | `LoadConfigAndClient`: resolve path → load `.env` → `config.Load` → verify `Slack.Enabled` → `NewClient` |
+| Env file loader | `client.go:67` | `loadEnvFile` skips protected keys via `security.IsProtected`, never overwrites existing env values |
+| Channel resolution | `client.go:23` | `ResolveChannel`: `--channel` flag → `HOTPLEX_SLACK_CHANNEL_ID` env → error |
+| Send / update / schedule | `message.go:16` / `:29` / `:37` | All accept `threadTS`; `ScheduleMessage` takes unix `postAt` int64 |
+| List with pagination | `channels.go:33` | Loops `GetConversationsContext` cursor until `limit` reached |
+| Bookmark CRUD | `bookmark.go:17` / `:38` / `:57` | Add always sets `Type: "link"` |
+| Upload size guard | `upload.go:34` | `UploadParams.MaxSize > 0` rejects oversize before upload |
+| Download cleanup | `download.go:18` | `MkdirAll` on out dir; on download error closes fd and `os.Remove`s partial file |
+| Reaction add/remove | `react.go:10` / `:21` | Build `slack.ItemRef{Channel, Timestamp}` then call context variant |
+
+## KEY PATTERNS
+
+**Verb → file mapping** (cobra commands in `cmd/hotplex/slack_*.go`)
+- `send-message` → `SendMessage`, `update-message` → `UpdateMessage`, `schedule-message` → `ScheduleMessage`
+- `upload-file` → `UploadFile`, `download-file` → `DownloadFile`, `delete-file` → `DeleteFile` (also `--file-id` validation)
+- `list-channels` → `ListChannels` (supports `--types im,public_channel`)
+- `bookmark add` / `bookmark list` / `bookmark remove` → bookmark.go
+- `react add` / `react remove` → react.go
+
+**Consistent error wrapping**
+- Every wrapper returns `fmt.Errorf("<verb>: %w", err)` so the cobra layer can surface a single causal chain.
+
+**Result structs are JSON-tagged**
+- `SendResult`, `BookmarkResult`, `UploadResult`, `ChannelInfo` all carry `json:"..."` tags so the CLI can render `--output json` without re-marshaling.
+
+**Env hygiene**
+- `loadEnvFile` only `os.Setenv` when the key is unset AND not `security.IsProtected` — secrets in `.env` never leak into child processes or override explicit env.
+
+## ANTI-PATTERNS
+- ❌ Construct `*slack.Client` inline in a command — go through `LoadConfigAndClient` so `.env` + `Slack.Enabled` checks always run.
+- ❌ Drop the `context.Context` parameter — every API call must use the `*Context` variant for cancellation/timeout.
+- ❌ Leave partial downloads on failure — `DownloadFile` already removes them; new code paths must follow suit.
+- ❌ Add a slack verb without a JSON-tagged result struct — breaks `--output json` consumers.

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -506,7 +506,7 @@ func (b *Bridge) ResetSession(ctx context.Context, sessionID string) error {
 	if si, err := b.sm.Get(ctx, sessionID); err == nil {
 		if su, ok := w.(worker.SystemPromptUpdater); ok {
 			info := &worker.SessionInfo{SystemPrompt: ""}
-			b.injectAgentConfig(info, si.Platform, si.BotName, si.BotID, nil, nil)
+			b.injectAgentConfig(info, si.Platform, si.BotName, si.BotID, nil, b.resolveWorkspaceOverrides(si.WorkspaceID))
 			if info.SystemPrompt != "" {
 				su.UpdateSystemPrompt(info.SystemPrompt)
 				b.log.Info("bridge: reset reloaded agent config",

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -59,13 +59,14 @@ type Bridge struct {
 	retryCancelMu  sync.Mutex
 	retryCancel    map[string]chan struct{} // sessionID → cancel channel
 
-	agentConfigDir     string        // agent config directory path; "" = disabled
-	turnTimeout        time.Duration // per-turn timeout; 0 = disabled
-	workerEnv          []string      // extra env vars from worker.environment config
-	workerEnvBlocklist []string      // extra blocklist entries from worker.env_blocklist config
-	cronEnv            []string      // env vars injected only into cron platform sessions
-	mcpConfigJSON      atomic.Value  // pre-serialized MCP config JSON string; "" = not configured
-	agentConfigExclude atomic.Value  // map[string][]string: platform → inject_exclude (global default at "" key)
+	agentConfigDir     string                   // agent config directory path; "" = disabled
+	turnTimeout        time.Duration            // per-turn timeout; 0 = disabled
+	workerEnv          []string                 // extra env vars from worker.environment config
+	workerEnvBlocklist []string                 // extra blocklist entries from worker.env_blocklist config
+	cronEnv            []string                 // env vars injected only into cron platform sessions
+	mcpConfigJSON      atomic.Value             // pre-serialized MCP config JSON string; "" = not configured
+	agentConfigExclude atomic.Value             // map[string][]string: platform → inject_exclude (global default at "" key)
+	wsStore            WorkspaceOverridesReader // per-workspace agent-config overrides resolver (spec ②); nil = Message Channel track
 
 	accum map[string]*sessionAccumulator // per-session stats accumulator
 
@@ -108,6 +109,7 @@ func NewBridge(deps BridgeDeps) *Bridge {
 		workerEnv:          deps.WorkerEnv,
 		workerEnvBlocklist: deps.WorkerEnvBlocklist,
 		cronEnv:            deps.CronEnv,
+		wsStore:            deps.WSStore,
 		retryCancel:        make(map[string]chan struct{}),
 		accum:              make(map[string]*sessionAccumulator),
 		crashTracker:       make(map[string]*crashHistory),
@@ -187,14 +189,15 @@ func (b *Bridge) StartSession(ctx context.Context, p worker.SessionStartParams) 
 	}
 
 	if _, err := b.createAndLaunchWorker(workerLaunchParams{
-		ctx:           ctx,
-		wt:            p.WorkerType,
-		workerInfo:    workerInfo,
-		platform:      p.Platform,
-		botID:         p.BotID,
-		botName:       p.BotName,
-		forwardOpts:   &forwardOpts{workDir: p.WorkDir},
-		injectExclude: p.InjectExclude,
+		ctx:                ctx,
+		wt:                 p.WorkerType,
+		workerInfo:         workerInfo,
+		platform:           p.Platform,
+		botID:              p.BotID,
+		botName:            p.BotName,
+		forwardOpts:        &forwardOpts{workDir: p.WorkDir},
+		injectExclude:      p.InjectExclude,
+		workspaceOverrides: b.resolveWorkspaceOverrides(p.WorkspaceID),
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if err := w.Start(ctx, info); err != nil {
@@ -295,13 +298,14 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 
 	workerInfo := b.prepareWorkerInfo(si.ID, si.UserID, workDir, si)
 	w, err := b.createAndLaunchWorker(workerLaunchParams{
-		ctx:         ctx,
-		wt:          si.WorkerType,
-		workerInfo:  workerInfo,
-		platform:    si.Platform,
-		botID:       si.BotID,
-		botName:     si.BotName,
-		forwardOpts: &opts,
+		ctx:                ctx,
+		wt:                 si.WorkerType,
+		workerInfo:         workerInfo,
+		platform:           si.Platform,
+		botID:              si.BotID,
+		botName:            si.BotName,
+		forwardOpts:        &opts,
+		workspaceOverrides: b.resolveWorkspaceOverrides(si.WorkspaceID),
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if si.State != events.StateRunning {
@@ -502,7 +506,7 @@ func (b *Bridge) ResetSession(ctx context.Context, sessionID string) error {
 	if si, err := b.sm.Get(ctx, sessionID); err == nil {
 		if su, ok := w.(worker.SystemPromptUpdater); ok {
 			info := &worker.SessionInfo{SystemPrompt: ""}
-			b.injectAgentConfig(info, si.Platform, si.BotName, si.BotID, nil)
+			b.injectAgentConfig(info, si.Platform, si.BotName, si.BotID, nil, nil)
 			if info.SystemPrompt != "" {
 				su.UpdateSystemPrompt(info.SystemPrompt)
 				b.log.Info("bridge: reset reloaded agent config",

--- a/internal/gateway/bridge.go
+++ b/internal/gateway/bridge.go
@@ -197,7 +197,7 @@ func (b *Bridge) StartSession(ctx context.Context, p worker.SessionStartParams) 
 		botName:            p.BotName,
 		forwardOpts:        &forwardOpts{workDir: p.WorkDir},
 		injectExclude:      p.InjectExclude,
-		workspaceOverrides: b.resolveWorkspaceOverrides(p.WorkspaceID),
+		workspaceOverrides: b.resolveWorkspaceOverrides(ctx, p.WorkspaceID),
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if err := w.Start(ctx, info); err != nil {
@@ -305,7 +305,7 @@ func (b *Bridge) resumeWithOpts(ctx context.Context, id, workDir string, opts fo
 		botID:              si.BotID,
 		botName:            si.BotName,
 		forwardOpts:        &opts,
-		workspaceOverrides: b.resolveWorkspaceOverrides(si.WorkspaceID),
+		workspaceOverrides: b.resolveWorkspaceOverrides(ctx, si.WorkspaceID),
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if si.State != events.StateRunning {
@@ -506,7 +506,7 @@ func (b *Bridge) ResetSession(ctx context.Context, sessionID string) error {
 	if si, err := b.sm.Get(ctx, sessionID); err == nil {
 		if su, ok := w.(worker.SystemPromptUpdater); ok {
 			info := &worker.SessionInfo{SystemPrompt: ""}
-			b.injectAgentConfig(info, si.Platform, si.BotName, si.BotID, nil, b.resolveWorkspaceOverrides(si.WorkspaceID))
+			b.injectAgentConfig(info, si.Platform, si.BotName, si.BotID, nil, b.resolveWorkspaceOverrides(ctx, si.WorkspaceID))
 			if info.SystemPrompt != "" {
 				su.UpdateSystemPrompt(info.SystemPrompt)
 				b.log.Info("bridge: reset reloaded agent config",

--- a/internal/gateway/bridge_overrides_integration_test.go
+++ b/internal/gateway/bridge_overrides_integration_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -61,7 +62,7 @@ func TestBridge_WorkspaceWithoutOverrides_InheritsTeamDefault(t *testing.T) {
 func buildPromptFor(t *testing.T, dir string, store *stubWSStore, workspaceID string) string {
 	t.Helper()
 	b := &Bridge{log: testLogger(t), wsStore: store, agentConfigDir: dir}
-	overrides := b.resolveWorkspaceOverrides(workspaceID)
+	overrides := b.resolveWorkspaceOverrides(context.Background(), workspaceID)
 	cfg, err := agentconfig.LoadForWorkspace(dir, "webchat", overrides)
 	require.NoError(t, err)
 	return agentconfig.BuildSystemPrompt(cfg)

--- a/internal/gateway/bridge_overrides_integration_test.go
+++ b/internal/gateway/bridge_overrides_integration_test.go
@@ -1,0 +1,68 @@
+package gateway
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/agentconfig"
+	"github.com/hrygo/hotplex/internal/session"
+)
+
+// TestBridge_TwoWorkspaces_DifferentOverrides verifies the core spec ② invariant:
+// two workspaces with different overrides produce different system prompts, and
+// neither pollutes the other nor the team default.
+func TestBridge_TwoWorkspaces_DifferentOverrides(t *testing.T) {
+	t.Parallel()
+
+	// Team defaults on disk (global level).
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("team-rules"), 0o644))
+
+	wsA := &session.Workspace{ID: "ws-a", AgentConfigOverrides: `{"SOUL.md":"persona-A"}`}
+	wsB := &session.Workspace{ID: "ws-b", AgentConfigOverrides: `{"SOUL.md":"persona-B"}`}
+	storeA := &stubWSStore{ws: wsA}
+	storeB := &stubWSStore{ws: wsB}
+
+	promptA := buildPromptFor(t, dir, storeA, "ws-a")
+	promptB := buildPromptFor(t, dir, storeB, "ws-b")
+
+	require.Contains(t, promptA, "persona-A")
+	require.NotContains(t, promptA, "persona-B")
+	require.Contains(t, promptB, "persona-B")
+	require.NotContains(t, promptB, "persona-A")
+	// Both inherit team default AGENTS.md
+	require.Contains(t, promptA, "team-rules")
+	require.Contains(t, promptB, "team-rules")
+}
+
+// TestBridge_WorkspaceWithoutOverrides_InheritsTeamDefault verifies a workspace
+// with empty overrides falls fully back to team defaults.
+func TestBridge_WorkspaceWithoutOverrides_InheritsTeamDefault(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SOUL.md"), []byte("team-soul"), 0o644))
+
+	ws := &session.Workspace{ID: "ws-x", AgentConfigOverrides: ""}
+	store := &stubWSStore{ws: ws}
+
+	prompt := buildPromptFor(t, dir, store, "ws-x")
+	require.Contains(t, prompt, "team-soul")
+}
+
+// buildPromptFor exercises the same data path as injectAgentConfig:
+// resolveWorkspaceOverrides → LoadForWorkspace → BuildSystemPrompt.
+//
+// resolveWorkspaceOverrides returns nil for empty/invalid overrides (graceful
+// degradation), and LoadForWorkspace accepts a nil overrides map (falls back to
+// team defaults), so no NotNil assertion is applied here.
+func buildPromptFor(t *testing.T, dir string, store *stubWSStore, workspaceID string) string {
+	t.Helper()
+	b := &Bridge{log: testLogger(t), wsStore: store, agentConfigDir: dir}
+	overrides := b.resolveWorkspaceOverrides(workspaceID)
+	cfg, err := agentconfig.LoadForWorkspace(dir, "webchat", overrides)
+	require.NoError(t, err)
+	return agentconfig.BuildSystemPrompt(cfg)
+}

--- a/internal/gateway/bridge_test.go
+++ b/internal/gateway/bridge_test.go
@@ -837,6 +837,47 @@ func TestResetSession_ReloadsAgentConfig(t *testing.T) {
 	sm.AssertExpectations(t)
 }
 
+func TestResetSession_WebChatWorkspaceOverrides(t *testing.T) {
+	t.Parallel()
+
+	// Team default on disk; workspace override must win after reset (spec ②).
+	// Regression guard: ResetSession must pass resolveWorkspaceOverrides(si.WorkspaceID),
+	// not nil — otherwise WebChat /reset silently drops workspace config and falls back
+	// to team defaults.
+	dir := t.TempDir()
+	writeAgentConfigFile(t, dir, "SOUL.md", "team-soul")
+
+	hub := newTestHub(t)
+	sm := new(mockBridgeSM)
+	ws := &session.Workspace{ID: "ws-reset", AgentConfigOverrides: `{"SOUL.md":"ws-soul"}`}
+	b := NewBridge(BridgeDeps{
+		Log:            slog.Default(),
+		Hub:            hub,
+		SM:             sm,
+		AgentConfigDir: dir,
+		WSStore:        &stubWSStore{ws: ws},
+	})
+
+	sid := "test-reset-webchat-overrides"
+	mw := &mockPromptUpdater{}
+
+	sm.On("GetWorker", sid).Return(mw)
+	sm.On("Get", sid).Return(&session.SessionInfo{
+		ID:          sid,
+		Platform:    "webchat",
+		WorkspaceID: "ws-reset",
+	}, nil)
+
+	err := b.ResetSession(context.Background(), sid)
+	require.NoError(t, err)
+
+	// Workspace override wins over team default — proves ResetSession resolves
+	// overrides for WebChat sessions, not hardcoded nil.
+	assert.Contains(t, mw.updatedPrompt, "ws-soul")
+	assert.NotContains(t, mw.updatedPrompt, "team-soul")
+	sm.AssertExpectations(t)
+}
+
 func TestResetSession_NoUpdater_NoReload(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/bridge_test.go
+++ b/internal/gateway/bridge_test.go
@@ -406,7 +406,7 @@ func TestBridge_InjectAgentConfig_BotNameResolution(t *testing.T) {
 			})
 
 			info := &worker.SessionInfo{}
-			b.injectAgentConfig(info, tt.platform, tt.botName, tt.botID, nil)
+			b.injectAgentConfig(info, tt.platform, tt.botName, tt.botID, nil, nil)
 
 			if tt.wantEmpty {
 				assert.Empty(t, info.SystemPrompt)

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -220,7 +220,7 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 		botName:            si.BotName,
 		forwardOpts:        &forwardOpts{workDir: p.workDir},
 		injectExclude:      nil, // resolved by injectAgentConfig
-		workspaceOverrides: b.resolveWorkspaceOverrides(si.WorkspaceID),
+		workspaceOverrides: b.resolveWorkspaceOverrides(context.Background(), si.WorkspaceID),
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if si.State != events.StateRunning {
@@ -321,12 +321,13 @@ func (b *Bridge) resolveInjectExclude(platform string, perSession []string) []st
 // resolveWorkspaceOverrides fetches a workspace's agent-config overrides and parses
 // them. Returns nil for empty workspaceID (Message Channel track) or nil wsStore, and
 // degrades to nil (team defaults) on any fetch/parse error — never blocks worker launch.
-// See design spec §7.3.
-func (b *Bridge) resolveWorkspaceOverrides(workspaceID string) map[string]string {
+// ctx propagates request-scoped cancellation/deadline and the OTel trace span to the
+// workspace DB query. See design spec §7.3.
+func (b *Bridge) resolveWorkspaceOverrides(ctx context.Context, workspaceID string) map[string]string {
 	if workspaceID == "" || b.wsStore == nil {
 		return nil
 	}
-	ws, err := b.wsStore.GetWorkspaceByID(context.Background(), workspaceID)
+	ws, err := b.wsStore.GetWorkspaceByID(ctx, workspaceID)
 	if err != nil {
 		b.log.Warn("bridge: fetch workspace overrides failed, degrading to team defaults",
 			"workspace_id", workspaceID, "err", err)

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -321,8 +321,9 @@ func (b *Bridge) resolveInjectExclude(platform string, perSession []string) []st
 // resolveWorkspaceOverrides fetches a workspace's agent-config overrides and parses
 // them. Returns nil for empty workspaceID (Message Channel track) or nil wsStore, and
 // degrades to nil (team defaults) on any fetch/parse error — never blocks worker launch.
-// ctx propagates request-scoped cancellation/deadline and the OTel trace span to the
-// workspace DB query. See design spec §7.3.
+// ctx propagates request-scoped cancellation/deadline to the workspace DB query (the
+// store layer uses standard QueryRowContext without otelsql instrumentation, so ctx
+// does not auto-generate an OTel DB span). See design spec §7.3.
 func (b *Bridge) resolveWorkspaceOverrides(ctx context.Context, workspaceID string) map[string]string {
 	if workspaceID == "" || b.wsStore == nil {
 		return nil

--- a/internal/gateway/bridge_worker.go
+++ b/internal/gateway/bridge_worker.go
@@ -29,14 +29,15 @@ type forwardOpts struct {
 
 // workerLaunchParams holds the parameters for createAndLaunchWorker.
 type workerLaunchParams struct {
-	ctx           context.Context
-	wt            worker.WorkerType
-	workerInfo    worker.SessionInfo
-	platform      string
-	botID         string
-	botName       string
-	forwardOpts   *forwardOpts
-	injectExclude []string // per-session agent config files to skip; nil = use platform default
+	ctx                context.Context
+	wt                 worker.WorkerType
+	workerInfo         worker.SessionInfo
+	platform           string
+	botID              string
+	botName            string
+	forwardOpts        *forwardOpts
+	injectExclude      []string          // per-session agent config files to skip; nil = use platform default
+	workspaceOverrides map[string]string // WebChat per-workspace config overrides (spec ②); nil = Message Channel track → Load
 }
 
 // workerStartFunc is called after AttachWorker and injectAgentConfig.
@@ -79,7 +80,7 @@ func (b *Bridge) createAndLaunchWorker(params workerLaunchParams, startFn worker
 		return nil, fmt.Errorf("bridge: attach worker: %w", err)
 	}
 
-	b.injectAgentConfig(&params.workerInfo, params.platform, params.botName, params.botID, params.injectExclude)
+	b.injectAgentConfig(&params.workerInfo, params.platform, params.botName, params.botID, params.injectExclude, params.workspaceOverrides)
 
 	if err := startFn(params.ctx, w, params.workerInfo); err != nil {
 		b.sm.DetachWorker(sid)
@@ -211,14 +212,15 @@ func (b *Bridge) attemptResumeFallback(p fallbackParams) bool {
 	workerInfo := b.prepareWorkerInfo(si.ID, si.UserID, p.workDir, si)
 
 	w, err := b.createAndLaunchWorker(workerLaunchParams{
-		ctx:           context.Background(),
-		wt:            si.WorkerType,
-		workerInfo:    workerInfo,
-		platform:      si.Platform,
-		botID:         si.BotID,
-		botName:       si.BotName,
-		forwardOpts:   &forwardOpts{workDir: p.workDir},
-		injectExclude: nil, // resolved by injectAgentConfig
+		ctx:                context.Background(),
+		wt:                 si.WorkerType,
+		workerInfo:         workerInfo,
+		platform:           si.Platform,
+		botID:              si.BotID,
+		botName:            si.BotName,
+		forwardOpts:        &forwardOpts{workDir: p.workDir},
+		injectExclude:      nil, // resolved by injectAgentConfig
+		workspaceOverrides: b.resolveWorkspaceOverrides(si.WorkspaceID),
 	},
 		func(ctx context.Context, w worker.Worker, info worker.SessionInfo) error {
 			if si.State != events.StateRunning {
@@ -316,16 +318,43 @@ func (b *Bridge) resolveInjectExclude(platform string, perSession []string) []st
 	return nil
 }
 
+// resolveWorkspaceOverrides fetches a workspace's agent-config overrides and parses
+// them. Returns nil for empty workspaceID (Message Channel track) or nil wsStore, and
+// degrades to nil (team defaults) on any fetch/parse error — never blocks worker launch.
+// See design spec §7.3.
+func (b *Bridge) resolveWorkspaceOverrides(workspaceID string) map[string]string {
+	if workspaceID == "" || b.wsStore == nil {
+		return nil
+	}
+	ws, err := b.wsStore.GetWorkspaceByID(context.Background(), workspaceID)
+	if err != nil {
+		b.log.Warn("bridge: fetch workspace overrides failed, degrading to team defaults",
+			"workspace_id", workspaceID, "err", err)
+		return nil
+	}
+	overrides, err := agentconfig.ValidateOverrides(ws.AgentConfigOverrides)
+	if err != nil {
+		b.log.Warn("bridge: parse workspace overrides failed, degrading to team defaults",
+			"workspace_id", workspaceID, "err", err)
+		return nil
+	}
+	return overrides
+}
+
 // injectAgentConfig loads agent config files and injects the unified system
 // prompt into session info. A no-op when config dir is empty or agent config
 // is not configured.
 // injectExclude lists file base names to skip; when nil, falls back to the
 // platform-level default from the atomic config map.
 //
+// workspaceOverrides selects the WebChat track (LoadForWorkspace) when non-nil;
+// nil selects the Message Channel track (Load with botName). WebChat sessions
+// don't select a bot, so botName is intentionally not passed to LoadForWorkspace.
+//
 // Parameter order note: botName (YAML config name, e.g. "my-bot") comes before
 // botID (platform runtime ID, e.g. "U12345") because botName is the primary key
 // for agent-config path resolution, while botID is only used for logging.
-func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botName, botID string, injectExclude []string) {
+func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botName, botID string, injectExclude []string, workspaceOverrides map[string]string) {
 	if b.agentConfigDir == "" {
 		return
 	}
@@ -337,8 +366,14 @@ func (b *Bridge) injectAgentConfig(info *worker.SessionInfo, platform, botName, 
 		b.log.Warn("bridge: inject_exclude contains unknown config files",
 			"unknown", unknown, "valid", agentconfig.KnownFiles())
 	}
-	b.log.Debug("bridge: loading agent config", "dir", b.agentConfigDir, "platform", platform, "bot_name", botName, "bot_id", botID, "exclude", injectExclude)
-	configs, err := agentconfig.Load(b.agentConfigDir, platform, botName, injectExclude...)
+	b.log.Debug("bridge: loading agent config", "dir", b.agentConfigDir, "platform", platform, "bot_name", botName, "bot_id", botID, "exclude", injectExclude, "workspace_overrides", workspaceOverrides != nil)
+	var configs *agentconfig.AgentConfigs
+	var err error
+	if workspaceOverrides != nil {
+		configs, err = agentconfig.LoadForWorkspace(b.agentConfigDir, platform, workspaceOverrides, injectExclude...)
+	} else {
+		configs, err = agentconfig.Load(b.agentConfigDir, platform, botName, injectExclude...)
+	}
 	if err != nil {
 		if errors.Is(err, agentconfig.ErrInvalidBotName) {
 			b.log.Error("bridge: agent config rejected",

--- a/internal/gateway/bridge_worker_test.go
+++ b/internal/gateway/bridge_worker_test.go
@@ -43,20 +43,20 @@ func TestResolveWorkspaceOverrides(t *testing.T) {
 	t.Run("empty workspace id returns nil", func(t *testing.T) {
 		t.Parallel()
 		b := newBridgeForOverrideTest(t, nil, nil)
-		require.Nil(t, b.resolveWorkspaceOverrides(""))
+		require.Nil(t, b.resolveWorkspaceOverrides(context.Background(), ""))
 	})
 
 	t.Run("nil wsStore returns nil", func(t *testing.T) {
 		t.Parallel()
 		b := &Bridge{log: testLogger(t)} // wsStore zero-value nil
-		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+		require.Nil(t, b.resolveWorkspaceOverrides(context.Background(), "ws-1"))
 	})
 
 	t.Run("valid overrides parsed", func(t *testing.T) {
 		t.Parallel()
 		ws := &session.Workspace{ID: "ws-1", AgentConfigOverrides: `{"SOUL.md":"x","USER.md":"y"}`}
 		b := newBridgeForOverrideTest(t, ws, nil)
-		got := b.resolveWorkspaceOverrides("ws-1")
+		got := b.resolveWorkspaceOverrides(context.Background(), "ws-1")
 		require.Equal(t, map[string]string{"SOUL.md": "x", "USER.md": "y"}, got)
 	})
 
@@ -64,19 +64,19 @@ func TestResolveWorkspaceOverrides(t *testing.T) {
 		t.Parallel()
 		ws := &session.Workspace{ID: "ws-1", AgentConfigOverrides: ""}
 		b := newBridgeForOverrideTest(t, ws, nil)
-		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+		require.Nil(t, b.resolveWorkspaceOverrides(context.Background(), "ws-1"))
 	})
 
 	t.Run("store error degrades to nil", func(t *testing.T) {
 		t.Parallel()
 		b := newBridgeForOverrideTest(t, nil, errors.New("boom"))
-		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+		require.Nil(t, b.resolveWorkspaceOverrides(context.Background(), "ws-1"))
 	})
 
 	t.Run("invalid JSON degrades to nil", func(t *testing.T) {
 		t.Parallel()
 		ws := &session.Workspace{ID: "ws-1", AgentConfigOverrides: `{bad`}
 		b := newBridgeForOverrideTest(t, ws, nil)
-		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+		require.Nil(t, b.resolveWorkspaceOverrides(context.Background(), "ws-1"))
 	})
 }

--- a/internal/gateway/bridge_worker_test.go
+++ b/internal/gateway/bridge_worker_test.go
@@ -1,0 +1,82 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hrygo/hotplex/internal/session"
+)
+
+// testLogger returns a minimal logger for bridge unit tests.
+func testLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	return slog.Default()
+}
+
+// stubWSStore implements WorkspaceOverridesReader for bridge helper tests.
+type stubWSStore struct {
+	ws  *session.Workspace
+	err error
+}
+
+func (s *stubWSStore) GetWorkspaceByID(_ context.Context, _ string) (*session.Workspace, error) {
+	return s.ws, s.err
+}
+
+// newBridgeForOverrideTest builds a minimal Bridge with only wsStore + log set,
+// enough to exercise resolveWorkspaceOverrides without the full dependency graph.
+func newBridgeForOverrideTest(t *testing.T, ws *session.Workspace, err error) *Bridge {
+	t.Helper()
+	return &Bridge{
+		log:     testLogger(t),
+		wsStore: &stubWSStore{ws: ws, err: err},
+	}
+}
+
+func TestResolveWorkspaceOverrides(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty workspace id returns nil", func(t *testing.T) {
+		t.Parallel()
+		b := newBridgeForOverrideTest(t, nil, nil)
+		require.Nil(t, b.resolveWorkspaceOverrides(""))
+	})
+
+	t.Run("nil wsStore returns nil", func(t *testing.T) {
+		t.Parallel()
+		b := &Bridge{log: testLogger(t)} // wsStore zero-value nil
+		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+	})
+
+	t.Run("valid overrides parsed", func(t *testing.T) {
+		t.Parallel()
+		ws := &session.Workspace{ID: "ws-1", AgentConfigOverrides: `{"SOUL.md":"x","USER.md":"y"}`}
+		b := newBridgeForOverrideTest(t, ws, nil)
+		got := b.resolveWorkspaceOverrides("ws-1")
+		require.Equal(t, map[string]string{"SOUL.md": "x", "USER.md": "y"}, got)
+	})
+
+	t.Run("empty overrides string returns nil", func(t *testing.T) {
+		t.Parallel()
+		ws := &session.Workspace{ID: "ws-1", AgentConfigOverrides: ""}
+		b := newBridgeForOverrideTest(t, ws, nil)
+		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+	})
+
+	t.Run("store error degrades to nil", func(t *testing.T) {
+		t.Parallel()
+		b := newBridgeForOverrideTest(t, nil, errors.New("boom"))
+		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+	})
+
+	t.Run("invalid JSON degrades to nil", func(t *testing.T) {
+		t.Parallel()
+		ws := &session.Workspace{ID: "ws-1", AgentConfigOverrides: `{bad`}
+		b := newBridgeForOverrideTest(t, ws, nil)
+		require.Nil(t, b.resolveWorkspaceOverrides("ws-1"))
+	})
+}

--- a/internal/gateway/deps.go
+++ b/internal/gateway/deps.go
@@ -1,11 +1,13 @@
 package gateway
 
 import (
+	"context"
 	"log/slog"
 	"time"
 
 	"github.com/hrygo/hotplex/internal/eventstore"
 	"github.com/hrygo/hotplex/internal/security"
+	"github.com/hrygo/hotplex/internal/session"
 )
 
 // HandlerDeps groups all dependencies for Handler construction.
@@ -18,6 +20,13 @@ type HandlerDeps struct {
 	SkillsLocator SkillsLocator
 }
 
+// WorkspaceOverridesReader is the narrow workspace-store subset Bridge needs to
+// resolve per-workspace agent-config overrides (spec ② §7.3). Kept separate from
+// session.UserWorkspaceStore so tests mock a single method.
+type WorkspaceOverridesReader interface {
+	GetWorkspaceByID(ctx context.Context, id string) (*session.Workspace, error)
+}
+
 // BridgeDeps groups all dependencies for Bridge construction.
 type BridgeDeps struct {
 	Log                *slog.Logger
@@ -28,9 +37,10 @@ type BridgeDeps struct {
 	RetryCtrl          *LLMRetryController
 	AgentConfigDir     string
 	TurnTimeout        time.Duration
-	WorkerEnv          []string            // extra env vars from worker.environment config
-	WorkerEnvBlocklist []string            // extra blocklist entries from worker.env_blocklist config
-	CronEnv            []string            // env vars injected only into cron platform sessions (e.g. admin API creds)
-	MCPConfigJSON      string              // pre-serialized MCP config JSON; "" = not configured → Claude Code default discovery
-	AgentConfigExclude map[string][]string // platform → inject_exclude (global default at "" key)
+	WorkerEnv          []string                 // extra env vars from worker.environment config
+	WorkerEnvBlocklist []string                 // extra blocklist entries from worker.env_blocklist config
+	CronEnv            []string                 // env vars injected only into cron platform sessions (e.g. admin API creds)
+	MCPConfigJSON      string                   // pre-serialized MCP config JSON; "" = not configured → Claude Code default discovery
+	AgentConfigExclude map[string][]string      // platform → inject_exclude (global default at "" key)
+	WSStore            WorkspaceOverridesReader // WebChat per-workspace agent-config overrides (spec ②); nil = disabled
 }

--- a/internal/gateway/workspace_handlers.go
+++ b/internal/gateway/workspace_handlers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hrygo/hotplex/internal/agentconfig"
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/session"
@@ -160,6 +161,19 @@ func (h *WorkspaceHandlers) Update(w http.ResponseWriter, r *http.Request) {
 		ws.Name = req.Name
 	}
 	if req.AgentConfigOverrides != "" {
+		if _, err := agentconfig.ValidateOverrides(req.AgentConfigOverrides); err != nil {
+			switch {
+			case errors.Is(err, agentconfig.ErrInvalidConfigJSON):
+				writeAppError(w, http.StatusBadRequest, "INVALID_CONFIG_JSON", err.Error())
+			case errors.Is(err, agentconfig.ErrUnknownConfigFile):
+				writeAppError(w, http.StatusBadRequest, "UNKNOWN_CONFIG_FILE", err.Error())
+			case errors.Is(err, agentconfig.ErrConfigTooLarge):
+				writeAppError(w, http.StatusBadRequest, "CONFIG_TOO_LARGE", err.Error())
+			default:
+				writeAppError(w, http.StatusBadRequest, "INVALID_CONFIG_VALUE", err.Error())
+			}
+			return
+		}
 		ws.AgentConfigOverrides = req.AgentConfigOverrides
 	}
 	if req.WorkerPreference != "" {

--- a/internal/gateway/workspace_handlers_test.go
+++ b/internal/gateway/workspace_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -134,4 +135,93 @@ func TestWorkspace_RequiresAuth(t *testing.T) {
 	w := httptest.NewRecorder()
 	env.wsHandlers.List(w, req)
 	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func (e *testAuthEnv) patchWorkspace(t *testing.T, cookie, id, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPatch, "/api/workspaces/"+id, bytes.NewReader([]byte(body)))
+	req.SetPathValue("id", id)
+	req.Header.Set("Cookie", cookie)
+	w := httptest.NewRecorder()
+	e.wsHandlers.Update(w, req)
+	return w
+}
+
+func TestWorkspace_PatchAgentConfigOverrides_Validation(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	cookie := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+	ws := env.createWorkspace(t, cookie, "proj", "/tmp/hotplex-ws-patch")
+
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "valid overrides accepted",
+			body:       `{"agent_config_overrides":"{\"SOUL.md\":\"x\",\"USER.md\":\"y\"}"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "empty object clears overrides",
+			body:       `{"agent_config_overrides":"{}"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid JSON rejected",
+			body:       `{"agent_config_overrides":"{not json"}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "INVALID_CONFIG_JSON",
+		},
+		{
+			name:       "unknown key rejected",
+			body:       `{"agent_config_overrides":"{\"META-COGNITION.md\":\"x\"}"}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "UNKNOWN_CONFIG_FILE",
+		},
+		{
+			name:       "non-string value rejected",
+			body:       `{"agent_config_overrides":"{\"SOUL.md\":123}"}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "INVALID_CONFIG_VALUE",
+		},
+		{
+			name:       "oversized file rejected",
+			body:       `{"agent_config_overrides":"{\"SOUL.md\":\"` + strings.Repeat("a", 8001) + `\"}"}`,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "CONFIG_TOO_LARGE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			w := env.patchWorkspace(t, cookie, ws.ID, tt.body)
+			require.Equal(t, tt.wantStatus, w.Code, "body=%s", w.Body.String())
+			if tt.wantCode != "" {
+				require.Contains(t, w.Body.String(), tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestWorkspace_PatchAgentConfigOverrides_Persists(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	cookie := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+	ws := env.createWorkspace(t, cookie, "proj", "/tmp/hotplex-ws-persist")
+
+	w := env.patchWorkspace(t, cookie, ws.ID, `{"agent_config_overrides":"{\"SOUL.md\":\"ws-soul\"}"}`)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Get round-trips the stored JSON (inner quotes are escaped by outer JSON encoding)
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+ws.ID, nil)
+	req.SetPathValue("id", ws.ID)
+	req.Header.Set("Cookie", cookie)
+	gr := httptest.NewRecorder()
+	env.wsHandlers.Get(gr, req)
+	require.Equal(t, http.StatusOK, gr.Code)
+	require.Contains(t, gr.Body.String(), `\"SOUL.md\":\"ws-soul\"`)
 }

--- a/internal/messaging/stt/AGENTS.md
+++ b/internal/messaging/stt/AGENTS.md
@@ -1,0 +1,60 @@
+# STT Package
+
+## OVERVIEW
+后端无关的语音转文字模块。定义 `Transcriber` 接口，提供本地命令、持久子进程、Fallback 三种实现。实际模型（Whisper/SenseVoice 等）由外部 `cmdTemplate` 决定，本包只管子进程生命周期与 JSON-over-stdio 协议。
+
+## STRUCTURE
+```
+stt/
+  stt.go              # Transcriber/Closer 接口 + LocalSTT/FallbackSTT/PersistentSTT + 工具函数
+  stt_job_unix.go     # closeJob no-op（Unix 用 PGID 清理）
+  stt_job_windows.go  # closeJob 调 proc.CloseJobHandle（Job Object KILL_ON_JOB_CLOSE）
+  *_test.go           # 测试
+```
+
+## WHERE TO LOOK
+| 任务 | 位置 | 说明 |
+|------|------|------|
+| Transcriber 接口 | `stt.go:27` | `Transcribe(ctx, audio) (string, error)` + `RequiresDisk() bool` |
+| 本地命令实现 | `stt.go:47` | `LocalSTT`: `{file}` 占位符，stdout 首行即结果 |
+| Fallback 实现 | `stt.go:86` | primary 失败或空 → secondary |
+| 持久子进程实现 | `stt.go:130` | `PersistentSTT`: JSON-over-stdio，模型常驻内存 |
+| stdin/stdout 协议 | `stt.go:199` | 入 `{"audio_path":...}`，出 `{"text":...,"error":...}` |
+| 双锁设计 | `stt.go:136-138` | `mu`（生命周期）+ `ioMu`（串行化 I/O）+ `inFlight` |
+| 可中断读行 | `stt.go:234` | `readLine`: ctx.Done 时 kill 子进程解锁 reader |
+| 分层终止 | `stt.go:364` | close stdin → GracefulTerminate PGID → 5s → ForceKill |
+| 空闲关闭 | `stt.go:450` | `idleMonitor`: 30s tick，inFlight + lastUsed vs idleTTL |
+| 临时音频文件 | `stt.go:488` | `<TempBaseDir>/media/stt_tmp/stt_<nanos>.opus`，defer 删除 |
+| Opus → PCM | `stt.go:503` | `AudioToPCM`: ffmpeg pipe → s16le 16kHz mono（供云端 API） |
+| 引用计数共享 | `stt.go:549` | `SharedTranscriber`: 多适配器共享同一子进程 |
+| 平台分离点 | `stt_job_*.go` | 仅 `closeJob`：Unix no-op，Windows 关 Job Object 句柄 |
+
+## KEY PATTERNS
+
+**后端无关设计**
+- 本包**不绑定**任何具体模型。Whisper / SenseVoice / 任何 CLI 都通过 `cmdTemplate` 注入
+- `PersistentSTT` 只负责：spawn 子进程、喂 audio_path、收 JSON、管生命周期
+- 配置示例：`stt.command: "sensevoice-server --port 0"`（外部二进制）
+
+**PersistentSTT 协议契约**
+```
+Go → stdin:  {"audio_path": "/tmp/.../stt_123.opus"}\n
+子进程 → stdout: {"text": "转录结果", "error": ""}\n
+```
+- stdout 行缓冲 64KB 起，上限 10MB（`stt.go:332`）
+- 读超时默认 30s（`readTimeout`），caller ctx 无 deadline 时兜底
+
+**进程隔离（跨平台）**
+- `proc.SetSysProcAttr`: Unix 设 PGID，Windows 设 CREATE_NEW_PROCESS_GROUP
+- `proc.CreateAndAssignJob`: Windows 绑 Job Object，Unix 返回空句柄
+- `proc.TrackPID`: 写全局 PID 文件，gateway 崩溃后启动期清理孤儿
+
+**idleMonitor 防死锁**
+- 不在 `terminate` 内等 `<-done`：idleMonitor 可能阻塞在调用方持有的 `mu` 上
+- 改为 cancel ctx 后让 monitor 自行退出（`stt.go:354` 注释）
+
+## ANTI-PATTERNS
+- ❌ 在本包硬编码模型名 —— 模型由 `cmdTemplate` 配置，保持后端无关
+- ❌ `readLine` 不设超时 —— 子进程卡住会永久阻塞，必须用 ctx 或 `readTimeout`
+- ❌ 临时音频文件不 defer 删除 —— 会撑爆 `<TempBaseDir>/media/stt_tmp`
+- ❌ Windows 跳过 `closeJob` —— 仅 PGID kill 清不掉子进程树，必须关 Job Object

--- a/internal/messaging/tts/AGENTS.md
+++ b/internal/messaging/tts/AGENTS.md
@@ -1,0 +1,61 @@
+# TTS Package
+
+## OVERVIEW
+Edge-TTS + MOSS 双引擎语音合成，FFmpeg 格式转换，LLM 长文摘要。实现 `Synthesizer` 接口，供 Slack/Feishu 适配器共享调用。无平台分离文件，全平台纯 Go。
+
+## STRUCTURE
+```
+tts/
+  tts.go            # Synthesizer/Closer 接口 + FallbackSynthesizer + SharedSynthesizer + 工厂
+  edge.go           # Edge-TTS 原生 WebSocket 实现（无三方依赖）
+  moss.go           # MossSynthesizer：委托 MossProcess，返回 WAV
+  moss_process.go   # MOSS-TTS-Nano FastAPI sidecar 进程管理
+  audio.go          # FFmpeg 转换：ToOpus/ToMP3 + Ogg 时长解析
+  prompt.go         # LLM 摘要（brain）+ SanitizeForSpeech 文本净化
+  truncate.go       # 句末标点感知截断
+  *_test.go         # 测试
+```
+
+## WHERE TO LOOK
+| 任务 | 位置 | 说明 |
+|------|------|------|
+| Synthesizer 接口 | `tts.go:17` | `Synthesize(ctx, text) ([]byte, error)` |
+| 默认引擎装配 | `tts.go:123` | `NewConfiguredSynthesizer`: Edge 主 + MOSS 备 Fallback |
+| Edge 令牌算法 | `edge.go:36` | `generateSecMSGec`: 5min 取整 → Windows 100ns ticks → SHA256 |
+| Edge WebSocket 握手 | `edge.go:66` | `synthesizeEdge`: config msg → SSML msg → 收 `turn.end` |
+| SSML 模板 | `edge.go:154` | `<speak><voice><prosody pitch rate volume>` |
+| SSML 转义 | `edge.go:180` | `sanitizeSSMLText`: XML 实体 + 剔除控制字符 |
+| 音频 wire 解析 | `edge.go:129` | 2 字节大端头长 + headers + audio |
+| FFmpeg → Opus（Feishu） | `audio.go:14` | `ToOpus`: 24kHz mono libopus，stdin/stdout pipe |
+| FFmpeg → MP3（Slack） | `audio.go:47` | `ToMP3`: 已是 MP3 则跳过（`isMP3` 探测） |
+| Ogg 时长 | `audio.go:120` | `ParseOggDurationMs`: 扫页取最大 granule（48kHz） |
+| MOSS sidecar 启动 | `moss_process.go:214` | `start`: single-flight + 60s warmup 轮询 `/api/warmup-status` |
+| MOSS 合成 API | `moss_process.go:87` | POST `/api/generate` form: text/voice/max_new_frames=150 |
+| MOSS 空闲关闭 | `moss_process.go:390` | `idleMonitor`: 30s tick，activeCount + lastUsed vs idleTTL |
+| LLM 播报摘要 | `prompt.go:52` | `SummarizeForTTS`: brain.Global + 中文口语化 system prompt |
+| 播报文本净化 | `prompt.go:84` | `SanitizeForSpeech`: 去 markdown/零宽字符/裸路径，大数中文化 |
+
+## KEY PATTERNS
+
+**Edge Sec-MS-GEC 令牌（`edge.go`）**
+- 时间戳 floor 到 300s 边界 → 转 Windows epoch 100ns ticks → `SHA256(ticks + TrustedClientToken)` 大写 hex
+- `TrustedClientToken` 硬编码常量，Chromium UA + Origin 伪装成 Edge 浏览器扩展
+
+**Fallback 链（`tts.go`）**
+- `FallbackSynthesizer`: primary 失败 → ctx 未取消才尝试 secondary
+- `SharedSynthesizer`: 原子引用计数，多适配器共享同一 MOSS sidecar 进程
+
+**MOSS sidecar 生命周期（`moss_process.go`）**
+- 懒启动 + single-flight（`readyCh`）：首调用者 spawn+warmup，余者等通知
+- 分层终止：GracefulTerminate PGID → 5s → ForceKill，`proc.TrackPID` 孤儿清理
+- 崩溃自愈：`maybeRestart` 检测进程死亡 → 置 `started=false`，下次请求重启
+
+**输出格式约定**
+- Edge 输出 MP3（24kHz mono），MOSS 输出 WAV（48kHz stereo）
+- 平台发送前转码：Feishu 需 Opus（`ToOpus`），Slack 需 MP3（`ToMP3`）
+
+## ANTI-PATTERNS
+- ❌ 直连 Edge 不带 `Sec-MS-GEC` —— 令牌 5 分钟过期，必须现算
+- ❌ 跳过 `sanitizeSSMLText` —— 未转义的 `<>&'` 会破坏 SSML 解析
+- ❌ MOSS sidecar 退出不调 `Close` —— 会泄漏 python3 进程（靠 PID tracker 兜底）
+- ❌ 长文直接送 TTS —— 先 `SummarizeForTTS` 摘要再合成，避免超长音频

--- a/internal/messaging/yuanxin/AGENTS.md
+++ b/internal/messaging/yuanxin/AGENTS.md
@@ -1,0 +1,60 @@
+# Yuanxin (元芯) Adapter
+
+## OVERVIEW
+元芯平台适配器。传输层用 **Apache Pulsar** 消息队列（非 HTTP/WebSocket），消费请求 topic、生产响应 topic。嵌入泛型 `BaseAdapter[*YuanxinConn]`，非流式（缓冲 delta，Done 时整条回发）。
+
+## STRUCTURE
+```
+yuanxin/
+  adapter.go          # Adapter + YuanxinConn + Pulsar 消费/生产 + WriteCtx 分发（690 行）
+  adapter_test.go     # 测试
+```
+
+## WHERE TO LOOK
+| 任务 | 位置 | 说明 |
+|------|------|------|
+| 注册 | `adapter.go:19` | `init()` → `messaging.Register(PlatformYuanxin, ...)` |
+| 配置 | `adapter.go:57` | `ConfigureWith`: app_id 必填，pulsar_url/tenant/ns/producer_topic 有默认 |
+| Pulsar 连接 | `adapter.go:211` | `connect`: NewClient → Subscribe consumer → CreateProducer |
+| 消费 topic | `adapter.go:237` | `persistent://<tenant>/<ns>/chatbot-<appID>-request`，Shared 订阅 |
+| 生产 topic | `adapter.go:248` | 默认 `global-open-claw-response-topic`，含 `://` 则原样用 |
+| 重连循环 | `adapter.go:116` | `runConsumer`: 指数退避（默认 2s/60s），3 次 receive 重试 |
+| 消息处理 | `adapter.go:329` | `handleMessage`: 解析 `YuanxinMessage` → Sanitize → Dedup → Gate → Bridge |
+| 消息格式 | `adapter.go:324` | `YuanxinMessage{Metadata map, Msg string}`，Metadata 承载路由 |
+| 用户标识 | `adapter.go:352` | `metadata.replyUserCodes` 作 userID，缺失回退 msg ID |
+| 发送响应 | `adapter.go:495` | `SendResponse`: producer.Send，Metadata 回带 conn 缓存 |
+| Cron 投递 | `adapter.go:405` | `SendCronResult`: 重组 Metadata（botId/messageId/sysId/platform="yx"） |
+| WriteCtx 分发 | `adapter.go:573` | delta 累积 → Done 整发；Error 发错误文本；交互降级纯文本 |
+| 连接实现 | `adapter.go:531` | `YuanxinConn`: channelID/threadKey/metadata/textBuilder |
+
+## KEY PATTERNS
+
+**Pulsar 双 topic 模型**
+- 收：consumer 订阅 `chatbot-<appID>-request`，`SubscriptionName=hotplex-gateway-<appID>`
+- 发：producer 写 `<producerTopic>`，单条消息完整投递（无流式分片）
+- URL 协议限 `pulsar://` 或 `pulsar+ssl://`（`adapter.go:66` 校验）
+
+**非流式缓冲（`YuanxinConn.WriteCtx`）**
+- `MessageDelta` 累积进 `textBuilder`（1MB 上限 `maxTextBuilderSize`）
+- 仅 `Done`/`Error` 触发 `SendResponse` 整条发送
+- 与 Slack/Feishu 的分块流式不同：元芯只有"全文一次性回发"
+
+**Metadata 透传**
+- 请求 Metadata（`replyUserCodes`/`sysId`/`secret` 等）存入 conn
+- 响应原样回带，平台侧据此路由到发起方
+- Cron 投递时重组 Metadata，补 `messageId`/`botId`
+
+**交互降级为纯文本**
+- permission/question/elicitation 无卡片，渲染成中文提示串
+- 例：`"权限请求：<tool>\n\n说明：<desc>\n\n选项：允许(allow)/拒绝(deny)"`（`adapter.go:649`）
+- 用户回复走 Bridge.Handle 自然语言路径
+
+**泛型 BaseAdapter（`adapter.go:30`）**
+- `BaseAdapter[*YuanxinConn]` 是较 Slack/Feishu 更新的泛型基座
+- `InitConnPool` 工厂按 `channelID#threadKey` 建 conn
+
+## ANTI-PATTERNS
+- ❌ 直接连 Pulsar 不走 `connect` —— 会绕过双检锁与旧 client 清理（`adapter.go:264`）
+- ❌ 响应不带 Metadata —— 平台侧无法路由，消息会丢
+- ❌ 假设流式 —— 元芯只收完整文本，不要在 WriteCtx 里分片发送
+- ❌ `consumer.Receive` 失败不退出 —— 超过 3 次重试必须退出重连，否则卡死

--- a/internal/observability/AGENTS.md
+++ b/internal/observability/AGENTS.md
@@ -1,0 +1,64 @@
+# Observability Package
+
+## OVERVIEW
+Unified OpenTelemetry bootstrap for the gateway: Prometheus metrics endpoint plus OTLP trace/metric export, all behind one `Init()` call with a noop fallback. Owns the full instrument registry (39 metrics across 9 domains) and the `RegisterGaugeCallbacks` indirection that lets other packages register gauges without racing package `init()`.
+
+## STRUCTURE
+```
+observability/
+  config.go          # Config struct, DefaultConfig(), IsOTELSDKDisabled()
+  observability.go   # Init() (sync.Once), Meter()/Tracer(), resource + exporters, gauge registrar
+  instruments.go     # 39 lazy instrument accessors, each guarded by its own sync.Once
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Bootstrap | `observability.go:46` Init | `initOnce.Do`; returns shutdown fn |
+| Noop fast-path | `observability.go:51` | `OTEL_SDK_DISABLED=true` or resource error → noop meter/tracer, still runs gauge callbacks |
+| Meter accessor | `observability.go:90` Meter | Returns `noopMeter` before Init runs |
+| Tracer accessor | `observability.go:121` Tracer | Returns `noopTracer` before Init runs |
+| Gauge registrar | `observability.go:107` RegisterGaugeCallbacks | Appends to `gaugeCallbackRegistrars`; called by session/pool packages |
+| Run gauge callbacks | `observability.go:113` runGaugeCallbacks | Invoked at end of Init only when meter is real |
+| W3C propagation | `observability.go:73` | Composite `TraceContext` + `Baggage` |
+| Trace exporter | `observability.go:170` initTracing | Noop SDK if no OTLP endpoint; ParentBased TraceIDRatio sampler |
+| Metric exporter | `observability.go:207` initMetrics | Prometheus reader always (when enabled) + OTLP periodic reader |
+| Prometheus handler | `observability.go:286` MetricsHandler | Returns `promhttp.Handler()`; app code never imports prometheus directly |
+| Config defaults | `config.go:71` DefaultConfig | SampleRate 0.1, MetricInterval 30s, CardinalityLimit 5000 |
+| Shutdown | `observability.go:128` | Joins tracer + meter shutdown errors via `errors.Join` |
+
+## KEY PATTERNS
+
+**sync.Once Init with noop fallback**
+- `initOnce` guarantees single setup. Three noop triggers: `OTEL_SDK_DISABLED=true`, `buildResource` failure, or missing `OTEL_EXPORTER_OTLP_ENDPOINT` (tracing only).
+- `Meter()` and `Tracer()` return package-level noop instances whenever `globalMeter`/`globalTracer` are still nil, so callers in early-init code paths never panic.
+
+**RegisterGaugeCallbacks (init-order workaround)**
+- Problem: packages like `session` and `pool` own gauge state but their `init()` runs before `observability.Init()`. Calling `Meter().RegisterCallback(...)` from their init hit the noop meter and silently dropped the callback.
+- Fix: those packages call `RegisterGaugeCallbacks(fn)` at init time. `Init()` invokes every registered `fn` with the live meter at the end of setup via `runGaugeCallbacks`. Callbacks are skipped under noop (the `globalMeter != noopMeter` guard).
+
+**Per-metric sync.Once (39 occurrences)**
+- Every instrument accessor (`SessionCreated()`, `GatewayMessages()`, ...) holds its own `sync.Once`. First call lazily creates the instrument through `Meter()` and caches it. Repeat calls are free.
+- Creation failures are logged via `warnInstrument` (metric name + err) rather than panicked, so a single misconfigured meter cannot take the gateway down.
+
+**Sampler and cardinality caps**
+- Root spans sampled at `cfg.SampleRate` (default 10%). Child spans respect parent decisions via `ParentBased`.
+- Metric reader enforces `CardinalityLimit` (default 5000) to bound series explosion from high-cardinality labels.
+
+**Instrument inventory (39 metrics, 9 domains)**
+- Session: `hotplex.session.created`, `.terminated`, `.deleted`, `.start.attempts`, `.start.errors`, `.start.duration`
+- Worker: `hotplex.worker.starts`, `.execution.duration`, `.crashes`, `.memory.bytes`, `.creation.duration`
+- Gateway: `hotplex.gateway.connections`, `.messages`, `.events`, `.deltas.dropped`, `.platform.dropped`, `.no_subscribers.dropped`, `.delta.coalesced`, `.delta.flush`, `.errors`, `.init.handshake.duration`
+- Pool: `hotplex.pool.acquire`, `.release.errors`
+- Cron: `hotplex.cron.fires`, `.errors`, `.duration`, `.attached`, `.delivery.result`
+- Streaming card: `hotplex.streaming.card.rotations`, `.rotation_failures`, `.flush_fallbacks`
+- ACP: `hotplex.acp.prompt_tokens`, `.tool_calls`, `.permission_requests`, `.handshake.duration`
+- Session guard: `hotplex.session.transition.guard.repersist.failures`, `.repersist.overwrites`
+- Retry: `hotplex.retry.attempts`, `.exhaustion`
+
+## ANTI-PATTERNS
+- ❌ Call `Meter().RegisterCallback(...)` from another package's `init()` — returns noop before Init; use `RegisterGaugeCallbacks` instead
+- ❌ Skip `errors.Join` in shutdown — partial exporter failures would mask the first error
+- ❌ Import `prometheus/client_golang` from app code — go through `MetricsHandler()`
+- ❌ Create instruments at package var time — breaks lazy creation and the noop fallback; use the accessor functions
+- ❌ Set `SampleRate` above 1.0 or below 0 — `TraceIDRatioBased` expects a ratio in `[0,1]`

--- a/internal/sqlutil/AGENTS.md
+++ b/internal/sqlutil/AGENTS.md
@@ -1,0 +1,50 @@
+# SQL Driver Plumbing Package
+
+## OVERVIEW
+Low-level database driver registration and SQLite-specific helpers shared by every store in HotPlex. Registers pure-Go SQLite (`modernc.org/sqlite`) and PostgreSQL (`pgx/v5/stdlib`) drivers, applies the SQLite PRAGMA stack on open, and exposes `WriteMu` to serialize writes at the application level. A companion combined doc lives at `internal/dbutil/AGENTS.md`.
+
+## STRUCTURE
+```
+sqlutil/
+  driver.go     # Blank-imports both drivers; exposes DriverName / DriverNamePG constants
+  open.go       # OpenDB + PoolOpts: SQLite-only open with dir creation, PRAGMA, pool config
+  pragma.go     # InitSQLiteDB: 8 PRAGMAs gated by config, no-op when dialect == postgres
+  writemu.go    # WriteMu + DialectSQLite / DialectPostgres constants (mirrored from dbutil)
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Driver constants | `driver.go:10` | `DriverName="sqlite"`, `DriverNamePG="pgx"` |
+| Open SQLite | `open.go:23` OpenDB | Rejects non-SQLite dialect; Postgres path lives in `dbutil.Open` |
+| Pool config | `open.go:14` PoolOpts | MaxOpen/MaxIdle/MaxLifetime/MaxIdleTime applied only when > 0 |
+| Parent dir mkdir | `open.go:32` | Creates db dir (mode 0755) unless `.` or `/` |
+| PRAGMA stack | `pragma.go:14` InitSQLiteDB | Returns nil immediately for Postgres |
+| Write serializer | `writemu.go:17` WriteMu | `mu sync.Mutex` (explicit, not embedded) + dialect string |
+| NewWriteMu | `writemu.go:25` | Empty dialect defaults to SQLite (safe-write behavior) |
+| WithLock helper | `writemu.go:50` | nil-safe; calls `fn` without locking for Postgres |
+
+## KEY PATTERNS
+
+**WriteMu behavior split**
+- SQLite: every `Lock`/`Unlock`/`WithLock` acquires the real `sync.Mutex`. One `*WriteMu` instance is shared across all SQLite stores (session, event, cron, message) to eliminate `SQLITE_BUSY`.
+- PostgreSQL: all three methods short-circuit on `m.dialect == DialectPostgres`. PG's MVCC handles concurrency natively, so the mutex is pure overhead.
+- The mutex field is named `mu` and never embedded, matching the project convention.
+
+**Dialect constant duplication (import-cycle avoidance)**
+- `DialectSQLite` / `DialectPostgres` are declared in `writemu.go:9` even though `dbutil.Dialect` already models the same concept.
+- Reason: `dbutil` imports `sqlutil` (it calls `OpenDB`), so `sqlutil` cannot import `dbutil` back without a cycle. The two definitions must stay string-equal; treat both as the source of truth for the literal `"sqlite"` / `"postgres"` values.
+
+**PRAGMA gating**
+- `InitSQLiteDB` reads `config.DBConfig` effective values (WAL, busy_timeout, cache_size, mmap_size, wal_autocheckpoint) so tuning is config-driven, not hard-coded.
+- WAL-only PRAGMAs (`journal_mode=WAL`, `wal_autocheckpoint`) are skipped when `EffectiveWALMode()` is false.
+
+**Open-time failure handling**
+- `openSQLiteDB` closes the `*sql.DB` if `InitSQLiteDB` returns an error, preventing leaked connections on misconfigured startup.
+
+## ANTI-PATTERNS
+- ❌ Import `dbutil` from `sqlutil` — creates a cycle; use the mirrored constants here
+- ❌ Open SQLite without `InitSQLiteDB` — missing PRAGMAs risk corruption and busy errors
+- ❌ Skip `WriteMu.WithLock` for SQLite writes — concurrent stores will hit `SQLITE_BUSY`
+- ❌ Rely on `Lock`/`Unlock` to do anything on Postgres — they are no-ops by design
+- ❌ Let `DialectSQLite`/`DialectPostgres` literals drift from `dbutil.Dialect` values — stores compare strings directly

--- a/internal/updater/AGENTS.md
+++ b/internal/updater/AGENTS.md
@@ -1,0 +1,53 @@
+# Self-Update Package
+
+## OVERVIEW
+GitHub Releases-driven binary self-update: check latest, download archive, verify sha256, extract, atomic rename. Used by `cmd/hotplex/update.go`. Windows cannot replace a running exe and falls back to `scripts/install.ps1`.
+
+## STRUCTURE
+```
+updater/
+  updater.go        # Full pipeline: Check → Download → VerifyChecksum → Extract → Replace
+  updater_test.go   # Table-driven tests
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Build updater | `updater.go:60` New | Production defaults: repo `hrygo/hotplex`, 30s client, GOOS/GOARCH from runtime |
+| Query latest release | `updater.go:90` Check | `GET /repos/{repo}/releases/latest`, 1MB JSON cap, 403 = rate-limited |
+| Resolve asset | `updater.go:120` Check loop | Prefers archive; legacy raw-binary fallback sets `IsLegacyBinary` |
+| Download archive | `updater.go:157` Download | New client without Timeout (ctx controls deadline), 200MB cap |
+| Verify checksum | `updater.go:292` VerifyChecksum | Downloads `checksums.txt` (64KB cap), sha256 compare via `EqualFold` |
+| Extract binary | `updater.go:209` extractBinary | zip on Windows, tar.gz elsewhere; path-traversal guard (`..`/abs rejected) |
+| Atomic replace | `updater.go:342` Replace | 3-step rename: `exe → exe.old`, `new → exe`, remove backup; rollback on step-2 failure |
+| Pre-flight writability | `updater.go:379` IsWritable | Resolves symlinks, probes `O_WRONLY`; hints `sudo` on EPERM |
+| Docker detection | `updater.go:393` IsDocker | `/.dockerenv` or cgroup scan; caller disables self-update |
+| Version compare | `updater.go:437` versionEqual | `v` prefix normalized; equality only, no semver ordering |
+
+## KEY PATTERNS
+
+**Atomic rename (Replace)**
+- Renames live exe to `exe.old` then moves new binary into place. Relies on POSIX rename atomicity on the same filesystem.
+- On failure mid-install, rolls the backup back so the prior version keeps running.
+- Backup `.old` removal is best-effort (`_ = os.Remove`).
+
+**Archive selection (Check)**
+- Two asset shapes supported: `hotplex-{os}-{arch}.tar.gz` (or `.zip` on Windows) and the legacy raw `hotplex-{os}-{arch}` binary.
+- Sets `CheckResult.IsLegacyBinary` so callers know the pre-archive asset was used.
+
+**Checksum enforcement**
+- `VerifyChecksum` refuses empty `checksums.txt` URL rather than silently skip. Parses `{hash}  {filename}` lines, tolerant of path prefixes via `filepath.Base`.
+- `EqualFold` compare handles lowercase/uppercase hex mix.
+
+**Path safety in extraction**
+- `extractFromTarGz` rejects entries containing `..` or absolute paths before writing.
+- Both extractors cap output at 200MB via `io.LimitReader`.
+
+**Docker short-circuit**
+- `IsDocker()` lets `update.go` surface a user-facing message instead of attempting an in-place replace inside a throwaway container layer.
+
+## ANTI-PATTERNS
+- ❌ Call `Replace` on Windows — running exe is locked; redirect users to `scripts/install.ps1`
+- ❌ Skip `VerifyChecksum` when `checksums.txt` is absent — package returns an error by design
+- ❌ Use a single shared `http.Client` with `Timeout` for download — large files time out; package builds a no-timeout client and relies on `ctx`
+- ❌ Trust `versionEqual` for ordering — it is equality only; there is no semver `<`/`>` here

--- a/internal/worker/acp/AGENTS.md
+++ b/internal/worker/acp/AGENTS.md
@@ -1,0 +1,89 @@
+# ACP Worker Adapter (Agent Client Protocol)
+
+## OVERVIEW
+通用 ACP v1 适配器，stdio 传输 JSON-RPC 2.0 over NDJSON。支持任何 ACP 兼容 agent（默认 `hermes acp`）。完整生命周期：Initialize 握手 → NewSession/LoadSession/ForkSession → session/prompt → session/cancel。B/C 通道 system prompt 作为首条 user input 前缀注入（ACP v1 无原生 system prompt）。
+
+## STRUCTURE
+```
+acp/
+  worker.go           # Worker: Start/Input/Resume/Terminate/ResetContext, lifecycle 编排, server request 路由
+  client.go           # ACPClient: JSON-RPC 调用 + readLoop, Initialize/NewSession/LoadSession/ForkSession/Prompt
+  codec.go            # NDJSON 编解码: JSONRPCRequest/Response/Notification/Error, WriteMessage/ReadMessage
+  mapper.go           # ACPMapper: notification → AEP Envelope, tool_call/plan/usage/permission 映射
+  conn.go             # acpConn: SessionConn 实现（仅 up 方向），TrySend 背压感知, InputRecoverer
+  trace.go            # TraceWriter: JSONL 协议级调试 trace（acp.debug:true 启用，50MB rotation）
+  stderr_handler.go   # acpStderrHandler: system prompt/traceback/XML config 折叠（per-session 状态）
+  *_test.go           # 单元测试 + bench + phase2/phase3 集成测试
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Initialize 握手 | `client.go:60` Initialize() | 30s timeout，协商 protocolVersion + agentInfo |
+| NewSession / LoadSession / ForkSession | `client.go:80,86,180` | LoadSession 需 capability，Fork 用于 AC-FR08-01 |
+| Prompt / Cancel | `client.go:99,121` | Prompt 30min 阻塞；Cancel 2-3s 短超时 |
+| JSON-RPC call + ID 兜底 | `client.go:272,340` | nextID 原子；`alternateIDKey` 兼容 `"1"` vs `1` |
+| 消息分发 readLoop | `client.go:214` | Response→pending / Notification→NotificationCh / Request→RequestCh |
+| NDJSON 编解码 | `codec.go:70,89` | WriteMessage 独立分配 line slice；ReadMessage discriminator 分类 |
+| Scanner buffer | `codec.go:56` | 初始 64KB，硬上限 10MB |
+| Start 编排 | `worker.go:236` Start() | 字段→proc→client→readLoop→Initialize→session→mapper→conn |
+| Session 类型决策 | `worker.go:372` | Fork→fork; loadSession cap→Load; 否则 NewSession |
+| 首输入注入（system prompt + JSON Schema） | `worker.go:478,482` | `[SYSTEM INSTRUCTIONS]` 前缀，CAS 保证只注入一次 |
+| Prompt 错误分类 | `worker.go:509` | `isFatalRPCError` → WorkerError(Unavailable) 触发崩溃恢复 |
+| Terminate 流程 | `worker.go:555` | trace→cancel→conn.Close→proc.Close（解阻塞 Scan）→client.Cancel→base.Terminate |
+| ResetContext | `worker.go:683` | 同进程新建 session（PID 不变，acpSessionID 变） |
+| Server request 路由 | `worker.go:998` handleServerRequest() | `session/request_permission` + 其他 → Raw 转发 |
+| 自动批准 | `worker.go:1008` | `autoApprove` atomic.Bool，默认 true（sandbox 无人工审批） |
+| 权限响应 | `worker.go:839` HandlePermissionResponse() | pendingPerm map → RespondRequest |
+| Notification → AEP | `mapper.go:81` MapNotification() | session/update 分发到 text/thought/tool/plan/mode/usage |
+| Permission request 映射 | `mapper.go:404` MapPermissionRequest() | PermissionMapResult 含 allowed/denied outcome |
+| TrySend 背压 | `conn.go:59` | droppable（message.delta/raw）丢弃；critical 阻塞 5s |
+| InputRecoverer | `conn.go:130` LastInput() | atomic.Pointer[string]，崩溃恢复重投递 |
+| Trace 启用 / rotation | `worker.go:344` / `trace.go:86` | `acp.debug:true` → NewTraceWriter，50MB rotation |
+
+## KEY PATTERNS
+
+**JSON-RPC 2.0 三类消息（codec.go）**
+- `JSONRPCRequest`: id + method（client 发起或 server 发起如 request_permission）
+- `JSONRPCResponse`: id + result/error
+- `JSONRPCNotification`: 无 id，有 method（session/update 主力）
+- 单次 unmarshal 用 discriminator 字段（`ID`/`Method` 是否为 nil）分类
+
+**ACP 会话状态机（worker.go:372）**
+```
+首次启动：             → NewSession
+WorkerSessionID 存在：ForkSession→Fork；loadSession cap→Load；否则 NewSession
+失败回退：             → NewSession + historyLost=true（发 HISTORY_LOST error 给客户端）
+```
+
+**双阶段超时**：Initialize 30s handshake；NewSession/LoadSession 独立 30s（不与 handshake 共享预算）
+
+**Prompt 错误双层分类（worker.go:509）**
+- `JSONRPCError` + `isFatalRPCError`（session not found/expired/invalid）→ `WorkerError{Kind: Unavailable}` 触发 Bridge 崩溃恢复
+- 业务错误（rate limit, permission denied）→ nil（worker 继续）
+
+**通知 drain 协议（worker.go:526）**
+- Prompt 返回前必须 drain 缓冲通知，否则 Input 与 readLoop 竞争 NotificationCh
+- 双 channel 信号：`drainCh` 触发 readLoop 排空，`drainDoneCh` 回执；readLoop 是 NotificationCh 唯一消费者
+
+**Terminate 关键顺序**
+- `proc.Close()` 必须早于 base.Terminate：关闭 stdout pipe 解除 `Scan()` 阻塞（ctx cancel 不中断 in-progress Scan）
+- `client.Cancel` 2s 短超时，不侵蚀 SIGTERM grace period
+
+**SystemPrompt/JSONSchema 注入**
+- ACP v1 无原生 system prompt，作为首条 user input 前缀（`[SYSTEM INSTRUCTIONS]...[/SYSTEM INSTRUCTIONS]` 包裹）
+- `CompareAndSwap(false, true)` 保证只注入一次；ResetContext 后重置
+
+**Capability 协商（worker.go:649）**：缺省 true（未声明视为支持），显式 false 才否定；当前仅 `loadSession` 受控
+
+**acpConn 仅 up 方向**：`Send()` 返回 `ErrNotImplemented`（用户输入走 client.Prompt）；`Recv()` 返回 readLoop → TrySend 的 recvCh；实现 `InputRecoverer`
+
+**Stderr 折叠（per-session 状态）**：12KB+ system prompt echo → 单行 Debug；Python traceback → 末行 Error；XML config → Debug；安全阀 256 行/32KB 强制 flush
+
+## ANTI-PATTERNS
+- ❌ 直接读 `client.NotificationCh` — readLoop 是唯一消费者，Input 必须走 drain 协议
+- ❌ 跳过 `proc.Close()` 直接 base.Terminate — Scan() 不会因 ctx cancel 解阻塞
+- ❌ 假设 agent ID 格式 — 用 `alternateIDKey` 兜底 `"1"` vs `1` 差异
+- ❌ 跳过 capability 检查直接 LoadSession — 不支持的 agent 会报错
+- ❌ Propagate nested agent env — `acpEnvBlocklist` 必须通过 `base.BuildEnv` 强制剥离
+- ❌ 在 acpConn.Send 实现真实写入 — 用户输入只能走 `client.Prompt`，acpConn 只负责 up 方向

--- a/internal/worker/base/AGENTS.md
+++ b/internal/worker/base/AGENTS.md
@@ -1,0 +1,84 @@
+# Shared Worker Base (base)
+
+## OVERVIEW
+所有 stdio worker 适配器（claudecode / opencodeserver）共享基座。`BaseWorker` 提供生命周期方法（Terminate/Kill/Wait/Health/LastIO）+ reset generation 计数；`Conn` 提供 NDJSON stdin SessionConn；`BuildEnv` 7 层安全构造子进程 env；`MetadataHandler` 统一三类控制响应分发。ACP 不复用 Conn（自建 acpConn）但仍 embed BaseWorker。
+
+## STRUCTURE
+```
+base/
+  worker.go             # BaseWorker: Terminate/Kill/Wait/Health/LastIO/Conn/resetGen
+  conn.go               # Conn: stdin NDJSON SessionConn, WriteMu/StdinLocked, InputRecoverer
+  env.go                # BuildEnv: 7 层 env 构造（blocklist + HOTPLEX_WORKER_ strip + session vars）
+  metadata.go           # MetadataHandler 接口 + DispatchMetadata 三类控制响应路由
+  pipeerr_unix.go       # IsDeadProcessError: EPIPE / ErrClosed
+  pipeerr_windows.go    # IsDeadProcessError: ERROR_BROKEN_PIPE / ERROR_NO_DATA
+  writeall_unix.go      # WriteAll: EAGAIN retry（macOS non-blocking pipe）
+  writeall_windows.go   # WriteAll: 无 EAGAIN，纯 partial write 循环
+  *_test.go             # Conn IO + env 构造 + worker lifecycle 测试
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Embed BaseWorker | `worker.go:30` | 适配器 embed `*base.BaseWorker`，`w.Mu` / `w.Proc` / `w.Log` 直接复用 |
+| Lifecycle 入口 | `worker.go:100,110,120` | Terminate/Kill/Wait，委托 proc.Manager |
+| Health 快照 | `worker.go:131` | PID/Running/Uptime/SessionID |
+| LastIO 原子读写 | `worker.go:162,171` | `atomic.Int64` 存 unix nano |
+| SetConn / SetConnLocked | `worker.go:176,184` | 后者调用方持锁 |
+| Reset generation | `worker.go:198,203` | forwardEvents 用于区分 reset vs crash |
+| Grace 常量 | `worker.go:26` | `GracefulShutdownTimeout = proc.DefaultGracePeriod`（5s） |
+| Conn 创建 | `conn.go:29` | recvCh cap=256 |
+| NDJSON Send | `conn.go:43` | 持 Mu 防 ControlHandler 写交错；EPIPE→WorkerError(Unavailable) |
+| Stdin 原子访问 | `conn.go:128` StdinLocked() | 返回 stdin + 已锁 Mu，调用方解锁 |
+| WriteMu 共享 | `conn.go:111` | ControlHandler 与 Send 共用同一 mutex |
+| CloseInput EOF | `conn.go:151` | 关闭 stdin pipe，worker 处理完缓冲后退出 |
+| InjectWithTimeout | `conn.go:87` | 2s 超时 + recover；Conn/acpConn/ocsConn 共享 |
+| LastInput 崩溃恢复 | `conn.go:200` | 持 Mu 字符串字段（acpConn 用 atomic.Pointer） |
+| Env 7 层构造 | `env.go:52` BuildEnv() | 见下 KEY PATTERNS |
+| HOTPLEX_WORKER_ 剥离 | `env.go:20,79` | 仅此前缀剥离，其他 HOTPLEX_* 阻塞 |
+| 动态 block 系统 secret | `env.go:108-112` | 剥离版存在时系统级同名变量自动屏蔽 |
+| nested agent 剥离 | `env.go:137` | `security.StripNestedAgent` 移除 `CLAUDECODE=` |
+| MetadataHandler 接口 | `metadata.go:8` | permission/question/elicitation 三类 |
+| DispatchMetadata 路由 | `metadata.go:17` | Input metadata type-switch，命中即终止 |
+| Pipe 错误检测 | `pipeerr_*.go` | Unix: EPIPE/ErrClosed；Win: ERROR_BROKEN_PIPE/NO_DATA |
+| WriteAll EAGAIN retry | `writeall_unix.go` | macOS 非阻塞 pipe，`runtime.Gosched()` 让出 |
+
+## KEY PATTERNS
+
+**BaseWorker embedding（高耦合影响）**
+- 每个 stdio 适配器 embed `*base.BaseWorker`，共享 `Mu` / `Proc` / `Log` / `Cfg` / `lastIO` / `resetGen`
+- ACP 也 embed 但 **不复用 Conn**（acpConn 仅 up 方向，user input 走 client.Prompt）：`SetConnLocked(nil)` + 重写 `Conn()` 方法
+- 修改 BaseWorker 字段 = 同步影响所有 4 个适配器
+
+**withProc 模式（worker.go:62-97）**：三泛型 helper（`withProc`/`withProcCode`/`withProcResult`），锁内 snapshot Proc，锁外调用 fn，成功后锁内置 nil。消除重复 lock-snapshot-nil-clear，保证 Terminate/Kill/Wait 只执行一次。
+
+**resetGen 解决 reset vs crash 竞态（worker.go:41-48）**：`IncResetGeneration()` 在 Terminate+Start 前递增；forwardEvents goroutine 启动时捕获 gen，recv channel 关闭后比较当前 gen；不一致 = 期间发生 reset，旧 forwardEvents 干净退出（不触发崩溃处理）。替代旧版 boolean flag 的竞态漏洞。
+
+**Conn 并发契约**
+- `Send` 持 `c.mu`，防 ControlHandler 同 fd 写交错；`StdinLocked()` 返回 Mu 已锁状态供原子 read-write-SetLastInput 序列；`WriteMu()` 暴露 Mu 给 ControlHandler 共享
+- recvCh cap=256；`TrySend` 非阻塞；`Inject` 2s 超时（`InjectWithTimeout` 由 Conn/acpConn/ocsConn 共享）
+
+**BuildEnv 7 层（env.go:52）优先级 low→high**
+1. `os.Environ()` 经 blocklist 过滤
+2. `HOTPLEX_WORKER_*` 前缀剥离注入（`HOTPLEX_WORKER_GITHUB_TOKEN`→`GITHUB_TOKEN`）
+3. `HOTPLEX_SESSION_ID` / `HOTPLEX_WORKER_TYPE` 注入
+4. 剥离变量覆盖系统同名（动态 block 系统 secret）
+5. `session.Env` per-session 覆盖
+6. `security.StripNestedAgent`（移除 `CLAUDECODE=` 防嵌套）
+7. `session.ConfigEnv`（`worker.environment`）最高优先级
+
+blocklist 规则：精确 key 进 `blockSet`；`_` 结尾进 `prefixKeys` 前缀匹配。
+
+**MetadataHandler 统一分发**：Input 进入时先 `DispatchMetadata`，命中 `permission_response`/`question_response`/`elicitation_response` 即路由到 handler 并跳过正常 Input。ClaudeCode（stdin control）和 OCS（HTTP POST）共享此模式。
+
+**跨平台 pipe 处理**：Unix `EPIPE`/`os.ErrClosed`，Windows `ERROR_BROKEN_PIPE`/`ERROR_NO_DATA`（避免 locale 字符串匹配）。`WriteAll` 在 macOS 非阻塞 pipe 上必须用裸 `syscall.Write` + `runtime.Gosched()` 重试 EAGAIN（Go stdlib `File.Write` 不重试）；Windows 无 EAGAIN，简化循环。
+
+## ANTI-PATTERNS
+- ❌ 修改 BaseWorker 字段不同步所有适配器 — 4 个适配器全受影响
+- ❌ 直接读 `Conn.stdin` 不持 Mu — 与 ControlHandler 写交错
+- ❌ 用 `Stdin()`（deprecated）— 返回的 `*os.File` 释放锁后无保护，改用 `StdinLocked()`
+- ❌ 用 `os.Environ()` 直接传 worker — 必须经 `BuildEnv` 7 层过滤
+- ❌ 在 BuildEnv 跳过 `StripNestedAgent` — `CLAUDECODE=` 会泄漏给子进程
+- ❌ 假设 `HOTPLEX_*` 都该传给 worker — 仅 `HOTPLEX_WORKER_*` 前缀剥离，其他全是 gateway 内部
+- ❌ 用 `os.ErrClosed` 字符串匹配判 pipe 错 — Windows 必须用 errno（locale-dependent）
+- ❌ ACP 适配器强制用 base.Conn — acpConn 仅 up 方向，user input 走 client.Prompt

--- a/internal/worker/codexcli/AGENTS.md
+++ b/internal/worker/codexcli/AGENTS.md
@@ -1,0 +1,87 @@
+# Codex CLI Worker Adapter (app-server singleton)
+
+## OVERVIEW
+`codex app-server` 单例进程适配器。所有 Codex CLI session 共享一个跨进程 stdio JSON-RPC 连接。`CodexAppServerManager` 管理引用计数 + 30min 空闲排空 + 崩溃检测；`AppServerWorker` 是轻量线程级适配器（thread/start, turn/start, thread/unsubscribe）。B/C 通道通过 `baseInstructions` 注入 thread/start。
+
+## STRUCTURE
+```
+codexcli/
+  config.go     # 全局 atomic.Pointer[CodexCLIConfig] + Singleton 生命周期（Init/Shutdown/Get）
+  manager.go    # CodexAppServerManager: 单例进程 + JSON-RPC + 引用计数 + idle drain + 崩溃恢复
+  worker.go     # AppServerWorker: thread 生命周期（Start/Resume/Input/Terminate/ResetContext）+ appConn
+  commands.go   # ServerCommander: control request 路由（context_usage/mcp_*/compact）
+  mapper.go     # Mapper: codex notification → AEP Envelope（25+ 通知类型）
+  parser.go     # Parser: JSONRPC frame 解析（method + params 提取）
+  types.go      # CodexEvent/Item/TokenUsage + JSON-RPC wire types + ThreadStart/TurnStart params
+  worker_test.go# 集成测试
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| 注册 Worker | `worker.go:22` init() | 依赖 `GetSingleton()` 已初始化 |
+| AppServerWorker 字段 | `worker.go:97` | embed `*base.BaseWorker`，manager/threadID/turnID/crashSub/doneCh |
+| Start / Resume | `worker.go:180,430` | Acquire→startNewThread；Resume=Start 回退 `ErrFellBackToFreshStart` |
+| Input 流程 | `worker.go:216` | DispatchMetadata→injectHistoryPrefix→turn/start |
+| 历史前缀注入 | `worker.go:379` | 首输入注入 ConversationHistory（boundary 包裹） |
+| Terminate/Kill | `worker.go:472,480` | 都调 `shutdown()`→`release()`，**不杀进程** |
+| release() 回收 | `worker.go:517` | thread/unsubscribe + Unsubscribe + conn.Close + manager.Release |
+| ResetContext | `worker.go:553` | IncResetGeneration→cleanupOldThread→startNewThread（同进程换 thread） |
+| Wait | `worker.go:497` | select crashSub/doneCh；崩溃返回 `CrashExitCode()` |
+| appState 状态机 | `worker.go:88` | New→Starting→Ready→Terminated |
+| Singleton API | `config.go:35-49` | InitSingleton/ShutdownSingleton/GetSingleton（globalSingleton atomic.Pointer） |
+| Manager 字段 | `manager.go:53` | refs/state/crashCh/crashExitCode/pending/subscribers/idleTimer/pgid |
+| managerState | `manager.go:25` | Idle→Starting→Running→Stopped（crash 回 Idle） |
+| Acquire / Release | `manager.go:119,150` | refs++ 懒启动；refs==0→startIdleDrainLocked |
+| 进程启动 | `manager.go:315` startProcessLocked() | `codex app-server` + handshake + readNotifications + monitorProcess |
+| initialize 握手 | `manager.go:372` | clientInfo + experimentalApi capability |
+| JSON-RPC Call | `manager.go:199` | nextReqID + pending map + 30s defaultCallTimeout |
+| Frame 分发 | `manager.go:471` dispatchFrame() | 单次 unmarshal：server request/response/notification 三分 |
+| Server request | `manager.go:530` dispatchServerRequest() | approval 等 server 主动请求 |
+| monitorProcess | `manager.go:940` | pm.Wait() 阻塞；exit→stateIdle + close(crashCh) + 重建 |
+| Idle drain | `manager.go:993` startIdleDrainLocked() | 30min AfterFunc；到期 ForceKill+ForceKillTree |
+| KillIfIdle | `manager.go:1048` | refs==0 跳过 SIGTERM 直接 ForceKill（避免 proc.mu 死锁） |
+| Subscribe 路由 | `manager.go:168` | per-thread chan cap=256 |
+| sendEnvelope 背压 | `manager.go:914` | delta 丢弃；critical 5s 超时；recover 防 send-on-closed |
+| buildEnv | `manager.go:1066` | 委托 `base.BuildEnv` + `EnvBlocklist`（HOTPLEX_/CODEX_/CODEXCLI） |
+| thread/start 参数 | `types.go:148` ThreadStartParams | model/cwd/sandbox/approvalPolicy + baseInstructions（B/C 通道） |
+| 事件常量 | `types.go:78-101` | thread.started/turn.completed/item.* + 11 item types |
+| Control request | `commands.go:17` | get_context_usage/mcp_status/mcp_refresh/mcp_oauth/compact |
+| Notification → AEP | `mapper.go:32` MapNotification() | 25+ 方法：item.started/updated/completed, turn.*, delta, approval |
+
+## KEY PATTERNS
+
+**Singleton + 引用计数（manager.go）**：单一 `codex app-server` 进程跨所有 session 共享。`Acquire` refs++（首次触发 `startProcessLocked` 懒启动），`Release` refs--（==0 时启动 30min `idleTimer`，到期 `ForceKill(pgid)` + `ForceKillTree`，绕过 proc.mu 防死锁）。
+
+**崩溃检测 + crashCh 隔离**：`monitorProcess` goroutine 阻塞 `pm.Wait()`；进程退出时 state→Idle + `close(crashCh)` + 重建新 crashCh。仅 `wasRunning && refs > 0` 视为崩溃（refs==0 是预期退出）。Worker 通过 `Wait()` 的 `<-crashSub` 分支感知，返回 `CrashExitCode()`。每个 Acquire→Release 生命周期返回当时的 crashCh，旧 Worker 不收过期信号。
+
+**Worker ≠ Manager 职责边界**
+| 操作 | AppServerWorker | CodexAppServerManager |
+|------|-----------------|----------------------|
+| fork/kill 进程 | ❌ | ✅ |
+| thread 创建/销毁 | ✅（JSON-RPC thread/start） | ❌ |
+| 引用计数 | ❌ | ✅ |
+| 崩溃检测 | ❌ | ✅ |
+
+`shutdown()`→`release()` 只 unsubscribe + Release ref，**绝不杀进程**。
+
+**Idle drain / KillIfIdle 死锁规避（manager.go:993,1048）**：不用 `proc.Manager.Kill()`（会 acq proc.mu + cmd.Wait()），与 `monitorProcess` 的 `pm.Wait()`（已持 proc.mu via waitOnce）死锁。改用裸 `proc.ForceKill(pgid)` + `proc.ForceKillTree(pgid)`，monitorProcess 观察到退出后自然清理。
+
+**Thread 生命周期**：`thread/start`（ThreadStartParams 含 baseInstructions）→ threadID；`turn/start`（每次 Input）；`thread/unsubscribe`（release 时）。同进程可创建多 thread（ResetContext 换新 thread 不重启进程）。
+
+**Resume = Start 回退（worker.go:430）**：ephemeral thread 无持久化状态。新建/已终止 → resetLifecycleState + Start + `ErrFellBackToFreshStart`（Bridge 调账）；已 Ready → cleanupOldThread + startNewThread。
+
+**Frame 单次解析（manager.go:471）**：单次 unmarshal 到 `JSONRPCFrame`，按 ID/Method/Error discriminator 三分：server request（ID+Method）/ response（ID only）/ notification（Method only）/ error-only（丢弃）。
+
+**B/C 通道 + 历史注入**：`baseInstructions` 字段（types.go:161）映射 codex `base_instructions`，bridge `injectAgentConfig` 合并 B/C 通道。`pendingHistory` 首输入注入（boundary 包裹防混淆）。
+
+**EnvBlocklist（types.go:104）**：`HOTPLEX_` / `CODEX_` / `CODEXCLI` 全剥离，通过 `base.BuildEnv` 7 层过滤。
+
+## ANTI-PATTERNS
+- ❌ 在 Worker.Terminate/Kill 调 `proc.Kill()` — 共享进程会被无辜 session 拖死
+- ❌ 用 `proc.Manager.Kill()` 做 idle drain — 与 monitorProcess 的 Wait 死锁
+- ❌ 跳过 `thread/unsubscribe` 直接 Unsubscribe — server 端订阅泄漏
+- ❌ 假设 Resume 恢复历史 — ephemeral thread，靠 `pendingHistory` 首输入注入
+- ❌ 并发写 stdin — 必须经 `writeMu`（writeFrame 内部已加锁）
+- ❌ 修改 baseInstructions 不重置 thread — 已运行 thread 不感知；需 ResetContext 换新 thread
+- ❌ 直接 close subscriber chan — `subsClosed atomic.Bool` 防 monitorProcess 双关闭

--- a/internal/worker/proc/AGENTS.md
+++ b/internal/worker/proc/AGENTS.md
@@ -1,0 +1,91 @@
+# Process Lifecycle Package (proc)
+
+## OVERVIEW
+跨平台 worker 子进程生命周期管理：PGID 隔离（Unix）+ Job Object（Windows）双轨制，3 层分层终止（SIGTERM → 5s grace → SIGKILL），tree-kill 兜底逃逸后代，PID 文件追踪孤儿进程。
+
+## STRUCTURE
+```
+proc/
+  manager.go                  # Manager: Start/Terminate/Kill/Wait/ReadLine, stdio pipe, scanner
+  pidfile.go                  # Tracker: PID 文件原子写（tmp+rename），orphan 扫描+清理
+  pid_helpers.go              # TrackPID/UntrackPID 包级 helper（全局 tracker 透明代理）
+  stderr_handler.go           # StderrHandler 接口 + DefaultStderrHandler（[LEVEL] 前缀解析）
+  signal_unix.go              # POSIX: Setpgid/SIGTERM/SIGKILL/-pgid 信号原语
+  signal_windows.go           # Win32: CREATE_NEW_PROCESS_GROUP/GenerateConsoleCtrlEvent
+  tree_kill_unix.go           # ForceKillTree + findDescendants（递归扫逃逸 PGID 的孤儿）
+  tree_kill_children_linux.go # /proc/<pid>/task/<pid>/children 快路径，/proc/*/stat 回退
+  tree_kill_children_darwin.go# sysctl KERN_PROC_PID 枚举（maxScanPID=4096）
+  tree_kill_windows.go        # no-op（Job Object 负责）
+  manager_job_unix.go         # createJobAndAssign/closeJobHandle no-op
+  manager_job_windows.go      # Job Object 句柄绑定到 Manager
+  jobobject_windows.go        # CreateJobObject/AssignProcessToJob（KILL_ON_JOB_CLOSE）
+  jobobject_other.go          # 非 Windows no-op stub
+  memlimit_linux.go           # RLIMIT_AS 已禁用（modern JIT 需要大 VA 空间）
+  memlimit_other.go           # 非 Linux no-op
+  *_test.go                   # Manager/PIDfile/tree-kill 测试
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Start subprocess | `manager.go:97` Start() | `exec.CommandContext` + `SetSysProcAttr` + 3 个 os.Pipe |
+| Graceful termination | `manager.go:209` Terminate() | `GracefulTerminate(pgid)` → 等 gracePeriod → `Kill()` |
+| Force kill | `manager.go:250` Kill() | `closeJobHandle()` + `ForceKill(pgid)` + `ForceKillTree(pgid)` |
+| Read stdout line | `manager.go:366` ReadLine() | 单 goroutine 串行，**不持 mu**；panic-recover 抓 `bufio.ErrTooLong` |
+| Drain stderr | `manager.go:408` drainStderr() | 后台 goroutine，stderr 句柄所有权转移 |
+| Pipe FD cleanup | `manager.go:447` closeLocked() | 幂等，跳过 `os.ErrClosed` |
+| PGID 隔离设置 | `signal_unix.go:13` | `SysProcAttr{Setpgid:true}` |
+| Windows 进程组 | `signal_windows.go:15` | `CREATE_NEW_PROCESS_GROUP` |
+| 3-layer 终止信号 | `signal_unix.go:18,29` | SIGTERM → SIGKILL，都用 `-pgid` 组播 |
+| Grace 常量 | `signal_unix.go:41` | `DefaultGracePeriod = 5 * time.Second`（Win/Mac 等价副本） |
+| Tree-kill 主流程 | `tree_kill_unix.go:17` | findDescendants → ForceKill(pgid) → 逐个 SIGKILL 孤儿 |
+| Linux 子进程枚举 | `tree_kill_children_linux.go:15` | 快路径 `/proc/<pid>/task/<pid>/children`，回退 `/proc/*/stat` |
+| Darwin 子进程枚举 | `tree_kill_children_darwin.go:14` | sysctl KERN_PROC_PID，capped 4096 |
+| Windows Job Object | `jobobject_windows.go:15` | `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` |
+| PID 文件原子写 | `pidfile.go:95` Write() | tmp 文件 + `os.Rename` |
+| Orphan 清理 | `pidfile.go:177` CleanupOrphans() | 并发 cap（默认 3），minAge 过滤防误杀新进程 |
+| PID 复用检测 | `pidfile.go:290` | `IsProcessGroupAlive(pgid)` 验证仍是 group leader |
+| stderr 级别解析 | `stderr_handler.go:66` ParseLevelPrefix() | `[INFO]` 降级为 Debug（agent INFO 噪声大） |
+| Scanner buffer | `manager.go:22` | 初始 64KB，硬上限 10MB |
+| Scanner buffer 上限常量 | `manager.go:22-24` | `scannerInitSize` / `scannerMaxSize` |
+
+## KEY PATTERNS
+
+**双轨制平台隔离（build tags）**
+- Unix：`Setpgid:true` 创建独立进程组，`kill(-pgid, sig)` 组播
+- Windows：`CREATE_NEW_PROCESS_GROUP` + Job Object（`KILL_ON_JOB_CLOSE` 关闭句柄即杀全树）
+- 每 platform-specific API 都有 `_unix`/`_windows` 或 `_linux`/`_darwin`/`_other` 对偶
+
+**3-layer 终止（强制顺序）**
+1. `GracefulTerminate(pgid)` → SIGTERM 整组（Unix）/ CTRL_BREAK（Win，best-effort）
+2. 等 `gracePeriod`（默认 5s，`DefaultGracePeriod` 常量跨文件共享避免魔术数字）
+3. `Kill()` → `closeJobHandle()` + `ForceKill(pgid)` + `ForceKillTree(pgid)`
+
+**tree-kill 兜底**
+- 标准 `kill(-pgid)` 抓不到逃逸 PGID 的后代（Codex MCP server 自建进程组）
+- `findDescendants` BFS 递归扫子进程，过滤同 PGID 的，返回孤儿列表
+- Linux 用 `/proc/<pid>/task/<pid>/children` 快路径，macOS 用 sysctl 枚举
+
+**Manager 并发契约**
+- `mu sync.Mutex` 显式字段，保护 cmd/scanner/pgid/started/exited
+- `waitOnce sync.Once` 保证 `cmd.Wait()` 只调一次（Terminate/Wait/Kill 三入口竞争）
+- `ReadLine` 故意不持 mu（避免阻塞 Terminate/Kill），调用方必须单 goroutine 串行
+
+**PID 文件追踪**
+- `InitTracker(dir, log)` 全局 atomic.Pointer，`Start` 时 `trackPID`，`Terminate/Kill/Wait` 时 `untrackPID`
+- `CleanupOrphans` 启动时扫 stale 文件，minAge 过滤防误杀新 worker
+- 双重校验：`IsProcessAlive` + `IsProcessGroupAlive`（防 PID 复用）
+
+**stderr 处理可插拔**
+- `StderrHandler` 接口：`Handle(line) (level, msg)`，空 msg = 抑制整行
+- `StderrHandlerFactory` 每 session 新建实例（支持多行折叠状态）
+- `DefaultStderrHandler` 解析 `[ERROR]/[WARN]/[DEBUG]/[INFO]` 前缀，`[INFO]` 降级 Debug
+
+## ANTI-PATTERNS
+- ❌ 跳过 `Setpgid:true` / `CREATE_NEW_PROCESS_GROUP` — 子进程清理全靠组隔离
+- ❌ 直接 `kill(pid)` 单进程 — 必须用 `-pgid` 组播，否则孤儿泄漏
+- ❌ 跳过 `ForceKillTree` — Codex MCP server 会逃逸 PGID
+- ❌ 并发调用 `ReadLine()` — 单 goroutine 所有权契约，扫描器不持锁
+- ❌ Windows 上跳过 Job Object — `GenerateConsoleCtrlEvent` 对独立 console 不可靠
+- ❌ 在 Linux 启用 `RLIMIT_AS` — modern JIT（Bun/Node）需要 ~70GB VA 空间，会立即崩
+- ❌ 跳过 PID 文件 minAge 过滤 — 会误杀刚启动、PID 被复用的进程

--- a/pkg/aep/AGENTS.md
+++ b/pkg/aep/AGENTS.md
@@ -1,0 +1,65 @@
+# pkg/aep — AEP v1 编解码器
+
+## OVERVIEW
+AEP v1 协议 codec。把 `events.Envelope` 序列化成 NDJSON 一行、反序列化回结构体，并执行字段校验。Gateway、所有客户端 SDK、Worker 适配器共用此包，没有第二个真相来源。
+
+## STRUCTURE
+```
+codec.go     # 全部公开 API：Encode/Decode/Validate/ID 生成/Envelope 工厂 + 内部 NDJSON 安全处理
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| 流式编码（带 `\n`） | `codec.go:27` | `Encode(w io.Writer, env *Envelope) error` |
+| 流式解码 | `codec.go:97` | `Decode(r io.Reader) (*Envelope, error)`，`DisallowUnknownFields` |
+| 单行编码（无 `\n`） | `codec.go:201` | `EncodeJSON(env) ([]byte, error)` |
+| 单行解码（完整校验） | `codec.go:128` | `DecodeLine([]byte) (*Envelope, error)` |
+| 客户端→服务端宽松解码 | `codec.go:116` | `DecodeLineMinimal`：不要求 session_id/seq（Gateway 后补） |
+| 完整字段校验 | `codec.go:140` | `Validate`：version/id/session_id/seq>0/timestamp>0/event.type |
+| 宽松校验 | `codec.go:178` | `ValidateMinimal`：仅 version 一致性 + event.type 非空 |
+| Envelope 工厂 | `codec.go:243/250` | `NewInputEnvelope`、`NewPingEnvelope`（Ping seq=0 + PriorityControl） |
+| ID 生成 | `codec.go:189/194` | `NewID()` → `evt_<uuid>`，`NewSessionID()` → `sess_<uuid>` |
+| 时间注入 | `codec.go:38-48/271` | `marshalEnvelope` 在浅拷贝上盖 `events.Version` 和 timestamp=0 时补当前 ms；入参不被改写 |
+
+## 函数签名（codec.go）
+```go
+Encode(w io.Writer, env *events.Envelope) error                          // :27
+Decode(r io.Reader) (*events.Envelope, error)                            // :97
+EncodeJSON(env *events.Envelope) ([]byte, error)                         // :201
+MustMarshal(env *events.Envelope) []byte                                 // :206 panic on err
+DecodeLine(data []byte) (*events.Envelope, error)                        // :128
+DecodeLineMinimal(data []byte) (*events.Envelope, error)                 // :116
+Validate(env *events.Envelope) error                                     // :140
+ValidateMinimal(env *events.Envelope) error                              // :178
+NewID() string                                                           // :189 "evt_"+uuid
+NewSessionID() string                                                    // :194 "sess_"+uuid
+NewInputEnvelope(sessionID, content string) *events.Envelope             // :243
+NewPingEnvelope(sessionID string) *events.Envelope                       // :250
+IsSessionBusy(env *events.Envelope) bool                                 // :215
+IsTerminalEvent(kind events.Kind) bool                                   // :228 (Done|Error)
+ParseSessionID(id string) string                                         // :233 trim "sess_"
+SeqKey(sessionID, eventID string) string                                 // :238 去重键
+EscapeJSTerminators(data []byte) []byte                                  // :92
+```
+
+## 版本控制
+**单一协议版本字段**：`events.Version = "aep/v1"`（events.go:9）。没有 `aep/v2`、没有 per-event version。`Validate`（codec.go:145）严格 `env.Version != events.Version` 即报 `unsupported version`，客户端发空 version 通过 `ValidateMinimal` 放行（Gateway 在 init 阶段补盖）。
+
+## KEY PATTERNS
+**NDJSON 安全（codec.go:22/62）** — `escapeJSTerminators` 把 U+2028/U+2029 转义成 `\u2028`/`\u2029`。Go `json.Marshal` 对 string 已自动转义，此函数兜底处理 `map[string]any` 里 raw []byte 的边界情况。任何把 NDJSON 行当 JS 字符串求值的消费者都会在裸 codepoint 处静默截断。
+
+**入参零改写（codec.go:38-48）** — `marshalEnvelope` 做 shallow copy 后填 Version/Timestamp 再 marshal，原 `*Envelope` 字段不动。这是 `Clone` + EncodeJSON 在并发发送链路能安全共存的根因。
+
+**三档校验强度** — `Validate`（全字段，Gateway 内部 / Worker 出口）> `ValidateMinimal`（C→S 入口宽松）> 无校验（`MustMarshal` 调用方自负）。`Decode` 还额外开 `DisallowUnknownFields` 拒绝未知字段，防 schema drift。
+
+**错误包装** — 所有 decode/validate 失败统一 `fmt.Errorf("aep: <op> envelope: %w", err)`，调用方 `errors.Is/As` 解包。
+
+## ANTI-PATTERNS
+- ❌ 用 `json.Marshal(env)` 直接发线，绕过 `Encode/EncodeJSON`（丢 NDJSON 转义 + 版本/时间戳注入）
+- ❌ 依赖 `nowFunc` 包变量做生产逻辑（仅测试 mock 用，默认 wall-clock）
+- ❌ 在客户端代码里手搓 init 握手（pkg/README.md 提到的 `NewInitEnvelope`/`ValidateInit`/`BuildInitAck` 在本包**不存在**，属 internal/aep 范畴）
+- ❌ 复用 decoded 出来的 `*Envelope` 跨 goroutine 而不 Clone（Event.Data 是 `interface{}`，map 共享会 race）
+
+## PUBLIC API STABILITY
+被 `client/`、`examples/{typescript,python,java}-client/`、Gateway、所有 Worker 适配器直接调用。函数签名和 NDJSON wire 格式是冻结契约，**禁止改签名、禁止改 `DisallowUnknownFields` 行为、禁止改 `"evt_"/"sess_"` 前缀**。新增可选字段走 `ValidateMinimal` 宽松路径。破坏性变更需 major 版本 bump，且需同步更新所有 SDK。

--- a/pkg/events/AGENTS.md
+++ b/pkg/events/AGENTS.md
@@ -1,0 +1,69 @@
+# pkg/events — AEP v1 数据结构
+
+## OVERVIEW
+AEP v1 (Agent Event Protocol v1) 类型定义。Gateway 和所有客户端 SDK 共享的唯一事件契约，是 wire format 的权威来源。
+
+## STRUCTURE
+```
+events.go     # Kind 常量、Envelope/Event、所有 *Data 载荷结构、SessionState 状态机、Clone
+helpers.go    # 类型提取辅助（DecodeAs 泛型、Map*Response 适配、数值/字符串提取）
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| 协议版本常量 | `events.go:9` | `Version = "aep/v1"`，所有 Envelope 必须 carry |
+| Envelope 字段 | `events.go:94-110` | Version/ID/Seq/Priority/SessionID/Timestamp/Event/Metadata/OwnerID |
+| Event wrapper | `events.go:172-175` | `Event{Type Kind, Data interface{}}`，Data 是开放联合 |
+| 构造函数 | `events.go:561` | `NewEnvelope(id, sid, seq, kind, data)` 自动盖时间戳+版本 |
+| 浅拷贝（独立 map） | `events.go:117` | `Clone` 递归深拷 Event.Data 和 Metadata |
+| 全独立拷贝 | `events.go:159` | `CloneDeep` JSON 往返，用于 event store replay |
+| 通用 Data 提取 | `helpers.go:120` | `DecodeAs[T](data)` 处理 typed struct 和 JSON round-trip 后的 map |
+| SessionState 状态机 | `events.go:530-558` | created→running→idle→terminated→deleted；`IsValidTransition` |
+
+## Kind 常量（events.go:15-52）
+
+**协议核心**：`Init` `Error` `State` `Input` `Done` `Control` `Ping` `Pong`
+**消息流（S→C）**：`Message` `MessageStart` `MessageDelta` `MessageEnd`
+**Tool（S→C）**：`ToolCall` `ToolResult` `Reasoning` `Step` `Raw`
+**用户交互**：`PermissionRequest/Response` `QuestionRequest/Response` `ElicitationRequest/Response`
+**Worker 控制（S→C）**：`ContextUsage` `SkillsList` `MCPStatus` `WorkerCmd`（"worker_command"）
+**ACP 扩展**：`ToolUpdate`（"tool_update"）`Plan` `ModeUpdate`
+**内部（不转发客户端）**：`KindInternalReset`（"internal_reset"，仅 Worker→Gateway 协调）
+
+## Data 载荷（按 Kind 配对）
+
+| Kind | Data 类型 | 行号 |
+|------|-----------|------|
+| Error | `ErrorData{Code, Message}` | 178 |
+| State | `StateData{State, Message}` | 184 |
+| Input | `InputData{Content, Metadata}` | 190 |
+| Message(Delta|Start|End) | `MessageDeltaData`/`StartData`/`EndData` | 196/204/210 |
+| Message | `MessageData`（非流式、向后兼容） | 265 |
+| ToolCall/Result | 带 ACP 扩展字段（Title/Kind/Locations、Status/Diff） | 228/239 |
+| Done | `DoneData{Success, Stats, Dropped}`（Dropped=背压静默丢弃标记） | 255 |
+| Control | `ControlData{Action, Reason, DelayMs, ...}` | 368 |
+| WorkerCmd | `WorkerCommandData{Command, Args}` | 410 |
+
+完整列表见源码 events.go:177-506。
+
+## KEY PATTERNS
+**开放 Data 接口（events.go:174）** — `Data interface{}` 不强制具体类型，运行时由 Kind 决定。Decode 后可能是 typed struct 或 `map[string]any`（JSON 往返后），用 `DecodeAs[T]` 统一处理。
+
+**Clone vs CloneDeep** — `Clone` 浅拷+递归 map（高性能、保留 typed struct）；`CloneDeep` JSON 往返（完全独立、用于持久化）。并发发送前用 Clone，避免 EncodeJSON in-place 改写互相干扰。
+
+**ErrorCode 哨兵集（events.go:65-91）** — 26 个 `ErrCode*`（如 `SESSION_BUSY`、`VERSION_MISMATCH`、`WORKER_CRASH`），客户端按 code 分支处理而非字符串匹配。
+
+**ControlAction vs WorkerStdioCommand** — Control 改会话状态（terminate/reset/gc/cd）；WorkerStdioCommand 是 Worker 进程内操作（context_usage/set_model/compact 等），`IsPassthrough()` 区分走 Input 还是 SendControlRequest。
+
+**Priority 背压（events.go:55-60）** — `PriorityControl` 跳过背压直发，`PriorityData`（默认）受背压影响。message.delta 在通道满时静默丢弃（Done.Dropped 标记）。
+
+## ANTI-PATTERNS
+- ❌ 在 pkg/events 引入 internal/ 依赖（gateway/session 等）— 这是公共契约层
+- ❌ 新增 Kind 不加对应 *Data 结构或 Documentation
+- ❌ 客户端用字符串字面量匹配 Kind，应导入常量
+- ❌ 跨 goroutine 共享 Envelope 不先 Clone（map 字段共享会导致数据竞争）
+- ❌ 依赖 OwnerID 字段做 wire 逻辑（`json:"-"` 不序列化，仅 Gateway 内部用）
+
+## PUBLIC API STABILITY
+被 `client/`（Go SDK）、`examples/{typescript,python,java}-client/`、Gateway 三方共用。Kind 常量值（如 `"message.delta"`）和 Envelope JSON tag 是 wire contract，**禁止改名或改 tag**。新增 Kind/Data 字段必须 `omitempty` 或向后兼容。任何破坏性变更需 major 版本 bump。


### PR DESCRIPTION
## Summary

WebChat 轨 agent-configs 支持 **per-workspace 两层继承**（团队默认 → workspace 自定义），同一团队不同 workspace 各自定制、互不影响；Message Channel 轨（Slack/Feishu）行为零变化。

- **DB JSON flat map 存储**（复用 spec ① `agent_config_overrides` 列，**无新迁移**）；逐文件覆盖；全部 5 文件可覆盖；`META-COGNITION.md` 不在白名单，物理不可覆盖
- **`LoadForWorkspace` 独立函数**双轨隔离——`Load` 与 Message Channel 轨三级 fallback 零改动（byte-equivalent，final review 确认）
- **Bridge 加窄接口 `WSStore` + `resolveWorkspaceOverrides` helper**，3 个 worker 启动调用点（StartSession / resume / fresh-start）统一解析；`workerLaunchParams` 携已解析 map；`injectAgentConfig` 纯函数分流
- **PATCH 三层校验**（JSON / 键白名单 / 类型 / size → `INVALID_CONFIG_JSON` / `UNKNOWN_CONFIG_FILE` / `CONFIG_TOO_LARGE` / `INVALID_CONFIG_VALUE`），修复了 invalid JSON 泄漏到 store 触发 500 的既有缺陷
- 后端 only，前端编辑 UI 归 spec ⑥

## 关联文档（本 PR 含 3 个 doc commit）

- 设计：`docs/specs/WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md`
- 实现计划：`docs/superpowers/plans/2026-06-16-webchat-multitenancy-spec2-per-workspace-agent-configs.md`

## Test Plan

- [x] `agentconfig`：`TestValidateOverrides`（9 场景：空/合法/非法JSON/未知键/类型/size/空对象/全5文件）+ `TestLoadForWorkspace`（7 场景：覆盖/继承/exclude优先/白名单/平台级）+ `TestLoad` 回归
- [x] `gateway`：`TestResolveWorkspaceOverrides`（6 场景：空id/nil store/合法/空串/store错误/坏JSON 降级）+ `TestWorkspace_PatchAgentConfigOverrides_Validation`（6 场景）+ `Persists` round-trip + `TestBridge_TwoWorkspaces_DifferentOverrides`（端到端隔离核心不变式）
- [x] `make check` 全绿（fmt + lint + race test + webchat rebuild + Go build）
- [x] 双轨隔离：Message Channel 轨 `Load` 路径与改造前 byte-equivalent
- [ ] reviewer（hotplex-ai）re-review

## 关联

- Closes #747
- 依赖 spec ①（#746，已合入）
- unblocks spec ⑥（webchat 前端配置编辑 UI）