### PR TITLE
docs(patrol): 2026-06-17 文档维护

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -44,6 +44,8 @@ hotplex
 │   ├── restart      # 重启服务
 │   ├── status       # 服务状态
 │   └── logs         # 查看日志
+├── admin            # 用户与账号管理
+│   └── create       # 创建账号（bootstrap admin 等）
 ├── slack            # Slack 消息操作
 │   ├── send-message      # 发送消息
 │   ├── update-message    # 更新消息
@@ -869,6 +871,36 @@ hotplex cron history daily-health --json
 | 参数 | 必填 | 说明 |
 |------|------|------|
 | `<id\|name>` | 是 | 任务 ID 或名称 |
+
+---
+
+## Admin 账号管理
+
+用户与账号管理命令。用于 WebChat 多租户部署的 bootstrap admin 创建等场景（v1.29.1+）。
+
+### `hotplex admin create`
+
+创建账号（首个 admin，或后续普通用户）。直接读写 session 数据库，无需 Gateway 运行。
+
+**示例**：
+
+```bash
+hotplex admin create --username bootstrap              # 交互式输入密码（不回显，推荐）
+hotplex admin create --username alice --password '...' # 通过参数指定密码
+hotplex admin create --username bob --admin=false      # 创建普通用户（非 admin 角色）
+hotplex admin create --username ops --config /path/config.yaml
+```
+
+> `hotplex admin create` 属于 WebChat 多租户功能（v1.29.1 起的后端地基）；面向终端用户的登录与 workspace 管理 UI 将在后续版本上线，当前可先用此命令 bootstrap 首个 admin 账号。
+
+| 标志 | 类型 | 默认值 | 必填 | 说明 |
+|------|------|--------|------|------|
+| `--username` | `string` | | 是 | 用户名（3-64 字符，仅 `[a-zA-Z0-9_.-]`，不可 `apikey:` 开头） |
+| `--password` | `string` | | 否 | 密码（省略则交互式不回显；最少 8 字符）。⚠️ 作为进程参数对同机其他用户经 `ps`/`/proc` 可见，生产环境请使用交互式输入 |
+| `--admin` | `bool` | `true` | 否 | 创建为 admin 角色 |
+| `--config` | `string` | `~/.hotplex/config.yaml` | 否 | 配置文件路径 |
+
+密码使用 bcrypt（cost=12）存储。用户名保留命名空间 `apikey:` 检查用于防止与 API key 伪用户冲突导致的身份接管。
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -231,6 +231,7 @@ Session 资源池配额管理。
 | `max_size` | int | `100` | `HOTPLEX_POOL_MAX_SIZE` | 池最大大小。系统级 Session 总量上限 |
 | `max_idle_per_user` | int | `5` | `HOTPLEX_POOL_MAX_IDLE_PER_USER` | 每用户最大空闲 Session 数 |
 | `max_memory_per_user` | int64 | `3221225472` (3GB) | `HOTPLEX_POOL_MAX_MEMORY_PER_USER` | 每用户最大内存配额（字节）。0 表示无限制 |
+| `max_per_workspace` | int | `0` | — | WebChat 多租户每 workspace 最大活跃 Session（v1.29.1+，spec ①）。0 = 无限制；默认禁用，WebChat 部署按需配置 |
 
 ---
 


### PR DESCRIPTION
## Summary
- **docs/reference/cli.md**：新增 `## Admin 账号管理` 章节，覆盖 `hotplex admin create`（v1.29.1 WebChat 多租户 bootstrap，含用户名校验规则与 bcrypt cost=12 存储说明）
- **docs/reference/configuration.md**：pool 表新增 `max_per_workspace`（WebChat 多租户每 workspace 并发配额，默认 0 禁用）

## 变更来源
PR #746 WebChat 多租户地基（spec ① Phase 0-7）+ release v1.29.1。`hotplex admin` 命令与 `max_per_workspace` 配置此前在文档中心零提及（仅存在于 specs/plans）。

## 刻意未改（避免过度文档化）
- `guides/enterprise/multi-tenant.md` / `guides/enterprise/resource-limits.md`：Bot-centric / per-user 描述准确；WebChat workspace 多租户前端登录 UI 在 spec ⑥ 才上线，相关 HTTP 端点已实现但**故意未接线**（`routes.go` 注释 `intentionally not wired until the frontend login flow is ready`），提前文档化会让用户照做失败
- 版本号 v1.29.1：frontmatter 已移除版本字段，无文档动作

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)