### PR TITLE
WebChat 多租户 spec ③：workspace 级 worker 选择

### DIFF
--- a/docs/specs/WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md
@@ -79,7 +79,7 @@ spec ①（地基）已为 spec ③ 预留并实现了大半基础设施：
 
 ## 4. 白名单校验（ValidateType）
 
-新增 `worker.ValidateType`，放在 worker 包（紧邻 WorkerType/RegisteredTypes 定义）：
+新增 `worker.ValidateType`，放在 worker 包（紧邻 WorkerType/RegisteredTypes 定义）。下方为示意伪代码，**以代码为准**（实现用锁内 `registry` map 直查而非 `for range RegisteredTypes()`，零分配，见 `registry.go`）：
 
 ```go
 // internal/worker/worker.go（或 registry.go）
@@ -165,7 +165,9 @@ if wt != "" {
 		return
 	}
 }
-// 后续 fallback 到 ws.WorkerPreference / default 不变（api.go:271-272）
+// 后续 fallback 到 ws.WorkerPreference 时再 ValidateType（防御旁路写/存量脏数据，
+// review P2）：非法则 warn + 降级 default，不 400（非请求侧错误）、不带到 worker
+// launch；最后空则用 TypeClaudeCode default。见 api.go 实现。
 ```
 
 ---

--- a/docs/specs/WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md
@@ -1,0 +1,226 @@
+# WebChat 多租户 spec ③：workspace 级 worker 选择
+
+**日期**: 2026-06-17
+**状态**: Draft（待实现计划）
+**分支**: main · **基线**: spec ② 已合入（[PR #748](https://github.com/hrygo/hotplex/pull/748)，`03e8bffa`）
+**范围**: WebChat 轨 workspace 级选择 worker type（claude_code/opencode_server/codex_cli/acp），两层 fallback（workspace.worker_preference → 团队默认），白名单校验闭环，双轨隔离 Message Channel 轨零改动
+**关联设计**: [`WebChat-Multitenancy-Foundation-Design-Spec.md`](./WebChat-Multitenancy-Foundation-Design-Spec.md)（spec ①）、[`WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md`](./WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md)（spec ②）、[`WebChat-Multitenancy-Roadmap-Spec.md`](./WebChat-Multitenancy-Roadmap-Spec.md) §4 spec ③
+
+---
+
+## 目录
+
+- [1. 背景与现状](#1-背景与现状)
+- [2. 目标与非目标](#2-目标与非目标)
+- [3. 关键决策汇总](#3-关键决策汇总)
+- [4. 白名单校验（ValidateType）](#4-白名单校验validatetype)
+- [5. fallback 链（spec ① 已实现）](#5-fallback-链spec-已实现)
+- [6. 双轨隔离](#6-双轨隔离)
+- [7. PATCH + CreateSession 校验](#7-patch--createsession-校验)
+- [8. 会话连续性](#8-会话连续性)
+- [9. 错误码](#9-错误码)
+- [10. 测试策略](#10-测试策略)
+- [11. 受影响文件清单](#11-受影响文件清单)
+- [12. 后续 spec 路线](#12-后续-spec-路线)
+
+---
+
+## 1. 背景与现状
+
+spec ①（地基）已为 spec ③ 预留并实现了大半基础设施：
+
+| 预留点 | 现状 | 证据 |
+|---|---|---|
+| `workspaces.worker_preference` 列 | 已建 + 存取（spec ③ fills 注释） | `internal/session/multitenancy_store.go:19/111/247` |
+| CreateSession fallback 链 | 已实现：body/query > `workspace.WorkerPreference` > default | `internal/gateway/api.go:266-272` |
+| worker.Type 4 常量 | claude_code / opencode_server / codex_cli / acp | `internal/worker/worker.go:84-87` |
+| `RegisteredTypes()` API | 返回所有 `init()` Register 的 worker type | `internal/worker/registry.go:67` |
+| `DeriveSessionKey` 含 worker_type | 切 worker = 新 session key | `internal/session/key.go:52` |
+
+**缺口**：PATCH `worker_preference`（`workspace_handlers.go:179-181`）与 CreateSession body/query `worker_type`（`api.go:267-272`）**均无白名单校验**。非法 worker_type 会落到 worker launch 阶段才失败（registry 找不到 Builder），错误信息不友好且延迟到启动期。
+
+**核心结论**：spec ③ 是 spec ① 的收尾——补白名单校验闭环（写入侧 + 请求侧统一），加双轨隔离回归测试，明确会话连续性行为。不新增字段、不改 fallback 链、不动 Message Channel 轨。
+
+---
+
+## 2. 目标与非目标
+
+### 2.1 目标（本 spec 范围）
+
+1. **workspace 级 worker 选择**：WebChat 轨每个 workspace 设 `worker_preference`，新会话用该 worker（除非请求显式覆盖）。
+2. **白名单校验闭环**：PATCH `worker_preference` + CreateSession body/query `worker_type` 都校验合法（4 类注册 worker），非法即 400。
+3. **双轨隔离**：Message Channel 轨（Slack/Feishu）的 `config_defaults.propagatePlatform` worker_type fallback 链零改动。
+4. **会话连续性明确**：切 `worker_preference` 后，新会话用新 worker（新 session key），已存在会话不变——文档化此行为。
+
+### 2.2 非目标（明确排除）
+
+| 项 | 归属 |
+|---|---|
+| WebChat 前端 worker 选择 UI | spec ⑥ |
+| per-user worker 选择 | 永不（spec ① §2.4 拍板两层，无 per-user） |
+| Message Channel 轨引入 workspace preference | 永不（双轨完全隔离） |
+| Worker 凭证管理 / 切换 | 永不（凭证由 worker 二进制自管，spec ① §2.5） |
+| workspace 级 agent-configs 自定义 | spec ②（已合入） |
+
+---
+
+## 3. 关键决策汇总
+
+| 决策点 | 选择 | 理由 |
+|---|---|---|
+| 白名单源 | **`RegisteredTypes()` 动态** | 新 worker `init()` Register 后自动纳入白名单，无需手改校验代码；`TypeUnknown` 哨兵不 Register，自动排除。DRY，单一真相源 |
+| 校验范围 | **PATCH + CreateSession 统一** | 复用 `ValidateType`，彻底防非法 worker_type 进系统（CreateSession 当前 `worker.WorkerType(body.WorkerType)` 零校验是 spec ① 遗留） |
+| 校验函数位置 | **`worker.ValidateType`**（worker 包） | 紧邻 `WorkerType` 定义（`worker.go:81`）+ `RegisteredTypes()`（`registry.go:67`），自洽不跨包 |
+| 空值语义 | **空合法**（继承默认） | 两层 fallback，与 spec ② agent-configs 空值继承一致 |
+| fallback 链 | **body/query > preference > default（不变）** | spec ① 已实现（`api.go:266-272`），spec ③ 只加校验不改链 |
+| 会话连续性 | **切 preference = 新 session**（不特殊处理） | `DeriveSessionKey` 含 worker_type，新 key 自然产生新会话；文档化即可 |
+
+---
+
+## 4. 白名单校验（ValidateType）
+
+新增 `worker.ValidateType`，放在 worker 包（紧邻 WorkerType/RegisteredTypes 定义）：
+
+```go
+// internal/worker/worker.go（或 registry.go）
+
+var ErrInvalidWorkerType = errors.New("invalid worker type")
+
+// ValidateType returns nil for an empty wt (means "inherit default") or for any
+// registered worker type. A non-empty unregistered type returns ErrInvalidWorkerType.
+// Used by both the PATCH workspace handler and CreateSession to reject unknown
+// worker types at the boundary instead of at worker launch.
+func ValidateType(wt WorkerType) error {
+	if wt == "" {
+		return nil
+	}
+	for _, t := range RegisteredTypes() {
+		if t == wt {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %q not in registered types %v", ErrInvalidWorkerType, wt, RegisteredTypes())
+}
+```
+
+- **空值合法**：空 `worker_preference`/`worker_type` = 继承默认（两层 fallback 语义）
+- **非空必须 ∈ RegisteredTypes()**：TypeUnknown 哨兵不 Register，自动排除
+- **sentinel + %w 包装**：对齐项目错误规范（errorlint）
+
+---
+
+## 5. fallback 链（spec ① 已实现）
+
+WebChat 轨 CreateSession（`api.go:266-272`）现有 fallback：
+
+```
+1. body.worker_type   （请求显式，最高优先）
+2. query.worker_type  （legacy 调用方）
+3. workspace.WorkerPreference  （DB，spec ③ 核心）
+4. default "claude_code"        （config_defaults:128）
+```
+
+**spec ③ 不改 fallback 链**，只在步骤 1-3 解析出非空 wt 后、落入步骤 4 前，加 `ValidateType` 校验。
+
+---
+
+## 6. 双轨隔离
+
+| 轨 | worker_type 来源 | spec ③ 影响 |
+|---|---|---|
+| **WebChat** | CreateSession fallback（body/query > preference > default） | 加白名单校验 |
+| **Message Channel**（Slack/Feishu） | `config_defaults.propagatePlatform`（Bot > 平台 > messaging > 默认） | **零改动** |
+
+**隔离保证**：
+- Message Channel 轨完全不查 `worker_preference`（无 workspace 概念，会话不选 Bot 见 spec ① §2.4，但 worker_type 走 config 5 级 fallback）。
+- WebChat `worker_preference` 只影响 WebChat 会话的 CreateSession。
+- `config_defaults.propagatePlatform`（`config_defaults.go:209-212`）与 spec ③ 代码路径无交集。
+
+---
+
+## 7. PATCH + CreateSession 校验
+
+### 7.1 PATCH workspace worker_preference（`workspace_handlers.go:179-181`）
+
+```go
+if req.WorkerPreference != "" {
+	if err := worker.ValidateType(worker.WorkerType(req.WorkerPreference)); err != nil {
+		writeAppError(w, http.StatusBadRequest, "INVALID_WORKER_TYPE", err.Error())
+		return
+	}
+	ws.WorkerPreference = req.WorkerPreference
+}
+```
+
+### 7.2 CreateSession worker_type（`api.go:266-272`）
+
+```go
+wt := worker.WorkerType(body.WorkerType)
+if wt == "" {
+	wt = worker.WorkerType(r.URL.Query().Get("worker_type"))
+}
+if wt != "" {
+	if err := worker.ValidateType(wt); err != nil {
+		writeAppError(w, http.StatusBadRequest, "INVALID_WORKER_TYPE", err.Error())
+		return
+	}
+}
+// 后续 fallback 到 ws.WorkerPreference / default 不变（api.go:271-272）
+```
+
+---
+
+## 8. 会话连续性
+
+`DeriveSessionKey(ownerID, wt worker.WorkerType, clientKey, workspaceID, workDir)`（`key.go:52`）将 worker_type 纳入 session key 派生。
+
+切 `workspace.worker_preference` 的行为：
+
+| 会话 | 行为 |
+|---|---|
+| 已存在会话 | **不变**——session key 已定，worker 继续跑直到 idle/terminate |
+| 新会话（切 preference 后创建） | 用新 worker_type 派生**新 session key** → 新会话，不继承旧 worker 上下文 |
+
+无需特殊处理（DeriveSessionKey 自然产生新 key）。**文档化**：spec 此节 + PATCH 响应可选提示「切换 worker 后，新会话将使用新 worker；已存在会话不受影响」。
+
+---
+
+## 9. 错误码
+
+| 场景 | HTTP | code | sentinel |
+|---|---|---|---|
+| PATCH 非法 worker_preference | 400 | `INVALID_WORKER_TYPE` | `worker.ErrInvalidWorkerType` |
+| CreateSession 非法 worker_type | 400 | `INVALID_WORKER_TYPE` | `worker.ErrInvalidWorkerType` |
+
+---
+
+## 10. 测试策略
+
+table-driven + `t.Parallel()` + `-race`，单模块 ≤5s：
+
+- **TestValidateType**：空合法 / 4 类（claude_code/opencode_server/codex_cli/acp）合法 / `TypeUnknown` 拒 / 大小写敏感（"Claude_Code" 拒）。
+- **TestPATCHWorkspaceWorkerPreference**：合法更新 / 非法 400 / 空值不变（保持原 preference）。
+- **TestCreateSessionWorkerTypeValidation**：body 合法 / body 非法 400 / query 合法 / query 非法 400 / 空 fallback 到 preference。
+- **TestDualTrackIsolation**：Message Channel 轨 worker_type fallback（config_defaults）不受 WebChat preference 影响（回归）。
+- **TestSwitchPreferenceNewSession**：切 preference → `DeriveSessionKey` 产生新 key（新会话），旧 key 不变。
+
+---
+
+## 11. 受影响文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `internal/worker/worker.go`（或 `registry.go`） | + `ErrInvalidWorkerType` + `ValidateType` |
+| `internal/worker/registry_test.go`（或 `worker_test.go`） | + `TestValidateType` |
+| `internal/gateway/workspace_handlers.go` | PATCH `worker_preference` 加 `ValidateType`（:179-181） |
+| `internal/gateway/workspace_handlers_test.go` | PATCH 白名单测试 |
+| `internal/gateway/api.go` | CreateSession `worker_type` 加 `ValidateType`（:267-272） |
+| `internal/gateway/api_test.go`（或新建） | CreateSession 白名单测试 |
+
+**不改**：`multitenancy_store.go`（字段/存取 spec ①）、`config_defaults.go`（Message Channel 轨）、`key.go`（DeriveSessionKey）、`api.go` fallback 链逻辑。
+
+---
+
+## 12. 后续 spec 路线
+
+spec ③ 合入 → spec ④（OAuth/SSO provider）+ spec ⑤（配额增强）→ spec ⑥（前端 UI，消费 `worker_preference` 选择 UI）。

--- a/docs/superpowers/plans/2026-06-17-webchat-multitenancy-spec3-workspace-worker.md
+++ b/docs/superpowers/plans/2026-06-17-webchat-multitenancy-spec3-workspace-worker.md
@@ -1,0 +1,409 @@
+# WebChat 多租户 spec ③：workspace 级 worker 选择 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 补 spec ① 遗留的 worker_type 白名单校验闭环（PATCH `worker_preference` + CreateSession body/query `worker_type` 统一 `worker.ValidateType`），双轨隔离测试 + 会话连续性文档化。
+
+**Architecture:** spec ① 已实现 worker_preference 字段、CreateSession fallback 链（body/query > preference > default）、worker.Type 4 常量 + `RegisteredTypes()`、`DeriveSessionKey` 含 worker_type。spec ③ 只补白名单校验（新 `worker.ValidateType`，RegisteredTypes 动态源）+ 两个调用点接入 + 双轨隔离/会话连续性回归测试。不改字段/存取/fallback 链/Message Channel 轨。
+
+**Tech Stack:** Go 1.x · testify/require · table-driven · `t.Parallel()` · `-race` · 现有 `internal/worker` registry + `internal/gateway` handlers。
+
+**设计文档:** [`docs/specs/WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md`](../../specs/WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md)（commit `423f8545`）
+
+---
+
+## 文件结构
+
+| 文件 | 责任 | 改动 |
+|---|---|---|
+| `internal/worker/registry.go` | worker 注册表 + 白名单源 | + `ErrInvalidWorkerType` + `ValidateType` |
+| `internal/worker/registry_test.go` | registry 单元测试 | + `TestValidateType` |
+| `internal/gateway/workspace_handlers.go` | PATCH workspace | worker_preference 接入 `ValidateType`（:179-181） |
+| `internal/gateway/workspace_handlers_test.go` | PATCH 测试 | + 白名单测试（复用 spec ② `patchWorkspace` helper） |
+| `internal/gateway/api.go` | CreateSession | body/query worker_type 接入 `ValidateType`（:267-276） |
+| `internal/gateway/api_test.go` | CreateSession 测试 | + 白名单测试（复用现有 CreateSession 测试模式） |
+| `internal/session/key_test.go` | session key 测试 | + 会话连续性（切 worker_type = 新 key）回归注释/测试 |
+
+---
+
+## Task 1: `worker.ValidateType` + sentinel error（TDD）
+
+**Files:**
+- Modify: `internal/worker/registry.go`（追加 `ErrInvalidWorkerType` + `ValidateType`，放在 `RegisteredTypes` 后 :75）
+- Test: `internal/worker/registry_test.go`（追加 `TestValidateType`）
+
+- [ ] **Step 1: Write the failing test**
+
+追加到 `internal/worker/registry_test.go` 末尾：
+
+```go
+func TestValidateType(t *testing.T) {
+	t.Parallel()
+
+	// 4 类已注册 worker（init() Register 由各适配器包完成）
+	registered := RegisteredTypes()
+
+	tests := []struct {
+		name    string
+		wt      WorkerType
+		wantErr bool
+	}{
+		{"empty inherits default", "", false},
+		{"claude_code valid", TypeClaudeCode, false},
+		{"opencode_server valid", TypeOpenCodeSrv, false},
+		{"codex_cli valid", TypeCodexCLI, false},
+		{"acp valid", TypeACP, false},
+		{"unknown sentinel rejected", TypeUnknown, true},
+		{"garbage rejected", WorkerType("bogus_worker"), true},
+		{"case sensitive uppercase rejected", WorkerType("CLAUDE_CODE"), true},
+		{"case sensitive capitalized rejected", WorkerType("Claude_Code"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateType(tt.wt)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrInvalidWorkerType)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+
+	// Sanity: the 4 valid constants are actually in RegisteredTypes()
+	// (guards against a future worker package losing its init() Register).
+	require.Contains(t, registered, TypeClaudeCode)
+	require.Contains(t, registered, TypeOpenCodeSrv)
+	require.Contains(t, registered, TypeCodexCLI)
+	require.Contains(t, registered, TypeACP)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestValidateType ./internal/worker/... -count=1`
+Expected: FAIL — `undefined: ValidateType` / `undefined: ErrInvalidWorkerType`
+
+- [ ] **Step 3: Write minimal implementation**
+
+追加到 `internal/worker/registry.go`（`RegisteredTypes` 函数后，:75 之后）：
+
+```go
+// ErrInvalidWorkerType signals a worker type that is not registered.
+// Returned by ValidateType for non-empty types absent from RegisteredTypes().
+var ErrInvalidWorkerType = errors.New("invalid worker type")
+
+// ValidateType returns nil for an empty wt (means "inherit default") or for any
+// registered worker type. A non-empty unregistered type returns ErrInvalidWorkerType.
+// Used by both the PATCH workspace handler and CreateSession to reject unknown
+// worker types at the boundary instead of at worker launch. See spec ③ §4.
+func ValidateType(wt WorkerType) error {
+	if wt == "" {
+		return nil
+	}
+	for _, t := range RegisteredTypes() {
+		if t == wt {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %q not in registered types %v", ErrInvalidWorkerType, wt, RegisteredTypes())
+}
+```
+
+确认 `registry.go` 顶部已 import `"errors"` + `"fmt"`（若无需补）。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run TestValidateType ./internal/worker/... -count=1 -race`
+Expected: PASS（含 9 子测试）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/worker/registry.go internal/worker/registry_test.go
+git commit -m "feat(worker): ValidateType + ErrInvalidWorkerType (spec ③)"
+```
+
+---
+
+## Task 2: PATCH worker_preference 白名单校验（TDD）
+
+**Files:**
+- Modify: `internal/gateway/workspace_handlers.go:179-181`
+- Test: `internal/gateway/workspace_handlers_test.go`（复用 spec ② `patchWorkspace` helper @140）
+
+- [ ] **Step 1: Write the failing test**
+
+追加到 `internal/gateway/workspace_handlers_test.go`（spec ② 白名单测试附近）：
+
+```go
+func TestPATCHWorkspaceWorkerPreference_Whitelist(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	cookie := env.createUserAndLogin(t, "owner", true)
+	ws := env.createWorkspace(t, cookie, "owner")
+
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantCode   string // empty = no error envelope
+	}{
+		{"valid claude_code", `{"worker_preference":"claude_code"}`, http.StatusOK, ""},
+		{"valid opencode_server", `{"worker_preference":"opencode_server"}`, http.StatusOK, ""},
+		{"valid codex_cli", `{"worker_preference":"codex_cli"}`, http.StatusOK, ""},
+		{"valid acp", `{"worker_preference":"acp"}`, http.StatusOK, ""},
+		{"empty keeps default", `{"worker_preference":""}`, http.StatusOK, ""},
+		{"unknown rejected", `{"worker_preference":"bogus"}`, http.StatusBadRequest, "INVALID_WORKER_TYPE"},
+		{"TypeUnknown rejected", `{"worker_preference":"unknown"}`, http.StatusBadRequest, "INVALID_WORKER_TYPE"},
+		{"case sensitive rejected", `{"worker_preference":"Claude_Code"}`, http.StatusBadRequest, "INVALID_WORKER_TYPE"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rec := env.patchWorkspace(t, cookie, ws.ID, tt.body)
+			require.Equal(t, tt.wantStatus, rec.Code, "body=%s resp=%s", tt.body, rec.Body.String())
+			if tt.wantCode != "" {
+				require.Contains(t, rec.Body.String(), tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestPATCHWorkspaceWorkerPreference_Persists(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	cookie := env.createUserAndLogin(t, "owner", true)
+	ws := env.createWorkspace(t, cookie, "owner")
+
+	// Set a valid preference
+	rec := env.patchWorkspace(t, cookie, ws.ID, `{"worker_preference":"acp"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Re-fetch and confirm persisted
+	got := env.getWorkspace(t, cookie, ws.ID)
+	require.Equal(t, "acp", got.WorkerPreference)
+}
+```
+
+> **Note:** 确认 `newTestAuthEnv` / `createUserAndLogin` / `createWorkspace` / `getWorkspace` helper 名称与 spec ① ② 测试一致（若 `getWorkspace` 不存在，用 `GET /api/workspaces/{id}` 直接 patchWorkspace 风格写）。参考 spec ② `TestPATCHWorkspaceAgentConfigOverrides_Persists`（workspace_handlers_test.go:216 区域）的现有模式对齐。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run 'TestPATCHWorkspaceWorkerPreference' ./internal/gateway/... -count=1`
+Expected: FAIL — 非法 worker_preference 当前被原样存储（:179-181 无校验），`unknown`/`bogus` 用例返回 200 而非 400。
+
+- [ ] **Step 3: Write minimal implementation**
+
+修改 `internal/gateway/workspace_handlers.go:179-181`：
+
+```go
+	if req.WorkerPreference != "" {
+		if err := worker.ValidateType(worker.WorkerType(req.WorkerPreference)); err != nil {
+			writeAppError(w, http.StatusBadRequest, "INVALID_WORKER_TYPE", err.Error())
+			return
+		}
+		ws.WorkerPreference = req.WorkerPreference
+	}
+```
+
+确认 `workspace_handlers.go` 顶部已 import `"github.com/hrygo/hotplex/internal/worker"`（spec ① 应已 import；若无需补）。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run 'TestPATCHWorkspaceWorkerPreference' ./internal/gateway/... -count=1 -race`
+Expected: PASS（含 8 白名单子测试 + Persists）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/gateway/workspace_handlers.go internal/gateway/workspace_handlers_test.go
+git commit -m "feat(gateway): PATCH worker_preference whitelist (spec ③)"
+```
+
+---
+
+## Task 3: CreateSession worker_type 白名单校验（TDD）
+
+**Files:**
+- Modify: `internal/gateway/api.go:266-276`
+- Test: `internal/gateway/api_test.go`（复用现有 CreateSession 测试模式，如 `TestCreateSession_WithClientSessionID` @252）
+
+- [ ] **Step 1: Write the failing test**
+
+追加到 `internal/gateway/api_test.go`（CreateSession 测试组附近）。复用现有 `newTestAuthEnv` / workspace 创建 helper：
+
+```go
+func TestCreateSession_InvalidWorkerType(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	cookie := env.createUserAndLogin(t, "owner", true)
+	ws := env.createWorkspace(t, cookie, "owner")
+
+	tests := []struct {
+		name       string
+		queryParam string // ?worker_type=
+		wantStatus int
+	}{
+		{"query bogus rejected", "bogus", http.StatusBadRequest},
+		{"query TypeUnknown rejected", "unknown", http.StatusBadRequest},
+		{"query case sensitive rejected", "Claude_Code", http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// 用 query param 形式（api.go:269 路径），body 无 worker_type
+			rec := env.createSessionRaw(t, cookie, ws.ID, "", "client-key-"+tt.name, "GET", "?worker_type="+tt.queryParam)
+			require.Equal(t, tt.wantStatus, rec.Code, "resp=%s", rec.Body.String())
+			require.Contains(t, rec.Body.String(), "INVALID_WORKER_TYPE")
+		})
+	}
+
+	t.Run("valid query worker_type accepted", func(t *testing.T) {
+		t.Parallel()
+		rec := env.createSessionRaw(t, cookie, ws.ID, "", "client-key-valid", "GET", "?worker_type=acp")
+		// 200 或经 bridge（可能 bridge error 但非 400 INVALID_WORKER_TYPE）
+		require.NotContains(t, rec.Body.String(), "INVALID_WORKER_TYPE")
+	})
+}
+```
+
+> **Note:** `createSessionRaw` 是占位名——核对现有 CreateSession 测试（api_test.go:252-369）用的 helper 签名（可能是 `env.createSession(t, cookie, ws.ID, ...)` 或直接 `httptest` 调 `/api/sessions`）。用现有 helper 的真实签名替换 `createSessionRaw`，保持传 `(workspaceID, body, clientSessionID, method, query)` 的语义。关键断言：非法 worker_type → 400 + `INVALID_WORKER_TYPE`。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -run TestCreateSession_InvalidWorkerType ./internal/gateway/... -count=1`
+Expected: FAIL — 非法 query `worker_type` 当前无校验，会落到 fallback / launch 失败（非 400 `INVALID_WORKER_TYPE`）。
+
+- [ ] **Step 3: Write minimal implementation**
+
+修改 `internal/gateway/api.go:266-276`，在 fallback 到 preference/default 前校验解析出的非空 wt：
+
+```go
+	// worker_type resolution: body/query > workspace.WorkerPreference > default.
+	wt := worker.WorkerType(body.WorkerType)
+	if wt == "" {
+		wt = worker.WorkerType(r.URL.Query().Get("worker_type"))
+	}
+	if wt != "" {
+		if err := worker.ValidateType(wt); err != nil {
+			writeAppError(w, http.StatusBadRequest, "INVALID_WORKER_TYPE", err.Error())
+			return
+		}
+	}
+	if wt == "" {
+		wt = worker.WorkerType(ws.WorkerPreference)
+	}
+	if wt == "" {
+		wt = worker.TypeClaudeCode
+	}
+```
+
+> **关键：** 校验只对 body/query 解析出的 wt（请求侧，可能非法）。`ws.WorkerPreference`（DB）已在 PATCH 写入侧校验（Task 2），此处不再重复校验——若 PATCH 闭环，DB 值必然合法。`TypeClaudeCode` default 是常量，无需校验。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -run 'TestCreateSession' ./internal/gateway/... -count=1 -race`
+Expected: PASS（新 `TestCreateSession_InvalidWorkerType` + 现有 CreateSession 全回归通过）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/gateway/api.go internal/gateway/api_test.go
+git commit -m "feat(gateway): CreateSession worker_type whitelist (spec ③)"
+```
+
+---
+
+## Task 4: 双轨隔离 + 会话连续性回归测试
+
+**Files:**
+- Test: `internal/session/key_test.go`（DeriveSessionKey 切 worker_type = 新 key，已部分有 @22 `TestDeriveSessionKey_DifferentTuples`，补明确断言）
+- Test: `internal/gateway/api_test.go`（双轨隔离：Message Channel 轨 worker_type 来自 config，不受 WebChat preference 影响——文档化回归）
+
+- [ ] **Step 1: Write the failing/clarifying test**
+
+追加到 `internal/session/key_test.go`（`TestDeriveSessionKey_DifferentTuples` 后）——**会话连续性**：切 worker_type 产生新 key，旧 key 不变：
+
+```go
+func TestDeriveSessionKey_SwitchWorkerType_NewKey(t *testing.T) {
+	t.Parallel()
+	// 会话连续性 (spec ③ §8): 切 worker_preference → DeriveSessionKey 新 wt → 新 session key → 新会话。
+	// 已存在会话（旧 key）不受影响。
+	keyCC := DeriveSessionKey("u1", worker.TypeClaudeCode, "s1", "ws-1", "/tmp/hotplex/ws")
+	keyOCS := DeriveSessionKey("u1", worker.TypeOpenCodeSrv, "s1", "ws-1", "/tmp/hotplex/ws")
+	require.NotEqual(t, keyCC, keyOCS,
+		"switching worker_type must produce a new session key (new session), not resume the old one")
+}
+```
+
+> **Note:** `key_test.go` 已 import `worker`（@15 用 `worker.TypeClaudeCode`）。无需补 import。
+
+- [ ] **Step 2: Run test — expect PASS already（这是回归/文档化测试，验证现有不变式）**
+
+Run: `go test -run TestDeriveSessionKey_SwitchWorkerType_NewKey ./internal/session/... -count=1 -race`
+Expected: PASS（DeriveSessionKey 含 worker_type，切则不同——现有行为，此测试锁定它防回归）。
+
+> 双轨隔离（Message Channel 轨 worker_type 来自 `config_defaults.propagatePlatform`，不查 `worker_preference`）是**结构性保证**——Message Channel 会话不绑 workspace（spec ① §2.4），代码路径无交集。无需新测试代码，但在 Task 5 的 design spec/CLAUDE.md 文档化此不变式。若需显式回归，在 `config_defaults_test.go` 加：`propagatePlatform` 不引用 `Workspace.WorkerPreference`（grep 确认无引用即可，作为轻量文档化）。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/session/key_test.go
+git commit -m "test(session): DeriveSessionKey switch-worker-type new-key regression (spec ③ §8)"
+```
+
+---
+
+## Task 5: 文档化（design spec 双轨 + 会话连续性已在；补 .agents/rules worker-proc.md / CLAUDE.md 一行引用）
+
+**Files:**
+- Modify: `docs/specs/WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md`（已含 §6 双轨隔离 + §8 会话连续性，确认无需改）
+- 可选：`.agents/rules/golang.md` 或 worker 规则补「worker_type 边界校验用 `worker.ValidateType`」
+
+- [ ] **Step 1: 确认 design spec §6/§8 已覆盖**
+
+Read `docs/specs/WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md` §6（双轨隔离）+ §8（会话连续性）—— 已在 brainstorming 写入。无需改。
+
+- [ ] **Step 2: 若 .agents/rules 有 worker 选择相关规则，补 ValidateType 引用**
+
+Grep: `grep -rn "worker_type\|WorkerPreference" .agents/rules/`
+若命中 `golang.md` 或 `session.md` 的 worker 选择段落，补一行：「worker_type 边界校验：PATCH workspace.worker_preference + CreateSession body/query 统一走 `worker.ValidateType`（spec ③），非法 → 400 `INVALID_WORKER_TYPE`」。
+
+若无命中，跳过此 Step（YAGNI）。
+
+- [ ] **Step 3: 全量质量门禁**
+
+Run: `make check`
+Expected: PASS（quality + build + test，三平台逻辑）
+
+- [ ] **Step 4: Commit（若有规则改动）**
+
+```bash
+git add .agents/rules/  # 仅当 Step 2 改了
+git commit -m "docs(rules): worker_type boundary validation (spec ③)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §4 ValidateType → Task 1 ✓
+- §7.1 PATCH 校验 → Task 2 ✓
+- §7.2 CreateSession 校验 → Task 3 ✓
+- §8 会话连续性 → Task 4（key_test 回归）+ design spec §8 ✓
+- §6 双轨隔离 → Task 4 Step 2（结构性保证 + design spec §6）+ Task 5 ✓
+- §10 测试策略（ValidateType / PATCH / CreateSession / 双轨 / 切 preference）→ Task 1-4 全覆盖 ✓
+- §11 受影响文件 → registry.go / registry_test.go / workspace_handlers.go / workspace_handlers_test.go / api.go / api_test.go / key_test.go 全在 Task ✓
+
+**2. Placeholder scan:** 无 TBD/TODO。"createSessionRaw"/"getWorkspace" 标注为「核对现有 helper 签名替换」——是 plan 内明确指引（非占位），实现者按 spec ② 现有 helper 对齐。✓
+
+**3. Type consistency:**
+- `ValidateType(wt WorkerType) error` — Task 1 定义，Task 2/3 调用一致 ✓
+- `ErrInvalidWorkerType` — Task 1 定义，Task 1 测试 `errors.Is` 用 ✓
+- `INVALID_WORKER_TYPE` code — Task 2/3 一致 ✓
+- `worker.WorkerType(req.WorkerPreference)` / `worker.WorkerType(body.WorkerType)` — 调用一致 ✓
+
+无问题，plan 完整。

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -268,6 +268,15 @@ func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 	if wt == "" {
 		wt = worker.WorkerType(r.URL.Query().Get("worker_type"))
 	}
+	// Validate request-supplied worker_type (body/query) at the boundary.
+	// ws.WorkerPreference is already validated on PATCH write; the default
+	// constant needs no check. See spec ③ §7.2.
+	if wt != "" {
+		if err := worker.ValidateType(wt); err != nil {
+			writeAppError(w, http.StatusBadRequest, "INVALID_WORKER_TYPE", err.Error())
+			return
+		}
+	}
 	if wt == "" {
 		wt = worker.WorkerType(ws.WorkerPreference)
 	}

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -268,17 +268,27 @@ func (g *GatewayAPI) CreateSession(w http.ResponseWriter, r *http.Request) {
 	if wt == "" {
 		wt = worker.WorkerType(r.URL.Query().Get("worker_type"))
 	}
-	// Validate request-supplied worker_type (body/query) at the boundary.
-	// ws.WorkerPreference is already validated on PATCH write; the default
-	// constant needs no check. See spec ③ §7.2.
+	// Validate request-supplied worker_type (body/query) at the boundary → 400
+	// on unknown types. See spec ③ §7.2.
 	if wt != "" {
 		if err := worker.ValidateType(wt); err != nil {
 			writeAppError(w, http.StatusBadRequest, "INVALID_WORKER_TYPE", err.Error())
 			return
 		}
 	}
+	// Fall back to the workspace preference. PATCH validates on write, but a
+	// stale row written before that gate existed (spec ①-②), or a bypass write
+	// (migration/manual SQL), could hold an unvalidated value. Re-validate and
+	// degrade to the default rather than failing late at worker launch (review P2).
 	if wt == "" {
-		wt = worker.WorkerType(ws.WorkerPreference)
+		if pref := worker.WorkerType(ws.WorkerPreference); pref != "" {
+			if err := worker.ValidateType(pref); err == nil {
+				wt = pref
+			} else {
+				g.log.Warn("workspace worker_preference invalid, falling back to default",
+					"workspace_id", ws.ID, "worker_preference", pref, "err", err)
+			}
+		}
 	}
 	if wt == "" {
 		wt = worker.TypeClaudeCode

--- a/internal/gateway/api_test.go
+++ b/internal/gateway/api_test.go
@@ -382,48 +382,73 @@ func TestCreateSession_BridgeError(t *testing.T) {
 	require.Contains(t, w.Body.String(), "failed to create session")
 }
 
-func TestCreateSession_InvalidWorkerType(t *testing.T) {
+func TestCreateSession_WorkerTypeValidation(t *testing.T) {
 	t.Parallel()
 
-	// Invalid worker_type must be rejected at the boundary (400) before reaching
-	// DeriveSessionKey / bridge.StartSession, so those mocks are intentionally
-	// left unset for the invalid cases.
-	invalidCases := []struct {
+	// worker_type is validated at the boundary whether supplied via query param
+	// (?worker_type=) or JSON body ({"worker_type":...}). Both parse paths
+	// (api.go:267-270) are independent and must reject unknown types with 400
+	// INVALID_WORKER_TYPE before reaching DeriveSessionKey / bridge.StartSession
+	// (so mocks are intentionally unset for invalid cases). See spec ③ §7.2/§10.
+	//
+	// testNoopType ("noop_gateway_test") is the registered test worker — the 4
+	// real constants are validated at the worker-package boundary (TestValidateType).
+	newAPI := func(t *testing.T) (*GatewayAPI, *mockAPISM, *mockAPIBridge) {
+		sm := new(mockAPISM)
+		bridge := new(mockAPIBridge)
+		return newTestAPIWithWorkspace(t, sm, bridge, ownedWorkspaceMock("anonymous", "/tmp/hotplex/proj")), sm, bridge
+	}
+
+	invalid := []struct {
 		name string
 		url  string
+		body string
 	}{
-		{"query bogus rejected", "/api/sessions?workspace_id=ws-test&client_session_id=c1&worker_type=bogus"},
-		{"query TypeUnknown rejected", "/api/sessions?workspace_id=ws-test&client_session_id=c2&worker_type=unknown"},
-		{"query case sensitive rejected", "/api/sessions?workspace_id=ws-test&client_session_id=c3&worker_type=Claude_Code"},
+		{"query bogus", "/api/sessions?workspace_id=ws-test&client_session_id=cq1&worker_type=bogus", ""},
+		{"query TypeUnknown", "/api/sessions?workspace_id=ws-test&client_session_id=cq2&worker_type=unknown", ""},
+		{"query case sensitive", "/api/sessions?workspace_id=ws-test&client_session_id=cq3&worker_type=Claude_Code", ""},
+		{"body bogus", "/api/sessions?workspace_id=ws-test&client_session_id=cb1", `{"worker_type":"bogus"}`},
+		{"body TypeUnknown", "/api/sessions?workspace_id=ws-test&client_session_id=cb2", `{"worker_type":"unknown"}`},
+		{"body case sensitive", "/api/sessions?workspace_id=ws-test&client_session_id=cb3", `{"worker_type":"Claude_Code"}`},
 	}
-	for _, tt := range invalidCases {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tt := range invalid {
+		t.Run("invalid/"+tt.name, func(t *testing.T) {
 			t.Parallel()
-			sm := new(mockAPISM)
-			bridge := new(mockAPIBridge)
-			api := newTestAPIWithWorkspace(t, sm, bridge, ownedWorkspaceMock("anonymous", "/tmp/hotplex/proj"))
-
+			api, _, _ := newAPI(t)
 			w := httptest.NewRecorder()
-			api.CreateSession(w, authedReq("POST", tt.url, nil))
+			var body io.Reader
+			if tt.body != "" {
+				body = strings.NewReader(tt.body)
+			}
+			api.CreateSession(w, authedReq("POST", tt.url, body))
 			require.Equal(t, http.StatusBadRequest, w.Code, "resp=%s", w.Body.String())
 			require.Contains(t, w.Body.String(), "INVALID_WORKER_TYPE")
 		})
 	}
 
-	t.Run("valid query worker_type accepted", func(t *testing.T) {
-		t.Parallel()
-		// testNoopType is the registered test worker; a valid type passes boundary
-		// validation and proceeds to bridge.StartSession (mocked to succeed).
-		sm := new(mockAPISM)
-		bridge := new(mockAPIBridge)
-		api := newTestAPIWithWorkspace(t, sm, bridge, ownedWorkspaceMock("anonymous", "/tmp/hotplex/proj"))
-		sm.On("Get", mock.Anything).Return(nil, session.ErrSessionNotFound)
-		bridge.On("StartSession", mock.Anything, mock.Anything).Return(nil)
-
-		w := httptest.NewRecorder()
-		api.CreateSession(w, authedReq("POST", "/api/sessions?workspace_id=ws-test&client_session_id=c-valid&worker_type="+string(testNoopType), nil))
-		require.Equal(t, http.StatusOK, w.Code, "resp=%s", w.Body.String())
-	})
+	valid := []struct {
+		name string
+		url  string
+		body string
+	}{
+		{"query", "/api/sessions?workspace_id=ws-test&client_session_id=cvq&worker_type=" + string(testNoopType), ""},
+		{"body", "/api/sessions?workspace_id=ws-test&client_session_id=cvb", `{"worker_type":"` + string(testNoopType) + `"}`},
+	}
+	for _, tt := range valid {
+		t.Run("valid/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+			api, sm, bridge := newAPI(t)
+			sm.On("Get", mock.Anything).Return(nil, session.ErrSessionNotFound)
+			bridge.On("StartSession", mock.Anything, mock.Anything).Return(nil)
+			w := httptest.NewRecorder()
+			var body io.Reader
+			if tt.body != "" {
+				body = strings.NewReader(tt.body)
+			}
+			api.CreateSession(w, authedReq("POST", tt.url, body))
+			require.Equal(t, http.StatusOK, w.Code, "resp=%s", w.Body.String())
+		})
+	}
 }
 
 var errTestBridge = fmt.Errorf("test bridge error")

--- a/internal/gateway/api_test.go
+++ b/internal/gateway/api_test.go
@@ -451,6 +451,33 @@ func TestCreateSession_WorkerTypeValidation(t *testing.T) {
 	}
 }
 
+func TestCreateSession_StaleWorkerPreferenceDegradesToDefault(t *testing.T) {
+	t.Parallel()
+	sm := new(mockAPISM)
+	bridge := new(mockAPIBridge)
+	// Workspace carries a stale, unvalidated worker_preference (written before
+	// the PATCH gate existed, or via a bypass write). It must NOT yield a 400
+	// (the caller didn't supply worker_type) and must NOT reach worker launch
+	// with the bad value — degrade to the default instead. See review P2.
+	ws := new(mockAPIWorkspace)
+	ws.On("GetWorkspaceByID", mock.Anything, mock.Anything).Return(&session.Workspace{
+		ID: "ws-test", OwnerUserID: "anonymous", WorkDir: "/tmp/hotplex/proj",
+		WorkerPreference: "bogus_stale", Status: "active",
+	}, nil)
+	api := newTestAPIWithWorkspace(t, sm, bridge, ws)
+
+	sm.On("Get", mock.Anything).Return(nil, session.ErrSessionNotFound)
+	bridge.On("StartSession", mock.Anything, mock.MatchedBy(func(p worker.SessionStartParams) bool {
+		return p.WorkerType == worker.TypeClaudeCode
+	})).Return(nil)
+
+	w := httptest.NewRecorder()
+	api.CreateSession(w, authedReq("POST", "/api/sessions?workspace_id=ws-test&client_session_id=stale", nil))
+
+	require.Equal(t, http.StatusOK, w.Code, "resp=%s", w.Body.String())
+	bridge.AssertExpectations(t)
+}
+
 var errTestBridge = fmt.Errorf("test bridge error")
 
 // TestCreateSession_WorkDirFromWorkspace: work_dir comes from the workspace

--- a/internal/gateway/api_test.go
+++ b/internal/gateway/api_test.go
@@ -382,6 +382,50 @@ func TestCreateSession_BridgeError(t *testing.T) {
 	require.Contains(t, w.Body.String(), "failed to create session")
 }
 
+func TestCreateSession_InvalidWorkerType(t *testing.T) {
+	t.Parallel()
+
+	// Invalid worker_type must be rejected at the boundary (400) before reaching
+	// DeriveSessionKey / bridge.StartSession, so those mocks are intentionally
+	// left unset for the invalid cases.
+	invalidCases := []struct {
+		name string
+		url  string
+	}{
+		{"query bogus rejected", "/api/sessions?workspace_id=ws-test&client_session_id=c1&worker_type=bogus"},
+		{"query TypeUnknown rejected", "/api/sessions?workspace_id=ws-test&client_session_id=c2&worker_type=unknown"},
+		{"query case sensitive rejected", "/api/sessions?workspace_id=ws-test&client_session_id=c3&worker_type=Claude_Code"},
+	}
+	for _, tt := range invalidCases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sm := new(mockAPISM)
+			bridge := new(mockAPIBridge)
+			api := newTestAPIWithWorkspace(t, sm, bridge, ownedWorkspaceMock("anonymous", "/tmp/hotplex/proj"))
+
+			w := httptest.NewRecorder()
+			api.CreateSession(w, authedReq("POST", tt.url, nil))
+			require.Equal(t, http.StatusBadRequest, w.Code, "resp=%s", w.Body.String())
+			require.Contains(t, w.Body.String(), "INVALID_WORKER_TYPE")
+		})
+	}
+
+	t.Run("valid query worker_type accepted", func(t *testing.T) {
+		t.Parallel()
+		// testNoopType is the registered test worker; a valid type passes boundary
+		// validation and proceeds to bridge.StartSession (mocked to succeed).
+		sm := new(mockAPISM)
+		bridge := new(mockAPIBridge)
+		api := newTestAPIWithWorkspace(t, sm, bridge, ownedWorkspaceMock("anonymous", "/tmp/hotplex/proj"))
+		sm.On("Get", mock.Anything).Return(nil, session.ErrSessionNotFound)
+		bridge.On("StartSession", mock.Anything, mock.Anything).Return(nil)
+
+		w := httptest.NewRecorder()
+		api.CreateSession(w, authedReq("POST", "/api/sessions?workspace_id=ws-test&client_session_id=c-valid&worker_type="+string(testNoopType), nil))
+		require.Equal(t, http.StatusOK, w.Code, "resp=%s", w.Body.String())
+	})
+}
+
 var errTestBridge = fmt.Errorf("test bridge error")
 
 // TestCreateSession_WorkDirFromWorkspace: work_dir comes from the workspace

--- a/internal/gateway/workspace_handlers.go
+++ b/internal/gateway/workspace_handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/security"
 	"github.com/hrygo/hotplex/internal/session"
+	"github.com/hrygo/hotplex/internal/worker"
 )
 
 // WorkspaceHandlers serves /api/workspaces (spec §9.1, §11.3).
@@ -177,6 +178,10 @@ func (h *WorkspaceHandlers) Update(w http.ResponseWriter, r *http.Request) {
 		ws.AgentConfigOverrides = req.AgentConfigOverrides
 	}
 	if req.WorkerPreference != "" {
+		if err := worker.ValidateType(worker.WorkerType(req.WorkerPreference)); err != nil {
+			writeAppError(w, http.StatusBadRequest, "INVALID_WORKER_TYPE", err.Error())
+			return
+		}
 		ws.WorkerPreference = req.WorkerPreference
 	}
 	if err := h.store.UpdateWorkspace(r.Context(), ws, h.nowUnix()); err != nil {

--- a/internal/gateway/workspace_handlers_test.go
+++ b/internal/gateway/workspace_handlers_test.go
@@ -225,3 +225,60 @@ func TestWorkspace_PatchAgentConfigOverrides_Persists(t *testing.T) {
 	require.Equal(t, http.StatusOK, gr.Code)
 	require.Contains(t, gr.Body.String(), `\"SOUL.md\":\"ws-soul\"`)
 }
+
+func TestWorkspace_PatchWorkerPreference_Whitelist(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	cookie := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+	ws := env.createWorkspace(t, cookie, "proj", "/tmp/hotplex-ws-wp")
+
+	// The gateway test binary does not import the real worker adapters, so the
+	// registry holds only testNoopType ("noop_gateway_test", registered in init).
+	// Use it as the stand-in for "a valid registered type" — the 4 real
+	// constants are validated at the worker-package boundary (TestValidateType).
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantCode   string
+	}{
+		{"valid registered type", `{"worker_preference":"` + string(testNoopType) + `"}`, http.StatusOK, ""},
+		{"empty keeps default", `{"worker_preference":""}`, http.StatusOK, ""},
+		{"unknown rejected", `{"worker_preference":"bogus"}`, http.StatusBadRequest, "INVALID_WORKER_TYPE"},
+		{"TypeUnknown rejected", `{"worker_preference":"unknown"}`, http.StatusBadRequest, "INVALID_WORKER_TYPE"},
+		{"case sensitive rejected", `{"worker_preference":"Claude_Code"}`, http.StatusBadRequest, "INVALID_WORKER_TYPE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			w := env.patchWorkspace(t, cookie, ws.ID, tt.body)
+			require.Equal(t, tt.wantStatus, w.Code, "body=%s", w.Body.String())
+			if tt.wantCode != "" {
+				require.Contains(t, w.Body.String(), tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestWorkspace_PatchWorkerPreference_Persists(t *testing.T) {
+	t.Parallel()
+	env := newTestAuthEnv(t)
+	cookie := env.loginAs(t, "admin", "adminpass", http.StatusOK)
+	ws := env.createWorkspace(t, cookie, "proj", "/tmp/hotplex-ws-wp-persist")
+
+	// Set a valid preference (testNoopType is the registered test worker).
+	w := env.patchWorkspace(t, cookie, ws.ID, `{"worker_preference":"`+string(testNoopType)+`"}`)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Re-fetch and confirm persisted (not just echoed in the PATCH response).
+	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+ws.ID, nil)
+	req.SetPathValue("id", ws.ID)
+	req.Header.Set("Cookie", cookie)
+	gr := httptest.NewRecorder()
+	env.wsHandlers.Get(gr, req)
+	require.Equal(t, http.StatusOK, gr.Code)
+	var got session.Workspace
+	require.NoError(t, json.NewDecoder(gr.Body).Decode(&got))
+	require.Equal(t, string(testNoopType), got.WorkerPreference)
+}

--- a/internal/session/key_test.go
+++ b/internal/session/key_test.go
@@ -34,6 +34,22 @@ func TestDeriveSessionKey_DifferentTuples(t *testing.T) {
 	require.NotEqual(t, key1, key5, "different workDir → different key")
 }
 
+// TestDeriveSessionKey_SwitchWorkerType_NewKey locks the session-continuity
+// invariant for spec ③ §8: switching workspace.worker_preference changes wt in
+// DeriveSessionKey, yielding a new session key (a new session) — existing
+// sessions keyed on the old wt are untouched.
+func TestDeriveSessionKey_SwitchWorkerType_NewKey(t *testing.T) {
+	t.Parallel()
+	const owner, clientKey, wsID, workDir = "u1", "s1", "ws-1", "/tmp/hotplex/ws"
+	keyCC := DeriveSessionKey(owner, worker.TypeClaudeCode, clientKey, wsID, workDir)
+	keyOCS := DeriveSessionKey(owner, worker.TypeOpenCodeSrv, clientKey, wsID, workDir)
+	require.NotEqual(t, keyCC, keyOCS,
+		"switching worker_type must produce a new session key (new session), not resume the old one")
+	// The original key is stable — re-deriving with the same wt reproduces it,
+	// so an existing session is not disturbed when the preference changes.
+	require.Equal(t, keyCC, DeriveSessionKey(owner, worker.TypeClaudeCode, clientKey, wsID, workDir))
+}
+
 // TestDeriveSessionKey_WorkspaceIDParticipates: non-empty workspaceID changes the key (spec §7 方案3).
 func TestDeriveSessionKey_WorkspaceIDParticipates(t *testing.T) {
 	t.Parallel()

--- a/internal/worker/registry.go
+++ b/internal/worker/registry.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"errors"
 	"fmt"
-	"slices"
 	"sync"
 )
 
@@ -88,11 +87,13 @@ func ValidateType(wt WorkerType) error {
 	if wt == "" {
 		return nil
 	}
-	registered := RegisteredTypes()
-	if slices.Contains(registered, wt) {
+	registryMu.RLock()
+	_, ok := registry[wt]
+	registryMu.RUnlock()
+	if ok {
 		return nil
 	}
-	return fmt.Errorf("%w: %q not in registered types %v", ErrInvalidWorkerType, wt, registered)
+	return fmt.Errorf("%w: %q not in registered types %v", ErrInvalidWorkerType, wt, RegisteredTypes())
 }
 
 // CanResumeTerminated returns true if the given worker type supports

--- a/internal/worker/registry.go
+++ b/internal/worker/registry.go
@@ -1,7 +1,9 @@
 package worker
 
 import (
+	"errors"
 	"fmt"
+	"slices"
 	"sync"
 )
 
@@ -72,6 +74,25 @@ func RegisteredTypes() []WorkerType {
 		types = append(types, t)
 	}
 	return types
+}
+
+// ErrInvalidWorkerType signals a worker type that is not registered.
+// Returned by ValidateType for non-empty types absent from RegisteredTypes().
+var ErrInvalidWorkerType = errors.New("invalid worker type")
+
+// ValidateType returns nil for an empty wt (means "inherit default") or for any
+// registered worker type. A non-empty unregistered type returns ErrInvalidWorkerType.
+// Used by both the PATCH workspace handler and CreateSession to reject unknown
+// worker types at the boundary instead of at worker launch. See spec ③ §4.
+func ValidateType(wt WorkerType) error {
+	if wt == "" {
+		return nil
+	}
+	registered := RegisteredTypes()
+	if slices.Contains(registered, wt) {
+		return nil
+	}
+	return fmt.Errorf("%w: %q not in registered types %v", ErrInvalidWorkerType, wt, registered)
 }
 
 // CanResumeTerminated returns true if the given worker type supports

--- a/internal/worker/registry_test.go
+++ b/internal/worker/registry_test.go
@@ -217,3 +217,51 @@ func TestWorkerError(t *testing.T) {
 		require.Nil(t, errors.Unwrap(e))
 	})
 }
+
+func TestValidateType(t *testing.T) {
+	// The worker package's own tests don't import adapter packages, so the
+	// global registry is empty here. Simulate the production registry by
+	// registering the 4 known types (mirrors each adapter's init() Register).
+	// Registry is global shared state — no t.Parallel on subtests (see TestRegister).
+	withRegistry(t, func() {
+		for _, wt := range []WorkerType{TypeClaudeCode, TypeOpenCodeSrv, TypeCodexCLI, TypeACP} {
+			Register(wt, func() (Worker, error) { return nil, nil })
+		}
+
+		registered := RegisteredTypes()
+
+		tests := []struct {
+			name    string
+			wt      WorkerType
+			wantErr bool
+		}{
+			{"empty inherits default", "", false},
+			{"claude_code valid", TypeClaudeCode, false},
+			{"opencode_server valid", TypeOpenCodeSrv, false},
+			{"codex_cli valid", TypeCodexCLI, false},
+			{"acp valid", TypeACP, false},
+			{"unknown sentinel rejected", TypeUnknown, true},
+			{"garbage rejected", WorkerType("bogus_worker"), true},
+			{"case sensitive uppercase rejected", WorkerType("CLAUDE_CODE"), true},
+			{"case sensitive capitalized rejected", WorkerType("Claude_Code"), true},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := ValidateType(tt.wt)
+				if tt.wantErr {
+					require.Error(t, err)
+					require.ErrorIs(t, err, ErrInvalidWorkerType)
+					return
+				}
+				require.NoError(t, err)
+			})
+		}
+
+		// Sanity: the 4 valid constants are actually in RegisteredTypes()
+		// (guards against a future worker package losing its init() Register).
+		require.Contains(t, registered, TypeClaudeCode)
+		require.Contains(t, registered, TypeOpenCodeSrv)
+		require.Contains(t, registered, TypeCodexCLI)
+		require.Contains(t, registered, TypeACP)
+	})
+}

--- a/internal/worker/registry_test.go
+++ b/internal/worker/registry_test.go
@@ -12,15 +12,32 @@ import (
 
 // withRegistry saves the current registry state, runs fn, then restores it.
 // This prevents test pollution when Register modifies the global registry.
+//
+// The swap of the package-level registry/capCache is performed under their
+// respective mutexes so the exchange is race-free (ValidateType/NewWorker/
+// RegisteredTypes read under the same locks). fn itself runs unlocked because
+// it typically calls Register, which acquires the locks itself — holding them
+// across fn would deadlock. Callers must keep subtests non-parallel since fn
+// mutates process-global state (see TestRegister).
 func withRegistry(t *testing.T, fn func()) {
 	t.Helper()
+	registryMu.Lock()
+	capCacheMu.Lock()
 	orig := registry
 	origCap := capCache
 	registry = make(map[WorkerType]Builder)
 	capCache = make(map[WorkerType]bool)
+	registryMu.Unlock()
+	capCacheMu.Unlock()
+
 	fn()
+
+	registryMu.Lock()
+	capCacheMu.Lock()
 	registry = orig
 	capCache = origCap
+	registryMu.Unlock()
+	capCacheMu.Unlock()
 }
 
 func TestRegister(t *testing.T) {


### PR DESCRIPTION
Closes #752.

## Summary

补 spec ① 遗留的 worker_type 白名单校验闭环。spec ① 已实现字段、fallback 链、常量、`RegisteredTypes()`、`DeriveSessionKey`；本 PR 只补**边界校验**（写入侧 + 请求侧统一），不改字段/存取/fallback 链/Message Channel 轨。

- **`worker.ValidateType` + `ErrInvalidWorkerType`**（`internal/worker/registry.go`）：空值合法（继承默认），非空必须在 `RegisteredTypes()` 动态白名单内，否则 `ErrInvalidWorkerType`（`%w` 包装）。`TypeUnknown` 哨兵不 Register，自动排除。用 `slices.Contains` 替代显式循环。
- **PATCH `worker_preference` 白名单**（`workspace_handlers.go:179`）：非空值接入 `ValidateType`，非法 → 400 `INVALID_WORKER_TYPE`。写入侧闭环。
- **CreateSession `worker_type` 白名单**（`api.go:266`）：body/query 解析出的非空 wt 接入 `ValidateType`，非法 → 400。不重复校验 DB 的 `ws.WorkerPreference`（PATCH 已闭环）和 default 常量。
- **会话连续性回归**（`key_test.go`）：锁定「切 `worker_preference` → `DeriveSessionKey` 新 key（新会话），旧 key 稳定（已存在会话不变）」（spec ③ §8）。
- **双轨隔离**：Message Channel 轨（`config_defaults.propagatePlatform`）零改动 —— grep 确认 `internal/config/` 无 `WorkerPreference` 引用，WebChat 校验代码与 config 包无代码路径交集（结构性保证，design spec §6 文档化）。

## 核心决策

| 决策点 | 选择 | 理由 |
|---|---|---|
| 白名单源 | `RegisteredTypes()` 动态 | 新 worker `init()` Register 后自动纳入，单一真相源 |
| 校验范围 | PATCH + CreateSession 统一 | 复用 `ValidateType`，彻底防非法 worker_type 进系统 |
| 校验位置 | `worker.ValidateType`（worker 包） | 紧邻 `WorkerType`/`RegisteredTypes` 定义 |
| 空值语义 | 空合法（继承默认） | 两层 fallback，与 spec ② 一致 |

## 设计文档 & 计划

- 设计：`docs/specs/WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md`
- 计划：`docs/superpowers/plans/2026-06-17-webchat-multitenancy-spec3-workspace-worker.md`（5 个 TDD 任务，已全部完成）

## Test Plan

- [x] `TestValidateType`（9 子测试）：空合法 / 4 类常量合法 / `TypeUnknown` 拒 / garbage 拒 / 大小写敏感拒（`CLAUDE_CODE`/`Claude_Code` 拒）
- [x] `TestWorkspace_PatchWorkerPreference_Whitelist` + `_Persists`：合法（testNoopType）/ 空 / bogus / unknown / 大小写 → 正确状态码；合法值持久化往返（GET 验证落库）
- [x] `TestCreateSession_WorkerTypeValidation`（8 子测试）：body + query × valid/invalid 全覆盖，非法 → 400 `INVALID_WORKER_TYPE`
- [x] `TestDeriveSessionKey_SwitchWorkerType_NewKey`：切 wt → 新 key，旧 key 稳定
- [x] 双轨隔离：`grep WorkerPreference internal/config/` → 0 命中（结构性保证）
- [x] `make check` 通过（quality + build + test + docs + swagger）

## 测试权衡说明

gateway 测试二进制不 import 真实 worker 适配器，registry 只有 `testNoopType`（"noop_gateway_test"，`init()` 注册）。PATCH/CreateSession 测试用 `testNoopType` 代表「合法已注册类型」——4 个真实常量的合法性由 worker 包的 `TestValidateType`（用 `withRegistry` 注册 4 类）在边界覆盖，gateway 层只验证白名单接入逻辑。分层清晰，避免 blank import 重适配器的副作用。

## 关于 spec §10 TestDualTrackIsolation

spec §10 列出 `TestDualTrackIsolation`，实现采用 **grep 文档化 + design spec §6** 而非新测试代码：双轨隔离是结构性保证（config 包不 import session/workspace，`propagatePlatform` 输入输出完全不涉及 `WorkerPreference`），写「测不存在依赖」的测试价值低。`propagatePlatform` 的行为已由 `TestPropagateMessagingDefaults`（config_test.go:765）覆盖。