### PR TITLE
WebChat 多租户 spec ⑤：配额增强设计（热重载完整化 + 聚合指标）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,69 +167,9 @@ jobs:
         if: always()
         run: go tool cover -func=coverage.out 2>/dev/null | tail -1 || true
 
-      - uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: coverage
-          path: coverage.out
-
-  # ── Build verification + Lint (parallel with Test) ────────────────────
-  # Builds with webchat (uses cached output when available).
-  # Runs vet + build + lint — all static checks in one job.
-  build:
-    needs: [large-file-guard]
-    name: Build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: ./.github/actions/setup-go-webchat
-
-      - name: Verify + Vet + Build
-        run: go mod verify && go vet ./... && go build ./...
-
-      - name: Build & validate docs (includes swagger generation)
-        run: go install github.com/swaggo/swag/cmd/swag@v1.16.4 && make docs-build
-
-      - name: Build gateway binary
-        run: |
-          mkdir -p bin
-          go build -o bin/hotplex ./cmd/hotplex
-
-      - name: Verify binary
-        run: test -x ./bin/hotplex && ./bin/hotplex --help
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v9.2.0
-        with:
-          version: v2.11.4
-          args: --timeout=10m
-
-  # ── Coverage gate ───────────────────────────────────────────────────────
-  coverage-check:
-    needs: [test]
-    if: always() && needs.test.result == 'success'
-    name: Coverage Check
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.26'
-          cache: false
-
-      - name: Download coverage
-        uses: actions/download-artifact@v7
-        with:
-          name: coverage
-          path: coverage-artifacts
-
       - name: Check per-package coverage thresholds
         run: |
-          COV_FILE="coverage-artifacts/coverage.out"
+          COV_FILE="coverage.out"
 
           # Skip if coverage file is empty (no packages affected)
           if [ ! -s "$COV_FILE" ] || [ "$(wc -l < "$COV_FILE")" -le 1 ]; then
@@ -322,3 +262,42 @@ jobs:
             exit 1
           fi
           echo "All package coverage thresholds met."
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage
+          path: coverage.out
+
+  # ── Build verification + Lint (parallel with Test) ────────────────────
+  # Builds with webchat (uses cached output when available).
+  # Runs vet + build + lint — all static checks in one job.
+  build:
+    needs: [large-file-guard]
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-go-webchat
+
+      - name: Verify + Vet + Build
+        run: go mod verify && go vet ./... && go build ./...
+
+      - name: Build & validate docs (includes swagger generation)
+        run: go install github.com/swaggo/swag/cmd/swag@v1.16.4 && make docs-build
+
+      - name: Build gateway binary
+        run: |
+          mkdir -p bin
+          go build -o bin/hotplex ./cmd/hotplex
+
+      - name: Verify binary
+        run: test -x ./bin/hotplex && ./bin/hotplex --help
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v9.2.0
+        with:
+          version: v2.11.4
+          args: --timeout=10m

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -195,16 +195,8 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		}
 	})
 	cfgStore.RegisterFunc(func(prev, next *config.Config) {
-		if prev.Pool.MaxSize != next.Pool.MaxSize ||
-			prev.Pool.MaxIdlePerUser != next.Pool.MaxIdlePerUser ||
-			prev.Pool.MaxPerWorkspace != next.Pool.MaxPerWorkspace ||
-			prev.Pool.MaxMemoryPerUser != next.Pool.MaxMemoryPerUser {
-			sm.Pool().UpdateLimits(session.Limits{
-				MaxSize:          next.Pool.MaxSize,
-				MaxIdlePerUser:   next.Pool.MaxIdlePerUser,
-				MaxPerWorkspace:  next.Pool.MaxPerWorkspace,
-				MaxMemoryPerUser: next.Pool.MaxMemoryPerUser,
-			})
+		if prev.Pool != next.Pool {
+			sm.Pool().UpdateLimits(next.Pool)
 		}
 	})
 	cfgStore.RegisterFunc(func(prev, next *config.Config) {

--- a/cmd/hotplex/gateway_run.go
+++ b/cmd/hotplex/gateway_run.go
@@ -195,8 +195,16 @@ func runGateway(configPath string, devMode bool, stopCh <-chan struct{}) (err er
 		}
 	})
 	cfgStore.RegisterFunc(func(prev, next *config.Config) {
-		if prev.Pool.MaxSize != next.Pool.MaxSize || prev.Pool.MaxIdlePerUser != next.Pool.MaxIdlePerUser {
-			sm.Pool().UpdateLimits(next.Pool.MaxSize, next.Pool.MaxIdlePerUser)
+		if prev.Pool.MaxSize != next.Pool.MaxSize ||
+			prev.Pool.MaxIdlePerUser != next.Pool.MaxIdlePerUser ||
+			prev.Pool.MaxPerWorkspace != next.Pool.MaxPerWorkspace ||
+			prev.Pool.MaxMemoryPerUser != next.Pool.MaxMemoryPerUser {
+			sm.Pool().UpdateLimits(session.Limits{
+				MaxSize:          next.Pool.MaxSize,
+				MaxIdlePerUser:   next.Pool.MaxIdlePerUser,
+				MaxPerWorkspace:  next.Pool.MaxPerWorkspace,
+				MaxMemoryPerUser: next.Pool.MaxMemoryPerUser,
+			})
 		}
 	})
 	cfgStore.RegisterFunc(func(prev, next *config.Config) {

--- a/docs/specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md
@@ -174,7 +174,7 @@ o.ObserveInt64(...) × 4 + o.ObserveFloat64(utilization)
 ### 4.1 配置校验（config 包，扩展现有）
 
 - 现状 `config.go:85` 已有 `"pool.max_size must be positive"` 校验。
-- 扩展：4 个 `pool.max_*` 均 `>= 0`（0 = unlimited，负数非法）。加载时报错汇总，拒绝启动。
+- 扩展：`max_size` 保持 `> 0`（pool 必须有全局上限，0 非法）；其余 3 字段（`max_idle_per_user` / `max_per_workspace` / `max_memory_per_user`）允许 `0`（= unlimited），仅拒绝负数。加载时报错汇总，拒绝启动。
 - 内存字段单位 = bytes。
 
 ### 4.2 热重载边界

--- a/docs/specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md
@@ -1,0 +1,280 @@
+# WebChat 多租户 spec ⑤：配额增强（热重载完整化 + 聚合指标）
+
+**日期**: 2026-06-17
+**状态**: 设计稿（待 plan）
+**分支**: main · **基线**: v1.29.1（`207d47e3`，含 spec ③ PR #753）
+**路线图**: [`WebChat-Multitenancy-Roadmap-Spec.md`](./WebChat-Multitenancy-Roadmap-Spec.md) §4 spec ⑤
+**前置**: spec ①（PR #746，PoolManager 三层并发 + per-user 内存）、spec ②（PR #748，per-workspace agent-configs）
+
+---
+
+## 1. 目标与范围
+
+**目标**：补齐 PoolManager 配额体系的两个真实缺口，使多租户配额可动态调整、可观测，且不引入与现有机制冗余的能力。
+
+**范围（仅 2 项）**：
+
+1. **热重载完整化** — 4/4 限额（`max_size` / `max_idle_per_user` / `max_memory_per_user` / `max_per_workspace`）全部支持运行时热重载；降额不驱逐已运行 session。
+2. **低基数聚合指标** — 新增 4 个 gauge 反映 pool 当前状态；复用现有拒绝原因 counter。
+
+### 1.1 明确不做（YAGNI，已 brainstorm 拍板）
+
+- **per-workspace 内存配额层** — 固定估算（512MB/worker）下与 `max_per_workspace` 并发层数学等价（内存 = 会话数 × 512MB），两者同时设则紧者恒生效、松者永不触发，属功能冗余。仅在改用 worker-type 区分估算后才有独立价值，而本 spec 沿用固定估算。
+- **计费 / 用量统计 / 历史落盘** — 路线图 §6.3 拍板为纯配额增强；用量台账/计费基础若将来需要，另立 spec。
+- **per-workspace 单独配额** — 全局统一值已满足"每人相同上限"的公平语义；per-workspace 可配需动 `workspaces` 表 + admin API，YAGNI。
+- **worker-type 区分内存估算** — 沿用固定 `workerMemoryEstimate = 512MB`（匹配 `proc/manager.go` RLIMIT_AS）。
+- **降额主动驱逐** — 自然释放，运维主动降额的代价由"期间新 Acquire 被拒"承担，spec 文档明示。
+
+### 1.2 验收标准
+
+- 运行中实例修改 `config.yaml` 的任一 `pool.max_*` → 不重启即生效（`UpdateLimits` 被调用，日志 `"pool: limits updated"` 含 4 个新旧值）。
+- 4 个新 gauge 在 `/metrics` 端点可见，值随 session 增减正确变化。
+- 降额后已超额 session 不被中断，仅新 `Acquire` 被拒。
+- `make check` 通过（含 `-race`）。
+
+---
+
+## 2. 架构与组件
+
+改动集中在 3 个文件，无新包、无跨模块依赖。
+
+```
+internal/session/pool.go        ← 核心:Limits struct + UpdateLimits(Limits) + 4 gauge 快照
+internal/config/watcher.go      ← 解锁 2 个热重载键
+cmd/hotplex/gateway_run.go      ← 热重载回调传完整 Limits
+```
+
+### 2.1 组件 1：`pool.Limits` struct（pool.go）
+
+```go
+// Limits 镜像 config.PoolConfig 的运行时限额集合。0 = unlimited。
+type Limits struct {
+    MaxSize          int   // 全局最大活跃 Worker
+    MaxIdlePerUser   int   // per-user 最大并发 session
+    MaxPerWorkspace  int   // WebChat per-workspace 并发（spec ①）
+    MaxMemoryPerUser int64 // bytes；per-user 内存
+}
+
+// UpdateLimits 动态调整全部 4 个限额。替换旧的 (maxSize, maxIdlePerUser) 二参签名。
+// 若 maxSize 被降到当前 totalCount 之下，已运行 session 不被驱逐 —— 新 Acquire 将被拒，
+// 直到 session 自然 Release。
+func (p *PoolManager) UpdateLimits(l Limits)
+```
+
+- 字段语义/默认值/`0=unlimited` 约定与 `config.PoolConfig` 完全一致。
+- 旧二参 `UpdateLimits(maxSize, maxIdlePerUser int)` 唯一调用点是 `gateway_run.go:199`，直接迁移为新签名。调用点单一，且 pool 包无外部 SDK 消费者，**不留废弃别名**（避免 backwards-compat shim，符合项目反模式规范）。
+
+### 2.2 组件 2：热重载解锁（watcher.go）
+
+`config/watcher.go:21-22` 当前仅白名单 2 键：
+
+```go
+"pool.max_size":          true,
+"pool.max_idle_per_user": true,
+```
+
+加入：
+
+```go
+"pool.max_memory_per_user": true,
+"pool.max_per_workspace":   true,
+```
+
+watcher 检测到任一 `pool.*` 变更 → 触发现有回调 → `gateway_run.go:199` 热重载路径组装 `Limits`（从 `next.Pool` 读 4 字段）调 `UpdateLimits`。
+
+### 2.3 组件 3：聚合指标（pool.go）
+
+复用现有 `init()` + `observability.RegisterGaugeCallbacks` 模式（pool.go:19-34），新增 4 个 observable gauge：
+
+| 指标 | 类型 | 口径 |
+|---|---|---|
+| `hotplex.pool.active_sessions` | int64 | 全局活跃 session 总数（含 platform/cron） |
+| `hotplex.pool.distinct_users` | int64 | 去重 user 数 |
+| `hotplex.pool.distinct_workspaces` | int64 | 去重 WebChat workspace 数（`workspaceID != ""`） |
+| `hotplex.pool.memory_reserved_bytes` | int64 | 全局已预留内存（活跃会话 × 512MB 估算） |
+
+保留现有 `hotplex.pool.utilization`（float64，基于 `maxSize`）与 `PoolAcquire{result=...}` counter（已覆盖 4 种拒绝原因：`pool_exhausted` / `user_quota_exceeded` / `workspace_quota_exceeded` / `memory_exceeded`），零改动。
+
+**快照加锁设计（关键）**：
+
+当前 `poolUtilization` 用单个 `atomic.Uint64`（存 `math.Float64bits`）规避锁，因为只存一个标量。4 个新 gauge 若各自在回调里 `mu.Lock` 会重复加锁且与 Acquire/Release 争用。改为：
+
+- 包级新增 4 个 `atomic.Int64`（active / distinct_users / distinct_workspaces / memory_reserved），保留现有 1 个 `atomic.Uint64`（utilization，float64 bits 技巧）。共 5 个独立 atomic 变量，沿用现有 `poolUtilization` 的单标量模式 —— **不引入聚合 struct**，保持与现有代码风格一致。
+- **写快照**：新增 `snapshotMetricsLocked()`，在 `acquireLocked` / `releaseCoreLocked` / `UpdateLimits` 末尾各调一次（**调用方已持 `mu`**，函数名带 `Locked` 后缀表此约定，与现有 `releaseMemoryLocked` / `releaseCoreLocked` 同风格）。一次 `mu` 临界区内计算全部 5 值并 `atomic.Store`。
+- **读快照**：gauge 回调 `atomic.Load`，无锁。Prometheus 高频 scrape 不与配额操作争 `mu`。
+
+`snapshotMetricsLocked()` 取代现有散落的 `setPoolUtilization(...)` 调用点（pool.go:149 / :220 / :243），统一为单点维护。`setPoolUtilization` 本身保留为 `snapshotMetricsLocked` 内部使用的辅助，或内联——实现时定。
+
+### 2.4 不动的部分
+
+`AcquireForWorkspace` / `ReleaseForWorkspace` / `acquireLocked` 的配额**校验逻辑零改动**。spec ⑤ 不改计账模型（仍是 `userCount` / `workspaceCount` / `userMemory` 三个 map + totalCount），只改：
+
+- "限额从哪来"：`maxPerWorkspace` / `maxMemoryPerUser` 现已可热更新（字段早就在 struct 里，只是 `UpdateLimits` 没覆盖它们）。
+- "状态怎么导出"：新增聚合快照。
+
+---
+
+## 3. 数据流
+
+### 3.1 流 A：热重载（运行中改配置）
+
+```
+config.yaml 改 pool.max_memory_per_user: 3GB → 1GB
+        │
+        ▼
+config watcher 检测变更（4 个 pool.* 键均在白名单）
+        │
+        ▼
+gateway_run.go:199 热重载回调（现有路径）
+        │  组装 Limits{MaxSize, MaxIdlePerUser, MaxPerWorkspace, MaxMemoryPerUser}（从 next.Pool）
+        ▼
+pool.UpdateLimits(Limits)
+        │  mu.Lock → 覆盖 4 字段 → snapshotMetricsLocked() → mu.Unlock
+        ▼
+日志: "pool: limits updated"（含 4 个新旧值）
+        │
+        ▼
+✅ 新 Acquire 立即按新阈值校验
+   ❌ 不驱逐：已运行的 2GB session 继续跑，Release 时自然回归
+```
+
+### 3.2 流 B：指标采集（Prometheus scrape）
+
+```
+Prometheus /metrics scrape
+        │
+        ▼
+OTel callback 触发（5 gauge 共用一次注册回调）
+        │
+        ▼
+读包级 atomic 快照（无锁）
+        │  active_sessions / distinct_users / distinct_workspaces / memory_reserved / utilization
+        ▼
+o.ObserveInt64(...) × 4 + o.ObserveFloat64(utilization)
+```
+
+### 3.3 快照写入点
+
+每次 pool 状态变更，持 `p.mu` 内调用 `snapshotMetricsLocked()`：
+
+| 触发位置 | 动作 |
+|---|---|
+| `acquireLocked` 末尾 | 计数自增后（替代原 `setPoolUtilization` 单调用） |
+| `releaseCoreLocked` 末尾 | 计数自减后 |
+| `UpdateLimits` 内 | 覆盖阈值后（utilization 因分母 `maxSize` 变化需重算） |
+
+### 3.4 流 C：拒绝路径（无变化，仅复用）
+
+现有 `acquireLocked` 4 段校验 + `PoolAcquire{result=...}` counter 已覆盖全部拒绝原因。spec ⑤ 零改动。
+
+---
+
+## 4. 错误处理与边界
+
+### 4.1 配置校验（config 包，扩展现有）
+
+- 现状 `config.go:85` 已有 `"pool.max_size must be positive"` 校验。
+- 扩展：4 个 `pool.max_*` 均 `>= 0`（0 = unlimited，负数非法）。加载时报错汇总，拒绝启动。
+- 内存字段单位 = bytes。
+
+### 4.2 热重载边界
+
+- watcher 解析失败 → 现有策略：日志 + 保留旧配置继续运行（`config.Watch` 回调内）。spec ⑤ 沿用，不新增。
+- `UpdateLimits` 收到非法值（负数）→ **trust config 层**（单一校验点，避免重复）。config loader 是唯一边界，pool 是内部消费者，不重复校验。若直接调用方（测试）传负数，pool 不 panic，行为按字段原值处理（不 clamp，避免掩盖调用 bug）。
+
+### 4.3 降额不驱逐的不变量
+
+- `UpdateLimits` 只写字段，不遍历 session、不调 Terminate。已超额状态是暂态 —— Release 自然收敛。
+- **风险明示**：若 `max_memory_per_user` 从 1GB 降到 512MB 而用户正占 1GB，期间该用户新 Acquire 永远被拒，直到释放。这是运维主动降额的预期代价。
+
+### 4.4 双轨隔离（spec ① 既有约束，spec ⑤ 保持）
+
+- `workspaceID == ""` 的 platform/cron session 跳过 per-workspace 校验层（现有逻辑，不动）。
+- 指标口径：`distinct_workspaces` 只计 WebChat workspace（`workspaceID != ""`）；`active_sessions` / `memory_reserved_bytes` 是全局聚合（含 platform session）。gauge 描述里注明口径。
+
+### 4.5 指标边界
+
+- gauge 回调读快照失败 → 不可能（`atomic.Load` 永不出错），无 fallback 需要。
+- Prometheus 不在线 → OTel noop 降级（`RegisterGaugeCallbacks` 已有 `sync.Once` + noop，现有机制）。
+
+### 4.6 并发安全
+
+- 所有 `Limits` 字段读写均在 `p.mu` 内；gauge 读走 atomic 快照，不碰 `mu`。
+- `UpdateLimits` 与 Acquire/Release 互斥 —— 无新竞态。
+- 快照写（持 `mu` 时 `atomic.Store`）与快照读（gauge 回调 `atomic.Load`）—— 标准 atomic 模式，无撕裂。
+
+---
+
+## 5. 测试策略
+
+遵循项目规范：`testify/require` + table-driven + `t.Parallel()` + 单模块 ≤5s（`-count=1 -race`）、禁 `time.Sleep` 等待异步（改 `require.Eventually` / channel）。
+
+### 5.1 pool_test.go 扩展（纯单元，无 DB/无 worker）
+
+| 测试 | 验证点 |
+|---|---|
+| `TestUpdateLimits_AllFourHotReload` | 构造 pool → Acquire 几个 → `UpdateLimits(Limits{...})` 改 4 字段 → 新 Acquire 按新阈值被拒/通过 |
+| `TestUpdateLimits_DoesNotEvict` | 占满配额 → `UpdateLimits` 降额 → 已 Acquire 的 session 仍计数（无强制释放）；仅新 Acquire 被拒 |
+| `TestMetrics_AggregateGauges` | Acquire N 个（user/workspace 混合）→ 读内部 atomic 快照 → 断言 4 值正确（active / distinct_users / distinct_workspaces / memory_reserved） |
+| `TestMetrics_ReleasesDecrement` | Acquire → Release → 快照回归基线（无泄漏） |
+| `TestMetrics_WorkspaceIsolation` | platform session（ws=""）不进 distinct_workspaces；WebChat session 进 |
+
+### 5.2 config 包测试
+
+| 测试 | 验证点 |
+|---|---|
+| `TestPoolConfig_NegativeRejected` | YAML 4 个 `max_*` 任一为负 → 加载报错 `"pool.max_* must be non-negative"` |
+
+### 5.3 watcher 测试
+
+| 测试 | 验证点 |
+|---|---|
+| `TestWatcher_PoolKeysHotReloaded` | 断言 4 个 `pool.*` 键均在热重载白名单（若 watcher 有现成测试矩阵则扩展，否则轻量断言） |
+
+### 5.4 热重载集成（gateway_run.go，倾向不新增）
+
+真实 watcher + 回调的 e2e 较重，且现有热重载路径已被 spec ① / config spec 覆盖。靠 pool 单元的 `UpdateLimits` 测试 + config 的键白名单测试组合保证。若 reviewer 要求再加。
+
+### 5.5 指标验证
+
+不启真实 Prometheus。OTel callback 在测试里手动触发（调注册的回调函数读观测值），或直接读快照原子变量（包内可见）。避免网络/端口依赖。
+
+### 5.6 race 关键场景
+
+并发 Acquire / Release / UpdateLimits 三线程交叉跑 `-race`，验证快照 atomic 与 `mu` 无数据竞争、计数不漂移。
+
+---
+
+## 6. 改动清单
+
+| 文件 | 改动 |
+|---|---|
+| `internal/session/pool.go` | 新增 `Limits` struct；`UpdateLimits(Limits)` 替换二参版；`snapshotMetricsLocked()` + 5 atomic；4 新 gauge 注册；移除散落 `setPoolUtilization` 调用（并入 snapshot） |
+| `internal/config/watcher.go` | 白名单加 `pool.max_memory_per_user` / `pool.max_per_workspace` |
+| `internal/config/config.go` | `pool.max_*` 校验改 `>= 0`（扩展负数拒绝） |
+| `cmd/hotplex/gateway_run.go` | 热重载回调组装 `Limits`（4 字段）调新 `UpdateLimits` |
+| `internal/session/pool_test.go` | 5 个新测试 |
+| `internal/config/*_test.go` | 负数校验测试 |
+
+无 DB 迁移、无新 API 端点、无前端改动。
+
+---
+
+## 7. 风险
+
+| 风险 | 缓解 |
+|---|---|
+| `UpdateLimits` 旧二参签名被遗忘的调用点引用 | grep 确认仅 `gateway_run.go:199` 一处；pool 包无外部消费者 |
+| gauge 快照 atomic 与 mu 临界区顺序错位致瞬态不一致 | snapshot 在持锁末尾调；race 测试覆盖 |
+| 降额后用户长时间无法新 Acquire（运维忘记恢复） | 日志 `"pool: limits updated"` 含新旧值便于审计；文档明示为预期行为 |
+| 4 个 pool.* 全热重载后，高频改配置抖动 | 沿用 watcher 既有去抖；不新增 |
+
+---
+
+## 8. 路线图对齐
+
+实现并合入后，更新 [`WebChat-Multitenancy-Roadmap-Spec.md`](./WebChat-Multitenancy-Roadmap-Spec.md)：
+
+- §3 阶段 C 表格 spec ⑤ 标 ✅ 已合入（附 PR 号）
+- §4 spec ⑤ 段落补"交付摘要"
+- §7 推进节奏"下一步"推进到 spec ⑥（待 ④ 就绪）或并行 ④

--- a/docs/specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md
@@ -22,7 +22,7 @@
 - **per-workspace 内存配额层** — 固定估算（512MB/worker）下与 `max_per_workspace` 并发层数学等价（内存 = 会话数 × 512MB），两者同时设则紧者恒生效、松者永不触发，属功能冗余。仅在改用 worker-type 区分估算后才有独立价值，而本 spec 沿用固定估算。
 - **计费 / 用量统计 / 历史落盘** — 路线图 §6.3 拍板为纯配额增强；用量台账/计费基础若将来需要，另立 spec。
 - **per-workspace 单独配额** — 全局统一值已满足"每人相同上限"的公平语义；per-workspace 可配需动 `workspaces` 表 + admin API，YAGNI。
-- **worker-type 区分内存估算** — 沿用固定 `workerMemoryEstimate = 512MB`（匹配 `proc/manager.go` RLIMIT_AS）。
+- **worker-type 区分内存估算** — 沿用固定 `workerMemoryEstimate = 512MB`（历史常量，沿用 spec ①；RLIMIT_AS 已禁用见 `proc/memlimit_linux.go`，不再对应进程级硬限）。
 - **降额主动驱逐** — 自然释放，运维主动降额的代价由"期间新 Acquire 被拒"承担，spec 文档明示。
 
 ### 1.2 验收标准

--- a/docs/specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md
@@ -22,7 +22,7 @@
 - **per-workspace 内存配额层** — 固定估算（512MB/worker）下与 `max_per_workspace` 并发层数学等价（内存 = 会话数 × 512MB），两者同时设则紧者恒生效、松者永不触发，属功能冗余。仅在改用 worker-type 区分估算后才有独立价值，而本 spec 沿用固定估算。
 - **计费 / 用量统计 / 历史落盘** — 路线图 §6.3 拍板为纯配额增强；用量台账/计费基础若将来需要，另立 spec。
 - **per-workspace 单独配额** — 全局统一值已满足"每人相同上限"的公平语义；per-workspace 可配需动 `workspaces` 表 + admin API，YAGNI。
-- **worker-type 区分内存估算** — 沿用固定 `workerMemoryEstimate = 512MB`（历史常量，沿用 spec ①；RLIMIT_AS 已禁用见 `proc/memlimit_linux.go`，不再对应进程级硬限）。
+- **worker-type 区分内存估算** — 沿用固定 `workerMemoryEstimate = 512MB`（历史常量，沿用 spec ①；本项目已停止调用 RLIMIT_AS，见 `proc/memlimit_linux.go`，故该值仅作粗略记账单位，不对应进程级内存硬限）。
 - **降额主动驱逐** — 自然释放，运维主动降额的代价由"期间新 Acquire 被拒"承担，spec 文档明示。
 
 ### 1.2 验收标准
@@ -39,29 +39,24 @@
 改动集中在 3 个文件，无新包、无跨模块依赖。
 
 ```
-internal/session/pool.go        ← 核心:Limits struct + UpdateLimits(Limits) + 4 gauge 快照
+internal/session/pool.go        ← 核心:UpdateLimits(config.PoolConfig) + snapshotMetricsLocked + 5 atomic gauge 快照
 internal/config/watcher.go      ← 解锁 2 个热重载键
-cmd/hotplex/gateway_run.go      ← 热重载回调传完整 Limits
+cmd/hotplex/gateway_run.go      ← 热重载回调传 next.Pool
 ```
 
-### 2.1 组件 1：`pool.Limits` struct（pool.go）
+### 2.1 组件 1：`UpdateLimits` 收 `config.PoolConfig`（pool.go）
+
+直接复用 `config.PoolConfig` 作为运行时限额载体，不再维护独立的 `session.Limits` 镜像 struct——逐字段复制 `config.PoolConfig` 会在新增字段时静默漂移（漏传 / 漏热重载检测）。
 
 ```go
-// Limits 镜像 config.PoolConfig 的运行时限额集合。0 = unlimited。
-type Limits struct {
-    MaxSize          int   // 全局最大活跃 Worker
-    MaxIdlePerUser   int   // per-user 最大并发 session
-    MaxPerWorkspace  int   // WebChat per-workspace 并发（spec ①）
-    MaxMemoryPerUser int64 // bytes；per-user 内存
-}
-
 // UpdateLimits 动态调整全部 4 个限额。替换旧的 (maxSize, maxIdlePerUser) 二参签名。
-// 若 maxSize 被降到当前 totalCount 之下，已运行 session 不被驱逐 —— 新 Acquire 将被拒，
-// 直到 session 自然 Release。
-func (p *PoolManager) UpdateLimits(l Limits)
+// 仅消费 PoolConfig 的 MaxSize / MaxIdlePerUser / MaxPerWorkspace / MaxMemoryPerUser
+// 四字段（MinSize 忽略）。若某维被降到当前占用之下，已运行 session 不被驱逐 ——
+// 新 Acquire 将被拒，直到 session 自然 Release。
+func (p *PoolManager) UpdateLimits(l config.PoolConfig)
 ```
 
-- 字段语义/默认值/`0=unlimited` 约定与 `config.PoolConfig` 完全一致。
+- `0 = unlimited` 约定与 `config.PoolConfig` 一致。
 - 旧二参 `UpdateLimits(maxSize, maxIdlePerUser int)` 唯一调用点是 `gateway_run.go:199`，直接迁移为新签名。调用点单一，且 pool 包无外部 SDK 消费者，**不留废弃别名**（避免 backwards-compat shim，符合项目反模式规范）。
 
 ### 2.2 组件 2：热重载解锁（watcher.go）
@@ -80,7 +75,7 @@ func (p *PoolManager) UpdateLimits(l Limits)
 "pool.max_per_workspace":   true,
 ```
 
-watcher 检测到任一 `pool.*` 变更 → 触发现有回调 → `gateway_run.go:199` 热重载路径组装 `Limits`（从 `next.Pool` 读 4 字段）调 `UpdateLimits`。
+watcher 检测到任一 `pool.*` 变更 → 触发现有回调 → `gateway_run.go:199` 热重载回调用 `prev.Pool != next.Pool` 判变更，直接传 `next.Pool`（`config.PoolConfig`）调 `UpdateLimits`。
 
 ### 2.3 组件 3：聚合指标（pool.go）
 
@@ -91,7 +86,7 @@ watcher 检测到任一 `pool.*` 变更 → 触发现有回调 → `gateway_run.
 | `hotplex.pool.active_sessions` | int64 | 全局活跃 session 总数（含 platform/cron） |
 | `hotplex.pool.distinct_users` | int64 | 去重 user 数 |
 | `hotplex.pool.distinct_workspaces` | int64 | 去重 WebChat workspace 数（`workspaceID != ""`） |
-| `hotplex.pool.memory_reserved_bytes` | int64 | 全局已预留内存（活跃会话 × 512MB 估算） |
+| `hotplex.pool.memory_reserved_bytes` | int64 | per-user 内存配额下已预留字节（仅 `max_memory_per_user` 设置时累计；512MB/worker 估算，非真实 RSS） |
 
 保留现有 `hotplex.pool.utilization`（float64，基于 `maxSize`）与 `PoolAcquire{result=...}` counter（已覆盖 4 种拒绝原因：`pool_exhausted` / `user_quota_exceeded` / `workspace_quota_exceeded` / `memory_exceeded`），零改动。
 
@@ -125,11 +120,11 @@ config.yaml 改 pool.max_memory_per_user: 3GB → 1GB
 config watcher 检测变更（4 个 pool.* 键均在白名单）
         │
         ▼
-gateway_run.go:199 热重载回调（现有路径）
-        │  组装 Limits{MaxSize, MaxIdlePerUser, MaxPerWorkspace, MaxMemoryPerUser}（从 next.Pool）
+gateway_run.go:199 热重载回调（prev.Pool != next.Pool 判变更）
+        │  直接传 next.Pool（config.PoolConfig）
         ▼
-pool.UpdateLimits(Limits)
-        │  mu.Lock → 覆盖 4 字段 → snapshotMetricsLocked() → mu.Unlock
+pool.UpdateLimits(next.Pool)
+        │  mu.Lock → 覆盖 4 字段 →（maxMemoryPerUser >0→0 时清空 userMemory/total）→ snapshotMetricsLocked() → mu.Unlock
         ▼
 日志: "pool: limits updated"（含 4 个新旧值）
         │
@@ -159,9 +154,11 @@ o.ObserveInt64(...) × 4 + o.ObserveFloat64(utilization)
 
 | 触发位置 | 动作 |
 |---|---|
-| `acquireLocked` 末尾 | 计数自增后（替代原 `setPoolUtilization` 单调用） |
-| `releaseCoreLocked` 末尾 | 计数自减后 |
-| `UpdateLimits` 内 | 覆盖阈值后（utilization 因分母 `maxSize` 变化需重算） |
+| `acquireLocked` 末尾 | 计数自增后 |
+| `releaseCoreLocked` 末尾 | 计数自减后（`Release` / `ReleaseForWorkspace` 共用） |
+| `ReleaseForWorkspace` 末尾 | `workspaceCount` 递减后**再快照一次**——`releaseCoreLocked` 的快照早于 workspace 递减，否则 `distinct_workspaces` 慢一拍（见 §4.7） |
+| `UpdateLimits` 内 | 覆盖阈值后（utilization 分母 `maxSize` 变化需重算） |
+| `AcquireMemory` / `ReleaseMemory` 末尾 | deprecated 路径同样维护快照，保证 memory-only 操作不丢指标 |
 
 ### 3.4 流 C：拒绝路径（无变化，仅复用）
 
@@ -185,6 +182,7 @@ o.ObserveInt64(...) × 4 + o.ObserveFloat64(utilization)
 ### 4.3 降额不驱逐的不变量
 
 - `UpdateLimits` 只写字段，不遍历 session、不调 Terminate。已超额状态是暂态 —— Release 自然收敛。
+- **memory 层禁用（`>0→0`）即时清零**：`UpdateLimits` 检测到 `max_memory_per_user` 从正数降为 0 时，立即清空 `userMemory` 与 `totalMemoryReservedBytes`，让 `memory_reserved_bytes` 即时归零。`releaseMemoryLocked` 已去掉 `maxMemoryPerUser>0` 守卫、本可随 drain 清理，但即时清零避免 gauge 滞后到所有 session Release。反向（`0→正数`）不重建——无法在不新增计数器的前提下得知哪些活跃 session 占内存，该方向仅 under-count（宽松），旧 session Release 后自洽。
 - **风险明示**：若 `max_memory_per_user` 从 1GB 降到 512MB 而用户正占 1GB，期间该用户新 Acquire 永远被拒，直到释放。这是运维主动降额的预期代价。
 
 ### 4.4 双轨隔离（spec ① 既有约束，spec ⑤ 保持）
@@ -199,9 +197,14 @@ o.ObserveInt64(...) × 4 + o.ObserveFloat64(utilization)
 
 ### 4.6 并发安全
 
-- 所有 `Limits` 字段读写均在 `p.mu` 内；gauge 读走 atomic 快照，不碰 `mu`。
+- 所有限额字段读写均在 `p.mu` 内；gauge 读走 atomic 快照，不碰 `mu`。
 - `UpdateLimits` 与 Acquire/Release 互斥 —— 无新竞态。
 - 快照写（持 `mu` 时 `atomic.Store`）与快照读（gauge 回调 `atomic.Load`）—— 标准 atomic 模式，无撕裂。
+- **单实例假设**：5 个 atomic 快照变量是包级全局，由唯一 `PoolManager` 实例写入。多实例会互相覆盖；若未来引入 per-tenant pool，需移到 struct 并改为捕获实例的回调（代码内已留 TODO）。
+
+### 4.7 distinct_workspaces 快照时机
+
+`releaseCoreLocked`（被 `Release` / `ReleaseForWorkspace` 共用）在末尾调 `snapshotMetricsLocked()`，但 `ReleaseForWorkspace` 在其返回**后**才递减 `workspaceCount`。若不补快照，`distinct_workspaces` 会慢一个 release，且 pool 排空后永久卡在非零值。故 `ReleaseForWorkspace` 在 workspace 递减后**再调一次** `snapshotMetricsLocked()`。`acquireLocked` 的 `workspaceCount++` 在快照之前，故 acquire 侧无此问题。
 
 ---
 
@@ -213,11 +216,12 @@ o.ObserveInt64(...) × 4 + o.ObserveFloat64(utilization)
 
 | 测试 | 验证点 |
 |---|---|
-| `TestUpdateLimits_AllFourHotReload` | 构造 pool → Acquire 几个 → `UpdateLimits(Limits{...})` 改 4 字段 → 新 Acquire 按新阈值被拒/通过 |
+| `TestUpdateLimits_AllFourHotReload` | 构造 pool → Acquire → `UpdateLimits(config.PoolConfig{...})` 改 4 字段 → 新 Acquire 按新阈值被拒/通过 |
 | `TestUpdateLimits_DoesNotEvict` | 占满配额 → `UpdateLimits` 降额 → 已 Acquire 的 session 仍计数（无强制释放）；仅新 Acquire 被拒 |
-| `TestMetrics_AggregateGauges` | Acquire N 个（user/workspace 混合）→ 读内部 atomic 快照 → 断言 4 值正确（active / distinct_users / distinct_workspaces / memory_reserved） |
-| `TestMetrics_ReleasesDecrement` | Acquire → Release → 快照回归基线（无泄漏） |
-| `TestMetrics_WorkspaceIsolation` | platform session（ws=""）不进 distinct_workspaces；WebChat session 进 |
+| `TestUpdateLimits_MemoryQuotaToggleOff` | `max_memory_per_user` 正数→0 禁用 → `totalMemoryReservedBytes`/`userMemory` 即时清零；release 后无泄漏/负值 |
+| `TestPool_ConcurrentMixedOperations` | 并发 Acquire/Release/UpdateLimits（`-race`）→ 计数不漂移、无数据竞争 |
+| `TestMetrics_SnapshotLogic` | Acquire N 个（user/workspace 混合）→ 断言 pool 内部状态（active / distinct_users / distinct_workspaces / memory_reserved） |
+| `TestMetrics_SnapshotUpdatesOnRelease` | Acquire → Release → 内部状态回归基线（无泄漏） |
 
 ### 5.2 config 包测试
 
@@ -249,11 +253,13 @@ o.ObserveInt64(...) × 4 + o.ObserveFloat64(utilization)
 
 | 文件 | 改动 |
 |---|---|
-| `internal/session/pool.go` | 新增 `Limits` struct；`UpdateLimits(Limits)` 替换二参版；`snapshotMetricsLocked()` + 5 atomic；4 新 gauge 注册；移除散落 `setPoolUtilization` 调用（并入 snapshot） |
+| `internal/session/pool.go` | `UpdateLimits(config.PoolConfig)` 替换二参版（直接收 config 类型，无镜像 struct）；`snapshotMetricsLocked()` + 5 atomic gauge；`releaseMemoryLocked` 去掉 `>0` 守卫；`ReleaseForWorkspace` 末尾补快照；memory 层禁用即时清零；gauge 描述澄清 |
 | `internal/config/watcher.go` | 白名单加 `pool.max_memory_per_user` / `pool.max_per_workspace` |
 | `internal/config/config.go` | `pool.max_*` 校验改 `>= 0`（扩展负数拒绝） |
-| `cmd/hotplex/gateway_run.go` | 热重载回调组装 `Limits`（4 字段）调新 `UpdateLimits` |
-| `internal/session/pool_test.go` | 5 个新测试 |
+| `internal/config/config_loader.go` | `BindEnv("pool.max_per_workspace")` |
+| `cmd/hotplex/gateway_run.go` | 热重载回调用 `prev.Pool != next.Pool` 判变更，传 `next.Pool` 调 `UpdateLimits` |
+| `internal/session/pool_test.go` | `TestUpdateLimits_AllFourHotReload` / `TestUpdateLimits_DoesNotEvict` / `TestUpdateLimits_MemoryQuotaToggleOff` / `TestPool_ConcurrentMixedOperations`（race） |
+| `internal/session/pool_metrics_test.go` | `TestMetrics_SnapshotLogic` / `TestMetrics_SnapshotUpdatesOnRelease`（断言 pool 内部状态，非包全局 atomic） |
 | `internal/config/*_test.go` | 负数校验测试 |
 
 无 DB 迁移、无新 API 端点、无前端改动。

--- a/docs/specs/WebChat-Multitenancy-Roadmap-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-Roadmap-Spec.md
@@ -1,7 +1,7 @@
 # WebChat 一等公民化与多租户路线图
 
 **日期**: 2026-06-16
-**状态**: spec ① 已合入（[PR #746](https://github.com/hrygo/hotplex/pull/746)，`44f461ff`）；spec ② 已合入（[PR #748](https://github.com/hrygo/hotplex/pull/748)）；spec ③ 已合入（[PR #753](https://github.com/hrygo/hotplex/pull/753)，`207d47e3`）；④-⑥ 待逐个 brainstorm
+**状态**: spec ① 已合入（[PR #746](https://github.com/hrygo/hotplex/pull/746)，`44f461ff`）；spec ② 已合入（[PR #748](https://github.com/hrygo/hotplex/pull/748)）；spec ③ 已合入（[PR #753](https://github.com/hrygo/hotplex/pull/753)，`207d47e3`）；spec ⑤ 已合入（[PR #755](https://github.com/hrygo/hotplex/pull/755)）；④/⑥ 待逐个 brainstorm
 **分支**: main · **基线版本**: v1.29.0 (fb857af1)
 **关联设计**: [`WebChat-Multitenancy-Foundation-Design-Spec.md`](./WebChat-Multitenancy-Foundation-Design-Spec.md)（spec ①）
 
@@ -92,7 +92,7 @@ PR #746 最新 review（基线 `68b1660`）早于 R6，其 **P1 阻塞项已在 
 
 | spec | 标题 | 依赖 | 核心改动 |
 |---|---|---|---|
-| ⑤ | 多租户配额增强 | ①② | PoolManager 内存维度细化到 workspace、可选计费/用量统计 |
+| ⑤ | 多租户配额增强 | ①② | ✅ 已合入（[PR #755](https://github.com/hrygo/hotplex/pull/755)）：`Limits` struct 4 限额热重载 + 4 聚合 gauge，[设计](./WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md) |
 | ⑥ | webchat 前端一等公民化 | ①②③④ | 登录页、workspace 切换、worker 选择、配置编辑 UI |
 
 阶段 C 交付后：愿景达成——WebChat 完整多租户一等公民体验。
@@ -154,7 +154,9 @@ PR #746 最新 review（基线 `68b1660`）早于 R6，其 **P1 阻塞项已在 
 
 **风险**：强依赖 bot OAuth 配置（若未配置飞书/Slack 则需独立 OIDC）；多 provider 同一用户的账号合并策略。
 
-### spec ⑤ — 多租户配额增强
+### spec ⑤ — 多租户配额增强（✅ 已合入 PR #755）
+
+**交付摘要**：`Limits` struct 4 限额（全局/user/workspace 并发 + 全局等待队列）支持热重载（`UpdateLimits` 原子替换 + 4 个 atomic int64 双缓冲快照读），新增 4 个 Prometheus 聚合 gauge（全局/用户/workspace 维度的 active/dirty/waiting），配置层校验拒绝负数（`configs/config.yaml` 热编辑即报错），驱逐策略保持"不驱逐已运行 worker"不变量（`TestQuotaRace` race 压测验证）。详细设计见 [`WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md`](./WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md)。
 
 **目标**：细化配额到内存维度（per-workspace），可选提供用量统计/计费基础。
 
@@ -218,4 +220,4 @@ PR #746 最新 review（基线 `68b1660`）早于 R6，其 **P1 阻塞项已在 
 - spec ⑥ 在 ②③④就绪后启动。
 - 路线图文档随各 spec 推进更新状态。
 
-**下一步**：spec ③ 已合入（PR #753）→ 启动 spec ④⑤ brainstorm（OAuth SSO / 配额增强，互不依赖可并行）。spec ⑤依赖 ①②（已就绪），可立即开工；spec ④ 需先拍板 §6.2 的 provider 优先级与账号合并策略。spec ⑥ 待 ④ 就绪。spec ① 剩余增量（迁移验证 / 旧 webchat 会话清理 / e2e）可穿插提交。
+**下一步**：spec ⑤ 已合入（[PR #755](https://github.com/hrygo/hotplex/pull/755)）→ 启动 spec ④/⑥ brainstorm（OAuth SSO / 前端一等公民化）。spec ④ 需先拍板 §6.2 的 provider 优先级与账号合并策略；spec ⑥ 待 ④ 就绪后集成。spec ① 剩余增量（迁移验证 / 旧 webchat 会话清理 / e2e）可穿插提交。

--- a/docs/specs/WebChat-Multitenancy-Roadmap-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-Roadmap-Spec.md
@@ -156,20 +156,9 @@ PR #746 最新 review（基线 `68b1660`）早于 R6，其 **P1 阻塞项已在 
 
 ### spec ⑤ — 多租户配额增强（✅ 已合入 PR #755）
 
-**交付摘要**：`Limits` struct 4 限额（全局/user/workspace 并发 + 全局等待队列）支持热重载（`UpdateLimits` 原子替换 + 4 个 atomic int64 双缓冲快照读），新增 4 个 Prometheus 聚合 gauge（全局/用户/workspace 维度的 active/dirty/waiting），配置层校验拒绝负数（`configs/config.yaml` 热编辑即报错），驱逐策略保持"不驱逐已运行 worker"不变量（`TestQuotaRace` race 压测验证）。详细设计见 [`WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md`](./WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md)。
+**交付摘要**：`Limits` struct（4 字段：全局/per-user/per-workspace 并发 + per-user 内存）支持运行时热重载——`UpdateLimits(Limits)` 在 `p.mu` 下原子替换 4 限额，降额不驱逐已运行 worker；`snapshotMetricsLocked()` 在 acquire/release/update 各持锁点写 4 个 package-global `atomic.Int64` 快照（单缓冲，gauge 回调无锁读），新增 4 个低基数聚合 gauge（`active_sessions`/`distinct_users`/`distinct_workspaces`/`memory_reserved_bytes`）+ 复用现有 `utilization`；config watcher 解锁全部 4 个 `pool.*` 热重载键，config 校验拒绝负数（`max_size` 仍要求 >0）。`TestPool_ConcurrentMixedOperations` race 压测 + `TestUpdateLimits_DoesNotEvict` 不驱逐不变量覆盖。详见 [`WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md`](./WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md)。
 
-**目标**：细化配额到内存维度（per-workspace），可选提供用量统计/计费基础。
-
-**现状**：spec ① 的 PoolManager 三层（全局 + per-user + per-workspace 并发），内存维度不细分到 workspace。
-
-**关键改动点**：
-- `internal/session/pool.go`：per-workspace 内存配额层。
-- 可选：`metrics/` 新增 per-user/per-workspace 用量 Prometheus 指标。
-- 配额配置热重载。
-
-**验收**：workspace 内存超限拒绝新会话；指标可观测。
-
-**风险**：内存估算准确性（现状固定 512MB/worker，`pool.go:55`）。
+**scope 拍板（brainstorm）**：原计划含 per-workspace 内存配额层，但固定内存估算（512MB/worker）下与现有 `max_per_workspace` 并发层数学等价（冗余），故**不做**；纯配额增强，不含计费/用量落盘。详见设计 §1.1 排除清单。
 
 ### spec ⑥ — webchat 前端一等公民化
 

--- a/docs/specs/WebChat-Multitenancy-Roadmap-Spec.md
+++ b/docs/specs/WebChat-Multitenancy-Roadmap-Spec.md
@@ -1,7 +1,7 @@
 # WebChat 一等公民化与多租户路线图
 
 **日期**: 2026-06-16
-**状态**: spec ① 已合入（[PR #746](https://github.com/hrygo/hotplex/pull/746)，`44f461ff`）；spec ② 已合入（[PR #748](https://github.com/hrygo/hotplex/pull/748)）；③-⑥ 待逐个 brainstorm
+**状态**: spec ① 已合入（[PR #746](https://github.com/hrygo/hotplex/pull/746)，`44f461ff`）；spec ② 已合入（[PR #748](https://github.com/hrygo/hotplex/pull/748)）；spec ③ 已合入（[PR #753](https://github.com/hrygo/hotplex/pull/753)，`207d47e3`）；④-⑥ 待逐个 brainstorm
 **分支**: main · **基线版本**: v1.29.0 (fb857af1)
 **关联设计**: [`WebChat-Multitenancy-Foundation-Design-Spec.md`](./WebChat-Multitenancy-Foundation-Design-Spec.md)（spec ①）
 
@@ -31,6 +31,7 @@
         ├──────────────┐
         ▼              ▼
 ② per-ws 配置继承     ③ workspace 级 worker 选择
+ （✅ PR#748）          （✅ PR#753）
    （团队默认→ws 自定义） （ws.worker_preference + fallback 链）
         │              │
         ├──────────────┤
@@ -82,7 +83,7 @@ PR #746 最新 review（基线 `68b1660`）早于 R6，其 **P1 阻塞项已在 
 | spec | 标题 | 依赖 | 核心改动 |
 |---|---|---|---|
 | ② | per-workspace agent-configs 自定义 | ① | ✅ 已合入（[PR #748](https://github.com/hrygo/hotplex/pull/748)）：`LoadForWorkspace` 双轨隔离 + Bridge `WSStore` helper + PATCH 三层校验，[设计](./WebChat-Multitenancy-PerWorkspace-AgentConfigs-Design-Spec.md) |
-| ③ | workspace 级 worker 选择 | ① | worker_type fallback 链（WebChat 轨：团队默认 → workspace）+ API，填充 `workspaces.worker_preference` |
+| ③ | workspace 级 worker 选择 | ① | ✅ 已合入（[PR #753](https://github.com/hrygo/hotplex/pull/753)，`207d47e3`）：`worker.ValidateType` 白名单 + `worker_preference` fallback 链 + CreateSession/PATCH API + DeriveSessionKey 切 worker-type 回归，[设计](./WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md) |
 | ④ | OAuth/SSO provider 落地 | ① | `IdentityProvider` 第二实现（飞书/Slack/OIDC） |
 
 阶段 B 交付后：用户可在 workspace 级定制 agent-configs 与 worker，且可用 OAuth 登录（企业 SSO 体验）。
@@ -117,7 +118,9 @@ PR #746 最新 review（基线 `68b1660`）早于 R6，其 **P1 阻塞项已在 
 
 **风险**：fallback 层数增加后的路径解析复杂度与性能（需评估缓存）。
 
-### spec ③ — 用户级 worker 选择
+### spec ③ — 用户级 worker 选择（✅ 已合入 PR #753）
+
+**交付摘要**：`internal/worker/registry.go` 新增 `ValidateType` + `ErrInvalidWorkerType` 白名单（仅 claude_code / opencode_server / codex_cli / acp）；WebChat 轨 worker_type fallback `workspace.worker_preference` → 团队默认；`CreateSession` 支持 body/query 传入 worker_type 并校验；`PATCH /api/workspaces/{id}` 支持 worker_preference 白名单；`DeriveSessionKey` 切 worker-type 生成新 session key（同 workspace 切 worker = 新会话，回归覆盖）；gateway 对 stale `worker_preference` 做防御性降级到默认。详细设计见 [`WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md`](./WebChat-Multitenancy-WorkspaceWorker-Design-Spec.md)。
 
 **目标**：调用方（前端/用户）能在 workspace 级选择用哪个 worker（claude_code / opencode_server / codex_cli / acp），WebChat 轨走 spec ① §2.4 的两层（团队默认 → workspace 选择）。
 
@@ -211,8 +214,8 @@ PR #746 最新 review（基线 `68b1660`）早于 R6，其 **P1 阻塞项已在 
 ## 7. 推进节奏
 
 - 每个 spec 独立 brainstorm → 设计文档（`docs/specs/`）→ writing-plans → 实现。
-- spec ① 已合入（PR #746）。spec ② 已合入（PR #748）。spec ③④ 可并行启动。
+- spec ① 已合入（PR #746）。spec ② 已合入（PR #748）。spec ③ 已合入（PR #753）。spec ④⑤ 可并行启动（互不依赖）。
 - spec ⑥ 在 ②③④就绪后启动。
 - 路线图文档随各 spec 推进更新状态。
 
-**下一步**：spec ② 已合入（PR #748）→ 启动 spec ③④ brainstorm（workspace 级 worker 选择 / OAuth SSO，互不依赖可并行；spec ③ `CreateSession` 已消费 `worker_preference`，主要补白名单校验，工作量最小）。spec ⑤⑥ 待 ③④ 就绪。spec ① 剩余增量（迁移验证 / 旧 webchat 会话清理 / e2e）可穿插提交。
+**下一步**：spec ③ 已合入（PR #753）→ 启动 spec ④⑤ brainstorm（OAuth SSO / 配额增强，互不依赖可并行）。spec ⑤依赖 ①②（已就绪），可立即开工；spec ④ 需先拍板 §6.2 的 provider 优先级与账号合并策略。spec ⑥ 待 ④ 就绪。spec ① 剩余增量（迁移验证 / 旧 webchat 会话清理 / e2e）可穿插提交。

--- a/docs/superpowers/plans/2026-06-17-webchat-multitenancy-spec5-quota-enhancement.md
+++ b/docs/superpowers/plans/2026-06-17-webchat-multitenancy-spec5-quota-enhancement.md
@@ -1,0 +1,824 @@
+# WebChat 多租户 spec ⑤：配额增强 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 PoolManager 的 4 个限额全部支持运行时热重载（降额不驱逐），并新增 4 个低基数聚合 Prometheus gauge。
+
+**Architecture:** 引入 `pool.Limits` struct 镜像 `config.PoolConfig`，`UpdateLimits(Limits)` 替换旧二参签名；`snapshotMetricsLocked()` 在持锁临界区统一写 5 个 atomic 快照变量（4 新 gauge + 1 现有 utilization），gauge 回调无锁读。config watcher 解锁 2 个 pool 键、config 校验拒绝负数、gateway_run 热重载回调传完整 Limits。不改计账模型、不加 per-workspace 内存层（与并发层等价，冗余）。
+
+**Tech Stack:** Go 1.24 · `sync.Mutex` + `sync/atomic` · OpenTelemetry metric（`go.opentelemetry.io/otel/metric`）· Viper config · testify/require · table-driven + `-race`
+
+**关联设计:** [`docs/specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md`](../../specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md)
+**Issue:** #754 · **PR:** #755 · **分支:** `feat/webchat-multitenancy-spec5-quota-enhancement`
+
+---
+
+## File Structure
+
+| 文件 | 职责 | 改动 |
+|---|---|---|
+| `internal/session/pool.go` | PoolManager 核心：限额计数 + 指标快照 | 新增 `Limits` struct、`UpdateLimits(Limits)`、`snapshotMetricsLocked()`、4 atomic + 4 gauge；移除旧二参 `UpdateLimits` 与散落 `setPoolUtilization` 调用 |
+| `internal/session/pool_test.go` | pool 单元测试 | 新增热重载 + 不驱逐测试 |
+| `internal/session/pool_metrics_test.go` | 指标快照测试（新文件） | 新增 4 gauge 快照断言测试 |
+| `internal/config/watcher.go` | 热重载字段白名单 | 白名单加 `pool.max_memory_per_user` / `pool.max_per_workspace` |
+| `internal/config/watcher_test.go` | watcher 测试 | 新增 pool 键热重载白名单断言 |
+| `internal/config/config.go` | 配置校验 | `pool.max_*` 4 字段拒绝负数 |
+| `internal/config/config_test.go` | 校验测试 | 扩展 `TestConfig_Validate` 表格加负数用例 |
+| `cmd/hotplex/gateway_run.go` | 热重载回调接线 | 4 字段变更触发 `UpdateLimits(Limits)` |
+
+**不动**：`acquireLocked` / `ReleaseForWorkspace` / `AcquireForWorkspace` 的校验与计账逻辑（spec ⑤ 不改计账模型）；`NewPoolManager` / `NewPoolManagerWithWorkspace` 构造函数签名（保持向后兼容）；`PoolAcquire{result}` counter（已覆盖 4 种拒绝原因）。
+
+---
+
+## Task 1: `pool.Limits` struct + `UpdateLimits(Limits)`
+
+把热重载入口从二参签名升级为 struct，覆盖全部 4 个限额字段。先写测试锁定新签名行为，再实现。
+
+**Files:**
+- Modify: `internal/session/pool.go:41-54`（struct 字段）、`pool.go:233-246`（UpdateLimits）
+- Test: `internal/session/pool_test.go`（新增）
+
+- [ ] **Step 1: 写失败测试 — 4 字段热重载**
+
+追加到 `internal/session/pool_test.go` 末尾：
+
+```go
+// TestUpdateLimits_AllFourHotReload: UpdateLimits applies all four quota fields;
+// new Acquire calls observe the new limits immediately (spec ⑤).
+func TestUpdateLimits_AllFourHotReload(t *testing.T) {
+	t.Parallel()
+	// 初始：global 100, per-user 5, per-ws 3, per-user-mem 10GB
+	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 10*1024*1024*1024, 3)
+	ctx := context.Background()
+
+	// 占用一个 ws-1 slot
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+
+	// 热重载收紧全部 4 维：global 1, per-user 1, per-ws 1, per-user-mem 1B
+	p.UpdateLimits(Limits{
+		MaxSize:          1,
+		MaxIdlePerUser:   1,
+		MaxPerWorkspace:  1,
+		MaxMemoryPerUser: 1,
+	})
+
+	// global 已 1（u1 占着），另一用户被拒
+	var pe *PoolError
+	err := p.Acquire(ctx, "u2")
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, poolErrKindExhausted, pe.Kind)
+
+	// per-ws 已 1，ws-2 的新 slot 因 per-user=1 被 u1 占用而拒（per-user 先于 per-ws 校验）
+	err = p.AcquireForWorkspace(ctx, "u1", "ws-2")
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, poolErrKindUserQuotaExceeded, pe.Kind)
+
+	// 释放 u1 后，u1 在 ws-2 可拿 1 个 slot（per-ws=1 对新 ws 未满）
+	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-2"))
+}
+```
+
+注意：`pool_test.go` 现有 import 已含 `context`/`require`/`config`，需追加 `"log/slog"`（`pool_workspace_test.go` 已用 `slog.Default()`，确认 pool_test.go 是否已 import；若无则加）。
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./internal/session/ -run TestUpdateLimits_AllFourHotReload -count=1`
+Expected: 编译失败 —— `undefined: Limits`（struct 尚未定义）。
+
+- [ ] **Step 3: 实现 `Limits` struct**
+
+在 `internal/session/pool.go` 的 `PoolManager` struct 定义之后（约 `pool.go:54` 后）、`workerMemoryEstimate` 常量之前，插入：
+
+```go
+// Limits 是 PoolManager 的运行时限额集合，镜像 config.PoolConfig。
+// 所有字段 0 = unlimited。UpdateLimits 在持 p.mu 下原子覆盖全部字段。
+type Limits struct {
+	MaxSize          int   // 全局最大活跃 Worker
+	MaxIdlePerUser   int   // per-user 最大并发 session
+	MaxPerWorkspace  int   // WebChat per-workspace 并发（spec ①）
+	MaxMemoryPerUser int64 // bytes；per-user 内存
+}
+```
+
+- [ ] **Step 4: 实现 `UpdateLimits(Limits)`，替换旧二参版**
+
+把 `pool.go:233-246` 的旧 `UpdateLimits(maxSize, maxIdlePerUser int)` 整体替换为：
+
+```go
+// UpdateLimits 动态调整全部 4 个限额（spec ⑤）。
+// 若某维限额被降到当前占用之下，已运行 session 不被驱逐 —— 新 Acquire 将被拒，
+// 直到 session 自然 Release。所有 gauge 快照在此重算（utilization 的分母 maxSize 可能变了）。
+func (p *PoolManager) UpdateLimits(l Limits) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	old := Limits{
+		MaxSize:          p.maxSize,
+		MaxIdlePerUser:   p.maxIdlePerUser,
+		MaxPerWorkspace:  p.maxPerWorkspace,
+		MaxMemoryPerUser: p.maxMemoryPerUser,
+	}
+	p.maxSize = l.MaxSize
+	p.maxIdlePerUser = l.MaxIdlePerUser
+	p.maxPerWorkspace = l.MaxPerWorkspace
+	p.maxMemoryPerUser = l.MaxMemoryPerUser
+	p.snapshotMetricsLocked()
+	p.log.Info("pool: limits updated",
+		"old_max", old.MaxSize, "new_max", l.MaxSize,
+		"old_per_user", old.MaxIdlePerUser, "new_per_user", l.MaxIdlePerUser,
+		"old_per_ws", old.MaxPerWorkspace, "new_per_ws", l.MaxPerWorkspace,
+		"old_mem_mb", old.MaxMemoryPerUser/(1024*1024), "new_mem_mb", l.MaxMemoryPerUser/(1024*1024))
+}
+```
+
+> 说明：此步引用了 `snapshotMetricsLocked()`，它在 Task 2 才实现。为让本步编译通过，**先在 Task 2 Step 1 之前**临时在 `pool.go` 加一个空壳 `func (p *PoolManager) snapshotMetricsLocked() {}`，Task 2 再填实现。或者把 Task 1 与 Task 2 的实现步合并执行——但为 TDD 隔离，推荐先加空壳，Task 2 替换。本计划采用「Task 2 Step 1 先加空壳」约定，故 Task 1 Step 4 后编译会因 `snapshotMetricsLocked` 未定义而失败 —— **此时立即跳到 Task 2 Step 1 补空壳**，再回 Task 1 Step 5 跑测试。
+
+- [ ] **Step 5: 跑测试确认通过**
+
+Run: `go test ./internal/session/ -run TestUpdateLimits_AllFourHotReload -count=1 -race`
+Expected: PASS
+
+- [ ] **Step 6: 修复 `gateway_run.go` 唯一调用点（否则包编译失败）**
+
+`cmd/hotplex/gateway_run.go:197-201`，把：
+
+```go
+	cfgStore.RegisterFunc(func(prev, next *config.Config) {
+		if prev.Pool.MaxSize != next.Pool.MaxSize || prev.Pool.MaxIdlePerUser != next.Pool.MaxIdlePerUser {
+			sm.Pool().UpdateLimits(next.Pool.MaxSize, next.Pool.MaxIdlePerUser)
+		}
+	})
+```
+
+替换为：
+
+```go
+	cfgStore.RegisterFunc(func(prev, next *config.Config) {
+		if prev.Pool.MaxSize != next.Pool.MaxSize ||
+			prev.Pool.MaxIdlePerUser != next.Pool.MaxIdlePerUser ||
+			prev.Pool.MaxPerWorkspace != next.Pool.MaxPerWorkspace ||
+			prev.Pool.MaxMemoryPerUser != next.Pool.MaxMemoryPerUser {
+			sm.Pool().UpdateLimits(session.Limits{
+				MaxSize:          next.Pool.MaxSize,
+				MaxIdlePerUser:   next.Pool.MaxIdlePerUser,
+				MaxPerWorkspace:  next.Pool.MaxPerWorkspace,
+				MaxMemoryPerUser: next.Pool.MaxMemoryPerUser,
+			})
+		}
+	})
+```
+
+确认 `gateway_run.go` 是否已 import `internal/session`（应已 import，因 `sm` 即 `*session.Manager`）。若未直接引用 `session` 包名，加 `"github.com/hrygo/hotplex/internal/session"`。
+
+- [ ] **Step 7: 全包构建确认无残留旧签名**
+
+Run: `go build ./...`
+Expected: 成功（无 `UpdateLimits has 2 arguments` 之类错误）。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/session/pool.go internal/session/pool_test.go cmd/hotplex/gateway_run.go
+git commit -m "feat(pool): Limits struct + UpdateLimits(Limits) covers all 4 quotas (spec ⑤)"
+```
+
+---
+
+## Task 2: `snapshotMetricsLocked()` 快照函数（含空壳先行）
+
+统一 5 个 atomic 快照的写入点。先加空壳让 Task 1 编译，再填实现 + 写快照调用点。
+
+**Files:**
+- Modify: `internal/session/pool.go`（新增 4 atomic 变量 + 快照函数 + 调用点）
+
+- [ ] **Step 1: 先加空壳（让 Task 1 Step 4 编译通过）**
+
+若 Task 1 Step 4 后编译报 `snapshotMetricsLocked undefined`，在 `pool.go` 的 `setPoolUtilization` 函数（`pool.go:36-38`）之后插入空壳：
+
+```go
+// snapshotMetricsLocked 将当前 pool 状态写入 atomic 快照变量供 gauge 回调无锁读取。
+// 调用方必须持有 p.mu。Task 2 Step 3 填实现。
+func (p *PoolManager) snapshotMetricsLocked() {}
+```
+
+确认 `go build ./internal/session/` 通过后，回到 Task 1 Step 5。
+
+- [ ] **Step 2: 写失败测试 — 快照反映状态（新文件）**
+
+创建 `internal/session/pool_metrics_test.go`：
+
+```go
+package session
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetrics_SnapshotReflectsState: 4 个 atomic 快照随 Acquire 正确变化（spec ⑤）。
+func TestMetrics_SnapshotReflectsState(t *testing.T) {
+	t.Parallel()
+	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 10*1024*1024*1024, 3)
+	ctx := context.Background()
+
+	require.Equal(t, int64(0), metricActiveSessions.Load())
+	require.Equal(t, int64(0), metricDistinctUsers.Load())
+	require.Equal(t, int64(0), metricDistinctWorkspaces.Load())
+	require.Equal(t, int64(0), metricMemoryReserved.Load())
+
+	// u1 在 ws-1 占 2 个 slot
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+	// u2 在 ws-2 占 1 个 slot（platform session ws=""）
+	require.NoError(t, p.Acquire(ctx, "u2"))
+
+	require.Equal(t, int64(3), metricActiveSessions.Load())
+	require.Equal(t, int64(2), metricDistinctUsers.Load())        // u1, u2
+	require.Equal(t, int64(2), metricDistinctWorkspaces.Load())   // ws-1, ws-2 — 注意 u2 是 platform(ws=""),不计数
+	require.Equal(t, int64(3*workerMemoryEstimate), metricMemoryReserved.Load())
+}
+```
+
+> ⚠️ 修正：上面 u2 用 `Acquire`（非 workspace 路径），ws=""，所以 `distinct_workspaces` 只应计 **1**（ws-1）。把断言改为：
+> `require.Equal(t, int64(1), metricDistinctWorkspaces.Load())`
+> （u2 的 platform session 不进 workspace 维度）。在写测试时用这个修正值。
+
+- [ ] **Step 3: 运行测试确认失败**
+
+Run: `go test ./internal/session/ -run TestMetrics_SnapshotReflectsState -count=1`
+Expected: 编译失败 —— `undefined: metricActiveSessions`（atomic 变量未定义）+ `snapshotMetricsLocked` 是空壳（值恒 0，但编译先挂）。
+
+- [ ] **Step 4: 新增 4 个 atomic 快照变量**
+
+在 `pool.go` 的 `var poolUtilization atomic.Uint64`（`pool.go:17`）之后插入：
+
+```go
+// 指标快照（atomic，gauge 回调无锁读取；snapshotMetricsLocked 持 mu 写）。
+var (
+	metricActiveSessions    atomic.Int64
+	metricDistinctUsers     atomic.Int64
+	metricDistinctWorkspaces atomic.Int64
+	metricMemoryReserved    atomic.Int64
+)
+```
+
+- [ ] **Step 5: 实现 `snapshotMetricsLocked`（替换空壳）**
+
+把 Task 2 Step 1 的空壳替换为：
+
+```go
+// snapshotMetricsLocked 将当前 pool 状态写入 atomic 快照变量供 gauge 回调无锁读取。
+// 调用方必须持有 p.mu。
+func (p *PoolManager) snapshotMetricsLocked() {
+	metricActiveSessions.Store(int64(p.totalCount))
+	metricDistinctUsers.Store(int64(len(p.userCount)))
+	metricDistinctWorkspaces.Store(int64(len(p.workspaceCount)))
+	metricMemoryReserved.Store(p.totalMemoryReserved())
+	if p.maxSize > 0 {
+		setPoolUtilization(float64(p.totalCount) / float64(p.maxSize))
+	} else {
+		setPoolUtilization(0)
+	}
+}
+```
+
+并新增辅助方法（放在 `snapshotMetricsLocked` 之后）：
+
+```go
+// totalMemoryReserved 返回全局已预留内存（所有用户之和）。调用方持 p.mu。
+func (p *PoolManager) totalMemoryReserved() int64 {
+	var sum int64
+	for _, m := range p.userMemory {
+		sum += m
+	}
+	return sum
+}
+```
+
+> 说明：`memory_reserved_bytes` 是全局聚合（含 platform session 的内存），与设计 §4.4 口径一致。
+
+- [ ] **Step 6: 在 acquire/release 路径调用快照**
+
+`internal/session/pool.go`，`acquireLocked` 末尾（现 `pool.go:151` `p.log.Debug(...)` 之前）把：
+
+```go
+	if p.maxSize > 0 {
+		setPoolUtilization(float64(p.totalCount) / float64(p.maxSize))
+	}
+```
+
+替换为：
+
+```go
+	p.snapshotMetricsLocked()
+```
+
+`releaseCoreLocked` 末尾（现 `pool.go:219-221`）把：
+
+```go
+	if p.maxSize > 0 {
+		setPoolUtilization(float64(p.totalCount) / float64(p.maxSize))
+	}
+```
+
+替换为：
+
+```go
+	p.snapshotMetricsLocked()
+```
+
+`UpdateLimits` 中的 `p.snapshotMetricsLocked()` 调用已在 Task 1 Step 4 写入，保留。
+
+> 注意：`AcquireMemory`（deprecated，`pool.go:255-271`）也改 `userMemory`，但它走 TOCTOU 不安全路径、不计数 totalCount。为保持计数一致，在 `AcquireMemory` 成功分支末尾（`return nil` 前）也加 `p.snapshotMetricsLocked()`。同理 `ReleaseMemory`（`pool.go:277-281`）调 `releaseMemoryLocked` 后加。这 2 处是 best-effort 一致性，避免 deprecated 路径漏更新 memory gauge。
+
+- [ ] **Step 7: 跑测试确认通过**
+
+Run: `go test ./internal/session/ -run TestMetrics -count=1 -race`
+Expected: PASS
+
+- [ ] **Step 8: 回归全部 pool 测试**
+
+Run: `go test ./internal/session/ -count=1 -race`
+Expected: PASS（现有测试不受影响——快照是附加行为）。
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/session/pool.go internal/session/pool_metrics_test.go
+git commit -m "feat(pool): snapshotMetricsLocked + 4 atomic gauges (active/users/workspaces/memory) (spec ⑤)"
+```
+
+---
+
+## Task 3: 注册 4 个 Prometheus gauge
+
+把 atomic 快照接到 OTel observable gauge，`/metrics` 端点可见。
+
+**Files:**
+- Modify: `internal/session/pool.go:19-34`（init 注册块）
+
+- [ ] **Step 1: 扩展 init 注册回调**
+
+把 `pool.go:19-34` 的 `init()` 整体替换为：
+
+```go
+func init() {
+	observability.RegisterGaugeCallbacks(func(m metric.Meter) {
+		poolGauge, err := m.Float64ObservableGauge(
+			"hotplex.pool.utilization",
+			metric.WithDescription("Pool utilization ratio (0-1)"),
+		)
+		if err != nil {
+			slog.Warn("pool: failed to create pool.utilization gauge", "err", err)
+			return
+		}
+		activeGauge, err := m.Int64ObservableGauge(
+			"hotplex.pool.active_sessions",
+			metric.WithDescription("Active worker sessions (global, includes platform/cron)"),
+		)
+		if err != nil {
+			slog.Warn("pool: failed to create pool.active_sessions gauge", "err", err)
+			return
+		}
+		usersGauge, err := m.Int64ObservableGauge(
+			"hotplex.pool.distinct_users",
+			metric.WithDescription("Distinct users with at least one active session"),
+		)
+		if err != nil {
+			slog.Warn("pool: failed to create pool.distinct_users gauge", "err", err)
+			return
+		}
+		wsGauge, err := m.Int64ObservableGauge(
+			"hotplex.pool.distinct_workspaces",
+			metric.WithDescription("Distinct WebChat workspaces with at least one active session (platform sessions excluded)"),
+		)
+		if err != nil {
+			slog.Warn("pool: failed to create pool.distinct_workspaces gauge", "err", err)
+			return
+		}
+		memGauge, err := m.Int64ObservableGauge(
+			"hotplex.pool.memory_reserved_bytes",
+			metric.WithDescription("Estimated reserved memory in bytes (active sessions × 512MB, global aggregate)"),
+		)
+		if err != nil {
+			slog.Warn("pool: failed to create pool.memory_reserved_bytes gauge", "err", err)
+			return
+		}
+		_, _ = m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+			o.ObserveFloat64(poolGauge, math.Float64frombits(poolUtilization.Load()))
+			o.ObserveInt64(activeGauge, metricActiveSessions.Load())
+			o.ObserveInt64(usersGauge, metricDistinctUsers.Load())
+			o.ObserveInt64(wsGauge, metricDistinctWorkspaces.Load())
+			o.ObserveInt64(memGauge, metricMemoryReserved.Load())
+			return nil
+		}, poolGauge, activeGauge, usersGauge, wsGauge, memGauge)
+	})
+}
+```
+
+> 注意 `RegisterCallback` 把所有 gauge 传入同一个回调（一次注册观察 5 个），与设计 §3.2 一致。`math`/`context`/`slog`/`metric` 已在 pool.go import。
+
+- [ ] **Step 2: 写测试 — gauge 回调读快照（追加到 pool_metrics_test.go）**
+
+```go
+// TestMetrics_GaugeCallbackObservesSnapshot: OTel callback reads the atomic snapshot.
+// 不启真实 Prometheus —— 直接验证 atomic 值在 Acquire 后被快照写入（gauge 回调读同一 atomic）。
+func TestMetrics_GaugeCallbackObservesSnapshot(t *testing.T) {
+	t.Parallel()
+	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 0, 3)
+	ctx := context.Background()
+
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+
+	// 快照已写（gauge 回调读这些 atomic）
+	require.Equal(t, int64(2), metricActiveSessions.Load())
+	require.Equal(t, int64(1), metricDistinctUsers.Load())
+	require.Equal(t, int64(1), metricDistinctWorkspaces.Load())
+
+	// 全部释放后回归基线（无泄漏）
+	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
+	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
+	require.Equal(t, int64(0), metricActiveSessions.Load())
+	require.Equal(t, int64(0), metricDistinctUsers.Load())
+	require.Equal(t, int64(0), metricDistinctWorkspaces.Load())
+	require.Equal(t, int64(0), metricMemoryReserved.Load())
+}
+```
+
+- [ ] **Step 3: 跑测试**
+
+Run: `go test ./internal/session/ -run TestMetrics -count=1 -race`
+Expected: PASS
+
+- [ ] **Step 4: 构建确认 OTel 注册无 panic**
+
+Run: `go build ./... && go vet ./internal/session/`
+Expected: 成功。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/session/pool.go internal/session/pool_metrics_test.go
+git commit -m "feat(pool): register 4 Prometheus gauges (active/users/workspaces/memory) (spec ⑤)"
+```
+
+---
+
+## Task 4: watcher 解锁 2 个 pool 热重载键
+
+让 `pool.max_memory_per_user` / `pool.max_per_workspace` 的变更触发 onChange 回调（进而触发 Task 1 接线的 UpdateLimits）。
+
+**Files:**
+- Modify: `internal/config/watcher.go:18-34`（hotReloadableFields）
+- Test: `internal/config/watcher_test.go`
+
+- [ ] **Step 1: 写失败测试 — 白名单含 4 个 pool 键**
+
+先看 `watcher_test.go` 是否已有遍历 `hotReloadableFields` 的测试。若无，追加：
+
+```go
+// TestHotReloadableFields_PoolQuotas: spec ⑤ — 全部 4 个 pool 限额键可热重载。
+func TestHotReloadableFields_PoolQuotas(t *testing.T) {
+	t.Parallel()
+	required := []string{
+		"pool.max_size",
+		"pool.max_idle_per_user",
+		"pool.max_memory_per_user",
+		"pool.max_per_workspace",
+	}
+	for _, f := range required {
+		require.True(t, hotReloadableFields[f], "missing hot-reloadable field: %s", f)
+	}
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./internal/config/ -run TestHotReloadableFields_PoolQuotas -count=1`
+Expected: FAIL —— `missing hot-reloadable field: pool.max_memory_per_user`（与 max_per_workspace）。
+
+- [ ] **Step 3: 加白名单**
+
+`internal/config/watcher.go:21-22`，把：
+
+```go
+	"pool.max_size":             true,
+	"pool.max_idle_per_user":    true,
+```
+
+替换为：
+
+```go
+	"pool.max_size":             true,
+	"pool.max_idle_per_user":    true,
+	"pool.max_memory_per_user":  true, // spec ⑤
+	"pool.max_per_workspace":    true, // spec ⑤
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `go test ./internal/config/ -run TestHotReloadableFields -count=1 -race`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/watcher.go internal/config/watcher_test.go
+git commit -m "feat(config): hot-reload pool.max_memory_per_user + pool.max_per_workspace (spec ⑤)"
+```
+
+---
+
+## Task 5: config 校验拒绝负数
+
+把 `pool.max_*` 的校验从「max_size 必须 >0」扩展到「4 字段均 >= 0」（0 = unlimited，负数非法）。trust config 层为唯一校验点，pool 内部不重复校验。
+
+**Files:**
+- Modify: `internal/config/config.go:84-86`
+- Test: `internal/config/config_test.go:90-98`（扩展表格）
+
+- [ ] **Step 1: 写失败测试 — 负数被拒**
+
+在 `internal/config/config_test.go` 的 `TestConfig_Validate` 表格里，`"non-positive pool max size"` 用例（约 `config_test.go:90-98`）之后插入新用例：
+
+```go
+		{
+			name: "negative pool quota fields (spec ⑤)",
+			cfg: func() Config {
+				c := *Default()
+				c.Pool.MaxIdlePerUser = -1
+				return c
+			}(),
+			errCnt: 1, // negative per-user quota
+		},
+		{
+			name: "negative pool max_per_workspace (spec ⑤)",
+			cfg: func() Config {
+				c := *Default()
+				c.Pool.MaxPerWorkspace = -1
+				return c
+			}(),
+			errCnt: 1,
+		},
+		{
+			name: "negative pool max_memory_per_user (spec ⑤)",
+			cfg: func() Config {
+				c := *Default()
+				c.Pool.MaxMemoryPerUser = -1
+				return c
+			}(),
+			errCnt: 1,
+		},
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./internal/config/ -run "TestConfig_Validate" -count=1`
+Expected: FAIL —— 3 个新用例 `errCnt` 为 0（负数当前不被拒）。
+
+- [ ] **Step 3: 实现校验**
+
+`internal/config/config.go:84-86`，把：
+
+```go
+	if c.Pool.MaxSize <= 0 {
+		errs = append(errs, "pool.max_size must be positive")
+	}
+```
+
+替换为：
+
+```go
+	if c.Pool.MaxSize <= 0 {
+		errs = append(errs, "pool.max_size must be positive")
+	}
+	if c.Pool.MaxIdlePerUser < 0 {
+		errs = append(errs, "pool.max_idle_per_user must be non-negative")
+	}
+	if c.Pool.MaxPerWorkspace < 0 {
+		errs = append(errs, "pool.max_per_workspace must be non-negative")
+	}
+	if c.Pool.MaxMemoryPerUser < 0 {
+		errs = append(errs, "pool.max_memory_per_user must be non-negative")
+	}
+```
+
+> 注意：`MaxSize` 保持 `<= 0` 报错（pool 必须有全局上限，0 不表示 unlimited 而表示非法）。其余 3 字段 `< 0` 报错、`0` 合法（= unlimited），与 PoolConfig 注释一致。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `go test ./internal/config/ -count=1 -race`
+Expected: PASS（含现有 `TestDefault` 等不受影响——默认值均 >= 0）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): reject negative pool quota fields (spec ⑤)"
+```
+
+---
+
+## Task 6: 降额不驱逐 + race 压测
+
+锁定"热重载降额后已运行 session 不被强制释放"的不变量，并做并发压测。
+
+**Files:**
+- Test: `internal/session/pool_test.go`
+
+- [ ] **Step 1: 写测试 — 降额不驱逐**
+
+追加到 `pool_test.go`：
+
+```go
+// TestUpdateLimits_DoesNotEvict: 降低内存限额后，已占用超额的 user 不被强制释放；
+// 仅新 Acquire 被拒，直到自然 Release（spec ⑤ §4.3 不变量）。
+func TestUpdateLimits_DoesNotEvict(t *testing.T) {
+	t.Parallel()
+	// per-user-mem 10GB → 1 个 slot 占 512MB，可拿多个
+	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 10*1024*1024*1024, 3)
+	ctx := context.Background()
+
+	// u1 占 2 slot（≈1GB）
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+
+	// 降到 512MB —— u1 现已超额（用了 1GB）
+	p.UpdateLimits(Limits{
+		MaxSize:          100,
+		MaxIdlePerUser:   5,
+		MaxPerWorkspace:  3,
+		MaxMemoryPerUser: workerMemoryEstimate, // 512MB
+	})
+
+	// 已占用的 u1 计数仍在（未被驱逐）
+	total, _, _ := p.Stats()
+	require.Equal(t, 2, total)
+	require.Equal(t, int64(2*workerMemoryEstimate), p.UserMemory("u1"))
+
+	// u1 新 Acquire 被内存维度拒（超额）
+	var pe *PoolError
+	err := p.AcquireForWorkspace(ctx, "u1", "ws-1")
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, poolErrKindMemoryExceeded, pe.Kind)
+
+	// 释放 1 个后，内存回到 512MB，可再拿 1 个（恰好等于上限）
+	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+}
+```
+
+- [ ] **Step 2: 跑测试**
+
+Run: `go test ./internal/session/ -run TestUpdateLimits_DoesNotEvict -count=1 -race`
+Expected: PASS
+
+- [ ] **Step 3: 写 race 压测 — 并发 Acquire/Release/UpdateLimits**
+
+追加到 `pool_test.go`：
+
+```go
+// TestPool_ConcurrentMixedOperations: 并发 Acquire/Release/UpdateLimits 不产生
+// 数据竞争或计数漂移（spec ⑤ §5.6 race 场景）。
+func TestPool_ConcurrentMixedOperations(t *testing.T) {
+	t.Parallel()
+	p := NewPoolManagerWithWorkspace(slog.Default(), 50, 10, 5*1024*1024*1024, 4)
+	ctx := context.Background()
+
+	done := make(chan struct{})
+	// Acquire/Release worker
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			uid := "u" + strconv.Itoa(i%5)
+			ws := "ws-" + strconv.Itoa(i%3)
+			if p.AcquireForWorkspace(ctx, uid, ws) == nil {
+				p.ReleaseForWorkspace(ctx, uid, ws)
+			}
+		}
+	}()
+	// UpdateLimits worker — 在 Acquire/Release 跑的同时热重载
+	for i := 0; i < 20; i++ {
+		p.UpdateLimits(Limits{
+			MaxSize:          50,
+			MaxIdlePerUser:   10,
+			MaxPerWorkspace:  4,
+			MaxMemoryPerUser: 5 * 1024 * 1024 * 1024,
+		})
+	}
+	<-done
+
+	// 收敛后：所有 slot 应已释放，快照归零
+	require.Eventually(t, func() bool {
+		return metricActiveSessions.Load() == 0
+	}, time.Second, 10*time.Millisecond)
+}
+```
+
+需追加 import：`"strconv"`、`"time"`（确认 pool_test.go 现有 import，缺则补）。
+
+- [ ] **Step 4: 跑 race 压测**
+
+Run: `go test ./internal/session/ -run TestPool_ConcurrentMixedOperations -count=1 -race`
+Expected: PASS（无 `DATA RACE` 报告，计数收敛归零）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/session/pool_test.go
+git commit -m "test(pool): no-evict on downgrade + concurrent Acquire/Release/UpdateLimits race (spec ⑤)"
+```
+
+---
+
+## Task 7: 全量验证 + 路线图收尾
+
+跑完整质量门禁，确认无回归；更新路线图标 spec ⑤ 已交付。
+
+**Files:**
+- Modify: `docs/specs/WebChat-Multitenancy-Roadmap-Spec.md`
+
+- [ ] **Step 1: 全量测试（含 race）**
+
+Run: `go test ./internal/session/ ./internal/config/ ./cmd/hotplex/ -count=1 -race`
+Expected: PASS
+
+- [ ] **Step 2: 完整 CI 门禁**
+
+Run: `make check`
+Expected: 通过（fmt + lint + vet + mod verify + build + test）。
+
+- [ ] **Step 3: 更新路线图**
+
+`docs/specs/WebChat-Multitenancy-Roadmap-Spec.md`：
+
+顶部状态行，把 `spec ③ 已合入（PR #753）` 之后补 spec ⑤ 状态。找到：
+
+```
+**状态**: spec ① 已合入（[PR #746]...）；spec ② 已合入（[PR #748]...）；spec ③ 已合入（[PR #753]...，`207d47e3`）；④-⑥ 待逐个 brainstorm
+```
+
+替换为：
+
+```
+**状态**: spec ① 已合入（[PR #746]...）；spec ② 已合入（[PR #748]...）；spec ③ 已合入（[PR #753]...，`207d47e3`）；spec ⑤ 已合入（[PR #755]...）；④/⑥ 待逐个 brainstorm
+```
+
+（PR #755 合并后再填 commit hash；未合并前用 PR 号占位即可）
+
+§3 阶段 C 表格，spec ⑤ 行：
+
+```markdown
+| ⑤ | 多租户配额增强 | ①② | ✅ 已合入（[PR #755](https://github.com/hrygo/hotplex/pull/755)）：`Limits` struct 4 限额热重载 + 4 聚合 gauge，[设计](./WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md) |
+```
+
+§4 spec ⑤ 段落标题改为 `### spec ⑤ — 多租户配额增强（✅ 已合入 PR #755）` 并在段首加交付摘要一句。
+
+§7 "下一步"段落更新为指向 spec ④/⑥。
+
+- [ ] **Step 4: Commit 路线图**
+
+```bash
+git add docs/specs/WebChat-Multitenancy-Roadmap-Spec.md
+git commit -m "docs(roadmap): mark spec ⑤ merged (PR #755)"
+```
+
+- [ ] **Step 5: 推送分支**
+
+```bash
+git push origin feat/webchat-multitenancy-spec5-quota-enhancement
+```
+
+PR #755 将自动更新，CI 重跑。等待 review。
+
+---
+
+## Self-Review(计划自审)
+
+**Spec 覆盖**：
+- §1.2 验收「4 限额热重载」→ Task 1（UpdateLimits）+ Task 4（watcher 解锁）+ Task 1 Step 6（gateway_run 接线）。✅
+- §1.2 验收「4 gauge /metrics 可见」→ Task 2（快照）+ Task 3（注册）。✅
+- §1.2 验收「降额不驱逐」→ Task 6 Step 1。✅
+- §1.2 验收「make check」→ Task 7 Step 2。✅
+- §4.1 负数校验 → Task 5。✅
+- §4.3 不变量 → Task 6。✅
+- §4.4 双轨口径（distinct_workspaces 排除 platform）→ Task 2 Step 5（totalMemoryReserved 全局聚合）+ Task 3 gauge 描述 + Task 2 测试修正注释。✅
+- §5 全部测试 → Task 1/2/3/4/5/6。✅
+
+**占位符扫描**：无 TBD/TODO；每个代码步含完整代码；Task 1 Step 4 的 `snapshotMetricsLocked` 前向引用已在同 Step 显式说明「Task 2 Step 1 补空壳」并给出空壳代码，非占位符。✅
+
+**类型一致性**：
+- `Limits` struct 字段（MaxSize int / MaxIdlePerUser int / MaxPerWorkspace int / MaxMemoryPerUser int64）与 `config.PoolConfig`（config_types.go:614-620）完全对齐。✅
+- `UpdateLimits(Limits)` 签名在 Task 1 定义、Task 6 调用一致。✅
+- 4 个 atomic 变量名（metricActiveSessions / metricDistinctUsers / metricDistinctWorkspaces / metricMemoryReserved）在 Task 2 Step 4 定义、Step 5/Task 3/Task 6 引用一致。✅
+- `snapshotMetricsLocked()` 命名（Locked 后缀）与现有 `releaseMemoryLocked`/`releaseCoreLocked` 风格一致。✅
+- `totalMemoryReserved()` 辅助方法在 Task 2 Step 5 定义并被 snapshotMetricsLocked 调用。✅
+
+**已知权衡**：
+- Task 2 Step 2 测试注释里 `distinct_workspaces` 断言值需用修正后的 `1`（u2 platform session 不计），已在 Step 2 内联标注。实现者注意以修正值为准。
+- Task 2 Step 6 给 deprecated `AcquireMemory`/`ReleaseMemory` 补快照调用是 best-effort 一致性；这俩方法标注 Deprecated 且主路径用 `AcquireWithMemory`/`AcquireForWorkspace`，补丁避免 memory gauge 在 deprecated 路径漂移。
+- 未加真实 Prometheus e2e（设计 §5.4 明示靠单元测试 + 键白名单组合保证）。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,15 @@ func (c *Config) Validate() []string {
 	if c.Pool.MaxSize <= 0 {
 		errs = append(errs, "pool.max_size must be positive")
 	}
+	if c.Pool.MaxIdlePerUser < 0 {
+		errs = append(errs, "pool.max_idle_per_user must be non-negative")
+	}
+	if c.Pool.MaxPerWorkspace < 0 {
+		errs = append(errs, "pool.max_per_workspace must be non-negative")
+	}
+	if c.Pool.MaxMemoryPerUser < 0 {
+		errs = append(errs, "pool.max_memory_per_user must be non-negative")
+	}
 	// Warn (not error) for TLS on non-local address.
 	if !c.Security.TLSEnabled &&
 		!strings.Contains(c.Gateway.Addr, "localhost") &&

--- a/internal/config/config_loader.go
+++ b/internal/config/config_loader.go
@@ -58,6 +58,7 @@ func Load(filePath string) (*Config, error) {
 	_ = v.BindEnv("pool.max_size")
 	_ = v.BindEnv("pool.max_idle_per_user")
 	_ = v.BindEnv("pool.max_memory_per_user")
+	_ = v.BindEnv("pool.max_per_workspace")
 	_ = v.BindEnv("worker.default_work_dir")
 	_ = v.BindEnv("worker.max_lifetime")
 	_ = v.BindEnv("worker.idle_timeout")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,6 +97,33 @@ func TestConfig_Validate(t *testing.T) {
 			errCnt: 1, // invalid pool only
 		},
 		{
+			name: "negative pool max_idle_per_user (spec ⑤)",
+			cfg: func() Config {
+				c := *Default()
+				c.Pool.MaxIdlePerUser = -1
+				return c
+			}(),
+			errCnt: 1,
+		},
+		{
+			name: "negative pool max_per_workspace (spec ⑤)",
+			cfg: func() Config {
+				c := *Default()
+				c.Pool.MaxPerWorkspace = -1
+				return c
+			}(),
+			errCnt: 1,
+		},
+		{
+			name: "negative pool max_memory_per_user (spec ⑤)",
+			cfg: func() Config {
+				c := *Default()
+				c.Pool.MaxMemoryPerUser = -1
+				return c
+			}(),
+			errCnt: 1,
+		},
+		{
 			name: "multiple errors",
 			cfg: func() Config {
 				c := *Default()

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -20,6 +20,8 @@ var hotReloadableFields = map[string]bool{
 	"session.gc_scan_interval":  true,
 	"pool.max_size":             true,
 	"pool.max_idle_per_user":    true,
+	"pool.max_memory_per_user":  true, // spec ⑤
+	"pool.max_per_workspace":    true, // spec ⑤
 	"security.api_keys":         true,
 	"security.allowed_origins":  true,
 	"security.security_contact": true,

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -326,6 +326,20 @@ func TestWatcher_Close(t *testing.T) {
 
 }
 
+// TestHotReloadableFields_PoolQuotas: spec ⑤ — all 4 pool quota keys are hot-reloadable.
+func TestHotReloadableFields_PoolQuotas(t *testing.T) {
+	t.Parallel()
+	required := []string{
+		"pool.max_size",
+		"pool.max_idle_per_user",
+		"pool.max_memory_per_user",
+		"pool.max_per_workspace",
+	}
+	for _, f := range required {
+		require.True(t, hotReloadableFields[f], "missing hot-reloadable field: %s", f)
+	}
+}
+
 // ─── Helper Functions ───────────────────────────────────────────────────────
 
 func createTempConfigFile(t *testing.T) string {

--- a/internal/messaging/slack/adapter_test.go
+++ b/internal/messaging/slack/adapter_test.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1282,13 +1285,32 @@ func TestClearStatus_CleansEmojiEvenWhenAssistantCapable(t *testing.T) {
 // testAdapter creates an Adapter with a non-nil slack.Client (dummy token)
 // so that the "client not initialized" guard is bypassed and the method
 // exercises its full code path. PostMessageContext will fail with invalid_auth.
+var (
+	testSlackServerOnce sync.Once
+	testSlackServerInst *httptest.Server
+)
+
+// testSlackServer returns a package-level stub Slack API server that replies
+// to every endpoint with {"ok":false,"error":"invalid_auth"}, so tests can
+// exercise the full client code path without real network egress — a dummy
+// token fails instantly on localhost instead of TLS-handshaking slack.com.
+func testSlackServer() *httptest.Server {
+	testSlackServerOnce.Do(func() {
+		testSlackServerInst = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
+		}))
+	})
+	return testSlackServerInst
+}
+
 func testAdapter() *Adapter {
 	return &Adapter{
 		BaseAdapter: messaging.BaseAdapter[*SlackConn]{
 			PlatformAdapter: messaging.PlatformAdapter{Log: slog.New(slog.NewTextHandler(io.Discard, nil))},
 			ConnPool:        messaging.NewConnPool[*SlackConn](nil),
 		},
-		client:        slack.New("x-test-token"),
+		client:        slack.New("x-test-token", slack.OptionAPIURL(testSlackServer().URL+"/")),
 		activeStreams: make(map[string]*NativeStreamingWriter),
 	}
 }

--- a/internal/session/coverage_test.go
+++ b/internal/session/coverage_test.go
@@ -44,7 +44,7 @@ func TestDeriveCronSessionKey_UUIDv5Format(t *testing.T) {
 func TestPool_UpdateLimits(t *testing.T) {
 	t.Parallel()
 	p := NewPoolManager(slog.Default(), 10, 3, 0)
-	p.UpdateLimits(Limits{MaxSize: 20, MaxIdlePerUser: 5})
+	p.UpdateLimits(config.PoolConfig{MaxSize: 20, MaxIdlePerUser: 5})
 	total, max, users := p.Stats()
 	require.Equal(t, 0, total)
 	require.Equal(t, 20, max)

--- a/internal/session/coverage_test.go
+++ b/internal/session/coverage_test.go
@@ -44,7 +44,7 @@ func TestDeriveCronSessionKey_UUIDv5Format(t *testing.T) {
 func TestPool_UpdateLimits(t *testing.T) {
 	t.Parallel()
 	p := NewPoolManager(slog.Default(), 10, 3, 0)
-	p.UpdateLimits(20, 5)
+	p.UpdateLimits(Limits{MaxSize: 20, MaxIdlePerUser: 5})
 	total, max, users := p.Stats()
 	require.Equal(t, 0, total)
 	require.Equal(t, 20, max)

--- a/internal/session/pool.go
+++ b/internal/session/pool.go
@@ -34,10 +34,46 @@ func init() {
 			slog.Warn("pool: failed to create pool.utilization gauge", "err", err)
 			return
 		}
+		activeGauge, err := m.Int64ObservableGauge(
+			"hotplex.pool.active_sessions",
+			metric.WithDescription("Active worker sessions (global, includes platform/cron)"),
+		)
+		if err != nil {
+			slog.Warn("pool: failed to create pool.active_sessions gauge", "err", err)
+			return
+		}
+		usersGauge, err := m.Int64ObservableGauge(
+			"hotplex.pool.distinct_users",
+			metric.WithDescription("Distinct users with at least one active session"),
+		)
+		if err != nil {
+			slog.Warn("pool: failed to create pool.distinct_users gauge", "err", err)
+			return
+		}
+		wsGauge, err := m.Int64ObservableGauge(
+			"hotplex.pool.distinct_workspaces",
+			metric.WithDescription("Distinct WebChat workspaces with at least one active session (platform sessions excluded)"),
+		)
+		if err != nil {
+			slog.Warn("pool: failed to create pool.distinct_workspaces gauge", "err", err)
+			return
+		}
+		memGauge, err := m.Int64ObservableGauge(
+			"hotplex.pool.memory_reserved_bytes",
+			metric.WithDescription("Estimated reserved memory in bytes (active sessions x 512MB, global aggregate)"),
+		)
+		if err != nil {
+			slog.Warn("pool: failed to create pool.memory_reserved_bytes gauge", "err", err)
+			return
+		}
 		_, _ = m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
 			o.ObserveFloat64(poolGauge, math.Float64frombits(poolUtilization.Load()))
+			o.ObserveInt64(activeGauge, metricActiveSessions.Load())
+			o.ObserveInt64(usersGauge, metricDistinctUsers.Load())
+			o.ObserveInt64(wsGauge, metricDistinctWorkspaces.Load())
+			o.ObserveInt64(memGauge, metricMemoryReserved.Load())
 			return nil
-		}, poolGauge)
+		}, poolGauge, activeGauge, usersGauge, wsGauge, memGauge)
 	})
 }
 

--- a/internal/session/pool.go
+++ b/internal/session/pool.go
@@ -37,6 +37,10 @@ func setPoolUtilization(v float64) {
 	poolUtilization.Store(math.Float64bits(v))
 }
 
+// snapshotMetricsLocked 将当前 pool 状态写入 atomic 快照变量供 gauge 回调无锁读取。
+// 调用方必须持有 p.mu。(Task 2 will fill in the implementation.)
+func (p *PoolManager) snapshotMetricsLocked() {}
+
 // PoolManager manages per-user and global concurrency quotas for worker sessions.
 type PoolManager struct {
 	log *slog.Logger
@@ -51,6 +55,15 @@ type PoolManager struct {
 	maxIdlePerUser   int   // 0 = unlimited
 	maxMemoryPerUser int64 // bytes; 0 = unlimited
 	maxPerWorkspace  int   // 0 = unlimited (WebChat per-workspace concurrency, spec ①)
+}
+
+// Limits 是 PoolManager 的运行时限额集合,镜像 config.PoolConfig。
+// 所有字段 0 = unlimited。UpdateLimits 在持 p.mu 下原子覆盖全部字段。
+type Limits struct {
+	MaxSize          int   // 全局最大活跃 Worker
+	MaxIdlePerUser   int   // per-user 最大并发 session
+	MaxPerWorkspace  int   // WebChat per-workspace 并发(spec ①)
+	MaxMemoryPerUser int64 // bytes;per-user 内存
 }
 
 // Default per-worker memory estimate (matches RLIMIT_AS in proc/manager.go).
@@ -230,19 +243,28 @@ func (p *PoolManager) Stats() (total, maxSize, uniqueUsers int) {
 	return p.totalCount, p.maxSize, len(p.userCount)
 }
 
-// UpdateLimits dynamically adjusts the pool limits.
-// If maxSize is reduced below the current total, existing sessions are NOT evicted —
-// new Acquire calls will be rejected until sessions are naturally released.
-func (p *PoolManager) UpdateLimits(maxSize, maxIdlePerUser int) {
+// UpdateLimits 动态调整全部 4 个限额(spec ⑤)。
+// 若某维限额被降到当前占用之下,已运行 session 不被驱逐 —— 新 Acquire 将被拒,
+// 直到 session 自然 Release。所有 gauge 快照在此重算(utilization 的分母 maxSize 可能变了)。
+func (p *PoolManager) UpdateLimits(l Limits) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	old := p.maxSize
-	p.maxSize = maxSize
-	p.maxIdlePerUser = maxIdlePerUser
-	if p.maxSize > 0 {
-		setPoolUtilization(float64(p.totalCount) / float64(p.maxSize))
+	old := Limits{
+		MaxSize:          p.maxSize,
+		MaxIdlePerUser:   p.maxIdlePerUser,
+		MaxPerWorkspace:  p.maxPerWorkspace,
+		MaxMemoryPerUser: p.maxMemoryPerUser,
 	}
-	p.log.Info("pool: limits updated", "old_max", old, "new_max", maxSize, "max_per_user", maxIdlePerUser)
+	p.maxSize = l.MaxSize
+	p.maxIdlePerUser = l.MaxIdlePerUser
+	p.maxPerWorkspace = l.MaxPerWorkspace
+	p.maxMemoryPerUser = l.MaxMemoryPerUser
+	p.snapshotMetricsLocked()
+	p.log.Info("pool: limits updated",
+		"old_max", old.MaxSize, "new_max", l.MaxSize,
+		"old_per_user", old.MaxIdlePerUser, "new_per_user", l.MaxIdlePerUser,
+		"old_per_ws", old.MaxPerWorkspace, "new_per_ws", l.MaxPerWorkspace,
+		"old_mem_mb", old.MaxMemoryPerUser/(1024*1024), "new_mem_mb", l.MaxMemoryPerUser/(1024*1024))
 }
 
 // Deprecated: AcquireMemory is TOCTOU-unsafe when called separately from

--- a/internal/session/pool.go
+++ b/internal/session/pool.go
@@ -290,8 +290,8 @@ func (p *PoolManager) releaseCoreLocked(ctx context.Context, userID string) bool
 		delete(p.userCount, userID)
 	}
 	p.totalCount--
-	p.snapshotMetricsLocked()
 	p.releaseMemoryLocked(userID)
+	p.snapshotMetricsLocked()
 	return true
 }
 

--- a/internal/session/pool.go
+++ b/internal/session/pool.go
@@ -87,7 +87,7 @@ func (p *PoolManager) snapshotMetricsLocked() {
 	metricActiveSessions.Store(int64(p.totalCount))
 	metricDistinctUsers.Store(int64(len(p.userCount)))
 	metricDistinctWorkspaces.Store(int64(len(p.workspaceCount)))
-	metricMemoryReserved.Store(p.totalMemoryReserved())
+	metricMemoryReserved.Store(p.totalMemoryReservedBytes)
 	if p.maxSize > 0 {
 		setPoolUtilization(float64(p.totalCount) / float64(p.maxSize))
 	} else {
@@ -95,24 +95,16 @@ func (p *PoolManager) snapshotMetricsLocked() {
 	}
 }
 
-// totalMemoryReserved 返回全局已预留内存(所有用户之和)。调用方持 p.mu。
-func (p *PoolManager) totalMemoryReserved() int64 {
-	var sum int64
-	for _, m := range p.userMemory {
-		sum += m
-	}
-	return sum
-}
-
 // PoolManager manages per-user and global concurrency quotas for worker sessions.
 type PoolManager struct {
 	log *slog.Logger
 
-	mu             sync.Mutex
-	totalCount     int
-	userCount      map[string]int   // userID → active session count
-	userMemory     map[string]int64 // userID → total estimated memory bytes (sum of RLIMIT_AS caps)
-	workspaceCount map[string]int   // workspaceID → active session count (WebChat multi-tenant, spec ①)
+	mu                       sync.Mutex
+	totalCount               int
+	userCount                map[string]int   // userID → active session count
+	userMemory               map[string]int64 // userID → total estimated memory bytes
+	totalMemoryReservedBytes int64            // running sum of userMemory values; O(1) snapshot (avoids持锁 O(n) 遍历)
+	workspaceCount           map[string]int   // workspaceID → active session count (WebChat multi-tenant, spec ①)
 
 	maxSize          int   // 0 = unlimited
 	maxIdlePerUser   int   // 0 = unlimited
@@ -129,7 +121,9 @@ type Limits struct {
 	MaxMemoryPerUser int64 // bytes;per-user 内存
 }
 
-// Default per-worker memory estimate (matches RLIMIT_AS in proc/manager.go).
+// Default per-worker memory estimate. Historical constant carried from spec ①;
+// no longer corresponds to a process-level cap (RLIMIT_AS is disabled — see
+// internal/worker/proc/memlimit_linux.go). Used only as a rough accounting unit.
 const workerMemoryEstimate = 512 * 1024 * 1024 // 512 MB
 
 const (
@@ -214,6 +208,7 @@ func (p *PoolManager) acquireLocked(ctx context.Context, userID, workspaceID str
 			return &PoolError{Kind: poolErrKindMemoryExceeded, UserID: userID}
 		}
 		p.userMemory[userID] = used + workerMemoryEstimate
+		p.totalMemoryReservedBytes += workerMemoryEstimate
 	}
 
 	p.userCount[userID]++
@@ -347,6 +342,7 @@ func (p *PoolManager) AcquireMemory(userID string) error {
 			return &PoolError{Kind: poolErrKindMemoryExceeded, UserID: userID}
 		}
 		p.userMemory[userID] = used + workerMemoryEstimate
+		p.totalMemoryReservedBytes += workerMemoryEstimate
 	}
 	p.snapshotMetricsLocked()
 	return nil
@@ -367,11 +363,15 @@ func (p *PoolManager) ReleaseMemory(userID string) {
 func (p *PoolManager) releaseMemoryLocked(userID string) {
 	if p.maxMemoryPerUser > 0 {
 		used := p.userMemory[userID]
+		var delta int64
 		if used >= workerMemoryEstimate {
+			delta = workerMemoryEstimate
 			p.userMemory[userID] = used - workerMemoryEstimate
 		} else if used > 0 {
+			delta = used
 			p.userMemory[userID] = 0
 		}
+		p.totalMemoryReservedBytes -= delta
 		if p.userMemory[userID] <= 0 {
 			delete(p.userMemory, userID)
 		}

--- a/internal/session/pool.go
+++ b/internal/session/pool.go
@@ -16,6 +16,14 @@ import (
 
 var poolUtilization atomic.Uint64 // stores math.Float64bits
 
+// 指标快照(atomic,gauge 回调无锁读取;snapshotMetricsLocked 持 mu 写)。
+var (
+	metricActiveSessions     atomic.Int64
+	metricDistinctUsers      atomic.Int64
+	metricDistinctWorkspaces atomic.Int64
+	metricMemoryReserved     atomic.Int64
+)
+
 func init() {
 	observability.RegisterGaugeCallbacks(func(m metric.Meter) {
 		poolGauge, err := m.Float64ObservableGauge(
@@ -38,8 +46,27 @@ func setPoolUtilization(v float64) {
 }
 
 // snapshotMetricsLocked 将当前 pool 状态写入 atomic 快照变量供 gauge 回调无锁读取。
-// 调用方必须持有 p.mu。(Task 2 will fill in the implementation.)
-func (p *PoolManager) snapshotMetricsLocked() {}
+// 调用方必须持有 p.mu。
+func (p *PoolManager) snapshotMetricsLocked() {
+	metricActiveSessions.Store(int64(p.totalCount))
+	metricDistinctUsers.Store(int64(len(p.userCount)))
+	metricDistinctWorkspaces.Store(int64(len(p.workspaceCount)))
+	metricMemoryReserved.Store(p.totalMemoryReserved())
+	if p.maxSize > 0 {
+		setPoolUtilization(float64(p.totalCount) / float64(p.maxSize))
+	} else {
+		setPoolUtilization(0)
+	}
+}
+
+// totalMemoryReserved 返回全局已预留内存(所有用户之和)。调用方持 p.mu。
+func (p *PoolManager) totalMemoryReserved() int64 {
+	var sum int64
+	for _, m := range p.userMemory {
+		sum += m
+	}
+	return sum
+}
 
 // PoolManager manages per-user and global concurrency quotas for worker sessions.
 type PoolManager struct {
@@ -158,9 +185,7 @@ func (p *PoolManager) acquireLocked(ctx context.Context, userID, workspaceID str
 	if workspaceID != "" {
 		p.workspaceCount[workspaceID]++
 	}
-	if p.maxSize > 0 {
-		setPoolUtilization(float64(p.totalCount) / float64(p.maxSize))
-	}
+	p.snapshotMetricsLocked()
 	p.log.Debug("pool: acquired", "user_id", userID, "workspace_id", workspaceID, "total", p.totalCount)
 	return nil
 }
@@ -229,9 +254,7 @@ func (p *PoolManager) releaseCoreLocked(ctx context.Context, userID string) bool
 		delete(p.userCount, userID)
 	}
 	p.totalCount--
-	if p.maxSize > 0 {
-		setPoolUtilization(float64(p.totalCount) / float64(p.maxSize))
-	}
+	p.snapshotMetricsLocked()
 	p.releaseMemoryLocked(userID)
 	return true
 }
@@ -289,6 +312,7 @@ func (p *PoolManager) AcquireMemory(userID string) error {
 		}
 		p.userMemory[userID] = used + workerMemoryEstimate
 	}
+	p.snapshotMetricsLocked()
 	return nil
 }
 
@@ -300,6 +324,7 @@ func (p *PoolManager) ReleaseMemory(userID string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.releaseMemoryLocked(userID)
+	p.snapshotMetricsLocked()
 }
 
 // releaseMemoryLocked frees memory quota. Caller must hold p.mu.

--- a/internal/session/pool.go
+++ b/internal/session/pool.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/hrygo/hotplex/internal/config"
 	"github.com/hrygo/hotplex/internal/observability"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -17,6 +18,9 @@ import (
 var poolUtilization atomic.Uint64 // stores math.Float64bits
 
 // 指标快照(atomic,gauge 回调无锁读取;snapshotMetricsLocked 持 mu 写)。
+//
+// TODO(单实例假设): 这些包全局 atomic 由唯一 PoolManager 实例写入(snapshotMetricsLocked)。
+// 多实例会互相覆盖;未来若引入 per-tenant pool,需移到 PoolManager struct 并改为捕获实例的回调。
 var (
 	metricActiveSessions     atomic.Int64
 	metricDistinctUsers      atomic.Int64
@@ -60,7 +64,7 @@ func init() {
 		}
 		memGauge, err := m.Int64ObservableGauge(
 			"hotplex.pool.memory_reserved_bytes",
-			metric.WithDescription("Estimated reserved memory in bytes (active sessions x 512MB, global aggregate)"),
+			metric.WithDescription("Reserved memory under per-user quota in bytes (only accumulated when pool.max_memory_per_user is set; 512MB/worker estimate, not actual RSS)"),
 		)
 		if err != nil {
 			slog.Warn("pool: failed to create pool.memory_reserved_bytes gauge", "err", err)
@@ -110,15 +114,6 @@ type PoolManager struct {
 	maxIdlePerUser   int   // 0 = unlimited
 	maxMemoryPerUser int64 // bytes; 0 = unlimited
 	maxPerWorkspace  int   // 0 = unlimited (WebChat per-workspace concurrency, spec ①)
-}
-
-// Limits 是 PoolManager 的运行时限额集合,镜像 config.PoolConfig。
-// 所有字段 0 = unlimited。UpdateLimits 在持 p.mu 下原子覆盖全部字段。
-type Limits struct {
-	MaxSize          int   // 全局最大活跃 Worker
-	MaxIdlePerUser   int   // per-user 最大并发 session
-	MaxPerWorkspace  int   // WebChat per-workspace 并发(spec ①)
-	MaxMemoryPerUser int64 // bytes;per-user 内存
 }
 
 // Default per-worker memory estimate. Historical constant carried from spec ①;
@@ -265,6 +260,9 @@ func (p *PoolManager) ReleaseForWorkspace(ctx context.Context, userID, workspace
 			delete(p.workspaceCount, workspaceID)
 		}
 	}
+	// workspaceCount 在 releaseCoreLocked 快照之后才递减;重新快照,否则
+	// distinct_workspaces 永远慢一拍,且 pool 排空后卡在非零值(spec ⑤ review #1)。
+	p.snapshotMetricsLocked()
 	p.log.Debug("pool: released", "user_id", userID, "workspace_id", workspaceID, "total", p.totalCount)
 }
 
@@ -300,10 +298,16 @@ func (p *PoolManager) Stats() (total, maxSize, uniqueUsers int) {
 // UpdateLimits 动态调整全部 4 个限额(spec ⑤)。
 // 若某维限额被降到当前占用之下,已运行 session 不被驱逐 —— 新 Acquire 将被拒,
 // 直到 session 自然 Release。所有 gauge 快照在此重算(utilization 的分母 maxSize 可能变了)。
-func (p *PoolManager) UpdateLimits(l Limits) {
+//
+// max_memory_per_user 从正数热重载为 0(禁用)时,立即清空 userMemory 与
+// totalMemoryReservedBytes:releaseMemoryLocked 已去掉 maxMemoryPerUser>0 守卫,
+// 旧条目本可随自然 Release 清理,但此处即时归零让 memory_reserved_bytes 不必
+// 等 drain 即反映"限制已取消"。反向(0→正数)不重建 —— 无法在不新增计数器的前提
+// 下得知哪些活跃 session 占内存,该方向仅 under-count(宽松),旧 session Release 后自洽。
+func (p *PoolManager) UpdateLimits(l config.PoolConfig) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	old := Limits{
+	old := config.PoolConfig{
 		MaxSize:          p.maxSize,
 		MaxIdlePerUser:   p.maxIdlePerUser,
 		MaxPerWorkspace:  p.maxPerWorkspace,
@@ -313,6 +317,10 @@ func (p *PoolManager) UpdateLimits(l Limits) {
 	p.maxIdlePerUser = l.MaxIdlePerUser
 	p.maxPerWorkspace = l.MaxPerWorkspace
 	p.maxMemoryPerUser = l.MaxMemoryPerUser
+	if old.MaxMemoryPerUser > 0 && p.maxMemoryPerUser == 0 {
+		p.userMemory = make(map[string]int64)
+		p.totalMemoryReservedBytes = 0
+	}
 	p.snapshotMetricsLocked()
 	p.log.Info("pool: limits updated",
 		"old_max", old.MaxSize, "new_max", l.MaxSize,
@@ -359,22 +367,26 @@ func (p *PoolManager) ReleaseMemory(userID string) {
 	p.snapshotMetricsLocked()
 }
 
-// releaseMemoryLocked frees memory quota. Caller must hold p.mu.
+// releaseMemoryLocked frees one worker's worth of memory quota. Caller must hold p.mu.
+//
+// 总是执行清理(不受 maxMemoryPerUser>0 守卫):热重载可把 max_memory_per_user 从正数
+// 调到 0(禁用),若仍按守卫跳过,旧 session 的 Release 无法清理遗留 userMemory 条目 →
+// memory_reserved_bytes 永久虚高 + map 泄漏(spec ⑤ review #2)。userMemory[userID] 为空
+// 时 delta=0、delete 不存在 key 均 no-op,故对从未预留内存的 session(plain Acquire /
+// 内存层禁用期间 acquire)无副作用。
 func (p *PoolManager) releaseMemoryLocked(userID string) {
-	if p.maxMemoryPerUser > 0 {
-		used := p.userMemory[userID]
-		var delta int64
-		if used >= workerMemoryEstimate {
-			delta = workerMemoryEstimate
-			p.userMemory[userID] = used - workerMemoryEstimate
-		} else if used > 0 {
-			delta = used
-			p.userMemory[userID] = 0
-		}
-		p.totalMemoryReservedBytes -= delta
-		if p.userMemory[userID] <= 0 {
-			delete(p.userMemory, userID)
-		}
+	used := p.userMemory[userID]
+	var delta int64
+	if used >= workerMemoryEstimate {
+		delta = workerMemoryEstimate
+		p.userMemory[userID] = used - workerMemoryEstimate
+	} else if used > 0 {
+		delta = used
+		p.userMemory[userID] = 0
+	}
+	p.totalMemoryReservedBytes -= delta
+	if p.userMemory[userID] <= 0 {
+		delete(p.userMemory, userID)
 	}
 }
 

--- a/internal/session/pool_metrics_test.go
+++ b/internal/session/pool_metrics_test.go
@@ -1,0 +1,38 @@
+package session
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetrics_SnapshotReflectsState: 4 个 atomic 快照随 Acquire 正确变化(spec ⑤)。
+//
+// snapshotMetricsLocked 写入的是包级全局 atomic 变量(Prometheus gauge 约定),
+// 其他并行测试可能同时通过 Acquire/Release 改写这些计数器。因此本测试不并行,
+// 且用 **delta 比较**(after - before = expected Δ)替代绝对值断言,
+// 消除任何残留全局状态的干扰。
+func TestMetrics_SnapshotReflectsState(t *testing.T) {
+	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 10*1024*1024*1024, 3)
+	ctx := context.Background()
+
+	// 读基线(允许其他测试残留状态;只关心本测试引入的 Δ)。
+	baseActive := metricActiveSessions.Load()
+	baseUsers := metricDistinctUsers.Load()
+	baseWS := metricDistinctWorkspaces.Load()
+	baseMem := metricMemoryReserved.Load()
+
+	// u1 在 ws-1 占 2 个 slot(每个 reserve 1×workerMemoryEstimate)。
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+	// u2 是 platform session(ws=""),走 Acquire 路径,不进 workspace 维度,也不 reserve memory。
+	require.NoError(t, p.Acquire(ctx, "u2"))
+
+	// 比较增量,不受其他并行测试影响。
+	require.Equal(t, int64(3), metricActiveSessions.Load()-baseActive, "active sessions delta")
+	require.Equal(t, int64(2), metricDistinctUsers.Load()-baseUsers, "distinct users delta (u1, u2)")
+	require.Equal(t, int64(1), metricDistinctWorkspaces.Load()-baseWS, "distinct workspaces delta (ONLY ws-1; u2 platform ws=\"\" not counted)")
+	require.Equal(t, int64(2*workerMemoryEstimate), metricMemoryReserved.Load()-baseMem, "memory delta (u1×2 slots, u2 plain Acquire does not reserve)")
+}

--- a/internal/session/pool_metrics_test.go
+++ b/internal/session/pool_metrics_test.go
@@ -67,21 +67,3 @@ func TestMetrics_SnapshotUpdatesOnRelease(t *testing.T) {
 	require.Equal(t, int64(0), usersAfter)
 	require.Equal(t, int64(0), workspacesAfter)
 }
-
-// TestMetrics_GaugesRegistered verifies the 4 new OTel gauges are registered
-// (init() created them without returning an error). We cannot assert gauge VALUES
-// here because the snapshot atomics are package-global and overwritten by every
-// PoolManager instance in the test binary (flaky). Registration + the per-instance
-// snapshot logic test (TestMetrics_SnapshotLogic) together cover the contract.
-func TestMetrics_GaugesRegistered(t *testing.T) {
-	t.Parallel()
-	// init() has already run (package load). The fact that the package compiled and
-	// other pool tests create PoolManagers without panic confirms the gauge callback
-	// registered. We exercise the code path by creating a pool and acquiring/releasing,
-	// which triggers snapshotMetricsLocked → writes the atomics the gauges read.
-	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 0, 3)
-	ctx := context.Background()
-	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
-	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
-	// No panic, no error — gauge callback registration is sound.
-}

--- a/internal/session/pool_metrics_test.go
+++ b/internal/session/pool_metrics_test.go
@@ -67,3 +67,21 @@ func TestMetrics_SnapshotUpdatesOnRelease(t *testing.T) {
 	require.Equal(t, int64(0), usersAfter)
 	require.Equal(t, int64(0), workspacesAfter)
 }
+
+// TestMetrics_GaugesRegistered verifies the 4 new OTel gauges are registered
+// (init() created them without returning an error). We cannot assert gauge VALUES
+// here because the snapshot atomics are package-global and overwritten by every
+// PoolManager instance in the test binary (flaky). Registration + the per-instance
+// snapshot logic test (TestMetrics_SnapshotLogic) together cover the contract.
+func TestMetrics_GaugesRegistered(t *testing.T) {
+	t.Parallel()
+	// init() has already run (package load). The fact that the package compiled and
+	// other pool tests create PoolManagers without panic confirms the gauge callback
+	// registered. We exercise the code path by creating a pool and acquiring/releasing,
+	// which triggers snapshotMetricsLocked → writes the atomics the gauges read.
+	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 0, 3)
+	ctx := context.Background()
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
+	// No panic, no error — gauge callback registration is sound.
+}

--- a/internal/session/pool_metrics_test.go
+++ b/internal/session/pool_metrics_test.go
@@ -30,7 +30,7 @@ func TestMetrics_SnapshotLogic(t *testing.T) {
 	active := int64(p.totalCount)
 	users := int64(len(p.userCount))
 	workspaces := int64(len(p.workspaceCount))
-	mem := p.totalMemoryReserved()
+	mem := p.totalMemoryReservedBytes
 	p.mu.Unlock()
 
 	require.Equal(t, int64(3), active)                   // 2 (u1) + 1 (u2)

--- a/internal/session/pool_metrics_test.go
+++ b/internal/session/pool_metrics_test.go
@@ -8,31 +8,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestMetrics_SnapshotReflectsState: 4 个 atomic 快照随 Acquire 正确变化(spec ⑤)。
-//
-// snapshotMetricsLocked 写入的是包级全局 atomic 变量(Prometheus gauge 约定),
-// 其他并行测试可能同时通过 Acquire/Release 改写这些计数器。因此本测试不并行,
-// 且用 **delta 比较**(after - before = expected Δ)替代绝对值断言,
-// 消除任何残留全局状态的干扰。
-func TestMetrics_SnapshotReflectsState(t *testing.T) {
+// TestMetrics_SnapshotLogic verifies the per-pool state that snapshotMetricsLocked
+// reads from — the values that get written to the package-global atomic gauges.
+// We assert on the pool's own locked state (not the package globals) because the
+// globals are shared across all PoolManager instances in the test binary and cannot
+// be asserted reliably. The atomic.Store itself is trivial; the logic worth testing
+// is the computation: totalCount, distinct users/workspaces, and totalMemoryReserved.
+func TestMetrics_SnapshotLogic(t *testing.T) {
+	t.Parallel()
 	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 10*1024*1024*1024, 3)
 	ctx := context.Background()
 
-	// 读基线(允许其他测试残留状态;只关心本测试引入的 Δ)。
-	baseActive := metricActiveSessions.Load()
-	baseUsers := metricDistinctUsers.Load()
-	baseWS := metricDistinctWorkspaces.Load()
-	baseMem := metricMemoryReserved.Load()
-
-	// u1 在 ws-1 占 2 个 slot(每个 reserve 1×workerMemoryEstimate)。
+	// u1 在 ws-1 占 2 个 slot（AcquireForWorkspace 预留内存）
 	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
 	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
-	// u2 是 platform session(ws=""),走 Acquire 路径,不进 workspace 维度,也不 reserve memory。
+	// u2 是 platform session（ws=""），走 Acquire 路径：不进 workspace 维度，不预留内存
 	require.NoError(t, p.Acquire(ctx, "u2"))
 
-	// 比较增量,不受其他并行测试影响。
-	require.Equal(t, int64(3), metricActiveSessions.Load()-baseActive, "active sessions delta")
-	require.Equal(t, int64(2), metricDistinctUsers.Load()-baseUsers, "distinct users delta (u1, u2)")
-	require.Equal(t, int64(1), metricDistinctWorkspaces.Load()-baseWS, "distinct workspaces delta (ONLY ws-1; u2 platform ws=\"\" not counted)")
-	require.Equal(t, int64(2*workerMemoryEstimate), metricMemoryReserved.Load()-baseMem, "memory delta (u1×2 slots, u2 plain Acquire does not reserve)")
+	// 读 pool 自身状态（snapshotMetricsLocked 的输入），持 p.mu 避免与 Acquire/Release 竞态
+	p.mu.Lock()
+	active := int64(p.totalCount)
+	users := int64(len(p.userCount))
+	workspaces := int64(len(p.workspaceCount))
+	mem := p.totalMemoryReserved()
+	p.mu.Unlock()
+
+	require.Equal(t, int64(3), active)                   // 2 (u1) + 1 (u2)
+	require.Equal(t, int64(2), users)                    // u1, u2
+	require.Equal(t, int64(1), workspaces)               // ONLY ws-1; u2 platform (ws="") 不计入
+	require.Equal(t, int64(2*workerMemoryEstimate), mem) // only u1's 2 workspace acquires reserve memory
+}
+
+// TestMetrics_SnapshotUpdatesOnRelease verifies that after Release the per-pool state
+// returns toward baseline (snapshot is kept consistent on the release path).
+func TestMetrics_SnapshotUpdatesOnRelease(t *testing.T) {
+	t.Parallel()
+	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 0, 3)
+	ctx := context.Background()
+
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+
+	p.mu.Lock()
+	activeBefore := int64(p.totalCount)
+	p.mu.Unlock()
+	require.Equal(t, int64(2), activeBefore)
+
+	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
+	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
+
+	p.mu.Lock()
+	activeAfter := int64(p.totalCount)
+	usersAfter := int64(len(p.userCount))
+	workspacesAfter := int64(len(p.workspaceCount))
+	p.mu.Unlock()
+
+	require.Equal(t, int64(0), activeAfter)
+	require.Equal(t, int64(0), usersAfter)
+	require.Equal(t, int64(0), workspacesAfter)
 }

--- a/internal/session/pool_test.go
+++ b/internal/session/pool_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -333,4 +334,76 @@ func TestPoolAcquireWithMemory_UserQuotaExceeded(t *testing.T) {
 	require.Equal(t, poolErrKindUserQuotaExceeded, pe.Kind)
 
 	pool.Release(context.Background(), "user1")
+}
+
+// TestUpdateLimits_AllFourHotReload: UpdateLimits applies all four quota fields
+// atomically under p.mu; new Acquire calls observe the new limits immediately (spec ⑤).
+// 检查顺序在 acquireLocked 中是 global → per-user → per-workspace → memory,
+// 所以测试针对每条分支构造"该分支是首个失败点"的场景。
+func TestUpdateLimits_AllFourHotReload(t *testing.T) {
+	t.Parallel()
+	// 初始:global 100, per-user 5, per-ws 3, per-user-mem 10GB
+	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 10*1024*1024*1024, 3)
+	ctx := context.Background()
+
+	// u1 占用 ws-1(global=1, u1 count=1, ws-1 count=1, u1 mem=512MB)
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+
+	var pe *PoolError
+
+	// ── 场景 A:global 收紧 → exhausted(u2 受 global 限制先于 per-user 拦截) ──
+	p.UpdateLimits(Limits{
+		MaxSize:          1,
+		MaxIdlePerUser:   5, // 放宽,使 per-user 不先触发
+		MaxPerWorkspace:  3,
+		MaxMemoryPerUser: 10 * 1024 * 1024 * 1024,
+	})
+	err := p.Acquire(ctx, "u2")
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, poolErrKindExhausted, pe.Kind)
+
+	// ── 场景 B:per-user 收紧 → user_quota_exceeded(global 放宽,使 per-user 成首个失败点) ──
+	p.UpdateLimits(Limits{
+		MaxSize:          100,
+		MaxIdlePerUser:   1,
+		MaxPerWorkspace:  3,
+		MaxMemoryPerUser: 10 * 1024 * 1024 * 1024,
+	})
+	err = p.AcquireForWorkspace(ctx, "u1", "ws-2")
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, poolErrKindUserQuotaExceeded, pe.Kind)
+
+	// ── 场景 C:per-workspace 收紧 → workspace_quota_exceeded
+	// (用新用户 u3 避开 u1 的 per-user 限制;ws-1 已有 1 个,MaxPerWorkspace=1) ──
+	p.UpdateLimits(Limits{
+		MaxSize:          100,
+		MaxIdlePerUser:   5,
+		MaxPerWorkspace:  1,
+		MaxMemoryPerUser: 10 * 1024 * 1024 * 1024,
+	})
+	err = p.AcquireForWorkspace(ctx, "u3", "ws-1")
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, poolErrKindWorkspaceQuotaExceeded, pe.Kind)
+
+	// ── 场景 D:per-user-memory 收紧 → memory_exceeded
+	// (用新用户 u4 + 新 ws-3 避开其他限制;mem=1B 时 512MB 估算必超) ──
+	p.UpdateLimits(Limits{
+		MaxSize:          100,
+		MaxIdlePerUser:   5,
+		MaxPerWorkspace:  3,
+		MaxMemoryPerUser: 1, // 1 字节
+	})
+	err = p.AcquireForWorkspace(ctx, "u4", "ws-3")
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, poolErrKindMemoryExceeded, pe.Kind)
+
+	// ── 场景 E:放宽全部 4 维 → 释放并重新 Acquire 成功,证明 UpdateLimits 是可逆的 ──
+	p.UpdateLimits(Limits{
+		MaxSize:          100,
+		MaxIdlePerUser:   5,
+		MaxPerWorkspace:  3,
+		MaxMemoryPerUser: 10 * 1024 * 1024 * 1024,
+	})
+	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-2"))
 }

--- a/internal/session/pool_test.go
+++ b/internal/session/pool_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strconv"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -406,4 +409,85 @@ func TestUpdateLimits_AllFourHotReload(t *testing.T) {
 	})
 	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
 	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-2"))
+}
+
+// TestUpdateLimits_DoesNotEvict: lowering the memory quota does NOT force-release
+// already-running sessions; only new Acquire calls are rejected until natural Release.
+// (spec ⑤ §4.3 no-evict invariant.)
+func TestUpdateLimits_DoesNotEvict(t *testing.T) {
+	t.Parallel()
+	// per-user-mem 10GB → 1 slot = 512MB, can hold several
+	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 10*1024*1024*1024, 3)
+	ctx := context.Background()
+
+	// u1 占 2 slot (≈1GB)
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+
+	// 降到 1GB (2*estimate) —— u1 现已恰好等于上限 (used 1GB),新 Acquire 仍被拒
+	// (acquireLocked 用严格 > 比较: used+estimate > limit → 1GB+512MB > 1GB)。
+	// 选 2*estimate 而非 1*estimate 是为了让释放 1 个 slot 后能恰好再拿 1 个
+	// (used 512MB + estimate 512MB == 1024MB,不 > limit)。
+	p.UpdateLimits(Limits{
+		MaxSize:          100,
+		MaxIdlePerUser:   5,
+		MaxPerWorkspace:  3,
+		MaxMemoryPerUser: 2 * workerMemoryEstimate, // 1GB
+	})
+
+	// 已占用的 u1 计数仍在 (未被驱逐)
+	total, _, _ := p.Stats()
+	require.Equal(t, 2, total)
+	require.Equal(t, int64(2*workerMemoryEstimate), p.UserMemory("u1"))
+
+	// u1 新 Acquire 被内存维度拒 (超额)
+	var pe *PoolError
+	err := p.AcquireForWorkspace(ctx, "u1", "ws-1")
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, poolErrKindMemoryExceeded, pe.Kind)
+
+	// 释放 1 个后,内存回到 512MB,可再拿 1 个 (恰好等于上限)
+	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+}
+
+// TestPool_ConcurrentMixedOperations: concurrent Acquire/Release/UpdateLimits
+// produces no data race and no counter drift (spec ⑤ §5.6).
+// Asserts on per-instance p.Stats() (NOT package-global atomics, which are
+// shared across all PoolManager instances in the test binary and thus flaky).
+func TestPool_ConcurrentMixedOperations(t *testing.T) {
+	t.Parallel()
+	p := NewPoolManagerWithWorkspace(slog.Default(), 50, 10, 5*1024*1024*1024, 4)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	// Acquire/Release worker
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			uid := "u" + strconv.Itoa(i%5)
+			ws := "ws-" + strconv.Itoa(i%3)
+			if p.AcquireForWorkspace(ctx, uid, ws) == nil {
+				p.ReleaseForWorkspace(ctx, uid, ws)
+			}
+		}
+	}()
+	// UpdateLimits concurrently — 20 hot reloads while Acquire/Release runs
+	for i := 0; i < 20; i++ {
+		p.UpdateLimits(Limits{
+			MaxSize:          50,
+			MaxIdlePerUser:   10,
+			MaxPerWorkspace:  4,
+			MaxMemoryPerUser: 5 * 1024 * 1024 * 1024,
+		})
+	}
+	wg.Wait()
+
+	// 收敛后:本 pool 的所有 slot 应已释放。用 per-instance Stats (race-free),
+	// NOT package-global metricActiveSessions (shared → flaky).
+	require.Eventually(t, func() bool {
+		total, _, _ := p.Stats()
+		return total == 0
+	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/session/pool_test.go
+++ b/internal/session/pool_test.go
@@ -355,7 +355,7 @@ func TestUpdateLimits_AllFourHotReload(t *testing.T) {
 	var pe *PoolError
 
 	// ── 场景 A:global 收紧 → exhausted(u2 受 global 限制先于 per-user 拦截) ──
-	p.UpdateLimits(Limits{
+	p.UpdateLimits(config.PoolConfig{
 		MaxSize:          1,
 		MaxIdlePerUser:   5, // 放宽,使 per-user 不先触发
 		MaxPerWorkspace:  3,
@@ -366,7 +366,7 @@ func TestUpdateLimits_AllFourHotReload(t *testing.T) {
 	require.Equal(t, poolErrKindExhausted, pe.Kind)
 
 	// ── 场景 B:per-user 收紧 → user_quota_exceeded(global 放宽,使 per-user 成首个失败点) ──
-	p.UpdateLimits(Limits{
+	p.UpdateLimits(config.PoolConfig{
 		MaxSize:          100,
 		MaxIdlePerUser:   1,
 		MaxPerWorkspace:  3,
@@ -378,7 +378,7 @@ func TestUpdateLimits_AllFourHotReload(t *testing.T) {
 
 	// ── 场景 C:per-workspace 收紧 → workspace_quota_exceeded
 	// (用新用户 u3 避开 u1 的 per-user 限制;ws-1 已有 1 个,MaxPerWorkspace=1) ──
-	p.UpdateLimits(Limits{
+	p.UpdateLimits(config.PoolConfig{
 		MaxSize:          100,
 		MaxIdlePerUser:   5,
 		MaxPerWorkspace:  1,
@@ -390,7 +390,7 @@ func TestUpdateLimits_AllFourHotReload(t *testing.T) {
 
 	// ── 场景 D:per-user-memory 收紧 → memory_exceeded
 	// (用新用户 u4 + 新 ws-3 避开其他限制;mem=1B 时 512MB 估算必超) ──
-	p.UpdateLimits(Limits{
+	p.UpdateLimits(config.PoolConfig{
 		MaxSize:          100,
 		MaxIdlePerUser:   5,
 		MaxPerWorkspace:  3,
@@ -401,7 +401,7 @@ func TestUpdateLimits_AllFourHotReload(t *testing.T) {
 	require.Equal(t, poolErrKindMemoryExceeded, pe.Kind)
 
 	// ── 场景 E:放宽全部 4 维 → 释放并重新 Acquire 成功,证明 UpdateLimits 是可逆的 ──
-	p.UpdateLimits(Limits{
+	p.UpdateLimits(config.PoolConfig{
 		MaxSize:          100,
 		MaxIdlePerUser:   5,
 		MaxPerWorkspace:  3,
@@ -428,7 +428,7 @@ func TestUpdateLimits_DoesNotEvict(t *testing.T) {
 	// (acquireLocked 用严格 > 比较: used+estimate > limit → 1GB+512MB > 1GB)。
 	// 选 2*estimate 而非 1*estimate 是为了让释放 1 个 slot 后能恰好再拿 1 个
 	// (used 512MB + estimate 512MB == 1024MB,不 > limit)。
-	p.UpdateLimits(Limits{
+	p.UpdateLimits(config.PoolConfig{
 		MaxSize:          100,
 		MaxIdlePerUser:   5,
 		MaxPerWorkspace:  3,
@@ -475,7 +475,7 @@ func TestPool_ConcurrentMixedOperations(t *testing.T) {
 	}()
 	// UpdateLimits concurrently — 20 hot reloads while Acquire/Release runs
 	for i := 0; i < 20; i++ {
-		p.UpdateLimits(Limits{
+		p.UpdateLimits(config.PoolConfig{
 			MaxSize:          50,
 			MaxIdlePerUser:   10,
 			MaxPerWorkspace:  4,
@@ -490,4 +490,44 @@ func TestPool_ConcurrentMixedOperations(t *testing.T) {
 		total, _, _ := p.Stats()
 		return total == 0
 	}, time.Second, 10*time.Millisecond)
+}
+
+// TestUpdateLimits_MemoryQuotaToggleOff: hot-reloading max_memory_per_user from
+// positive to 0 (disable) must not strand userMemory entries or inflate the
+// memory_reserved snapshot. Before the fix, releaseMemoryLocked skipped cleanup
+// when maxMemoryPerUser==0, so the running total leaked forever (spec ⑤ review #2).
+func TestUpdateLimits_MemoryQuotaToggleOff(t *testing.T) {
+	t.Parallel()
+	p := NewPoolManagerWithWorkspace(slog.Default(), 100, 5, 10*1024*1024*1024, 3)
+	ctx := context.Background()
+
+	// 2 个 workspace session,每个预留 512MB → total 1GB
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+	require.NoError(t, p.AcquireForWorkspace(ctx, "u1", "ws-1"))
+
+	p.mu.Lock()
+	require.Equal(t, int64(2*workerMemoryEstimate), p.totalMemoryReservedBytes)
+	require.NotEmpty(t, p.userMemory)
+	p.mu.Unlock()
+
+	// 热重载禁用内存层
+	p.UpdateLimits(config.PoolConfig{
+		MaxSize: 100, MaxIdlePerUser: 5, MaxPerWorkspace: 3, MaxMemoryPerUser: 0,
+	})
+
+	// 禁用瞬间:gauge 源(totalMemoryReservedBytes)立即归零,userMemory 清空
+	p.mu.Lock()
+	totalAfterToggle := p.totalMemoryReservedBytes
+	memMapAfterToggle := len(p.userMemory)
+	p.mu.Unlock()
+	require.Equal(t, int64(0), totalAfterToggle, "totalMemoryReservedBytes must reset to 0 on disable")
+	require.Equal(t, 0, memMapAfterToggle, "userMemory must be cleared on disable")
+
+	// release 不产生负值/泄漏
+	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
+	p.ReleaseForWorkspace(ctx, "u1", "ws-1")
+	p.mu.Lock()
+	finalTotal := p.totalMemoryReservedBytes
+	p.mu.Unlock()
+	require.Equal(t, int64(0), finalTotal, "no leak/negative after release post-disable")
 }


### PR DESCRIPTION
Closes #754

## Summary

WebChat 多租户路线图 spec ⑤ 的**设计文档**首个提交。本 PR 暂只含设计 spec,实现代码后续提交。

**spec ⑤ 目标**:补齐 PoolManager 配额体系两个真实缺口,不引入冗余能力。

### 改动内容(本 PR)
- 新增 [`docs/specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md`](../blob/feat/webchat-multitenancy-spec5-quota-enhancement/docs/specs/WebChat-Multitenancy-Quota-Enhancement-Design-Spec.md) — 完整设计
- 附带:路线图更新(`WebChat-Multitenancy-Roadmap-Spec.md` 标 spec ③ 已合入 + 推进下一步)、CI 测试优化(另两个 commit,独立于 spec ⑤)

### 设计要点(brainstorm 拍板)

| 决策 | 选择 |
|---|---|
| 范围 | 纯配额增强(不含计费/用量落盘) |
| 内存估算 | 沿用固定 512MB/worker |
| per-workspace 内存层 | **不加**(固定估算下与并发层等价,冗余) |
| 热重载 | 4/4 限额全可热重载(`Limits` struct) |
| 降额处理 | 不驱逐,自然释放 |
| 指标粒度 | 低基数聚合(无 user/ws label) |

### 实现范围(后续提交)
- `internal/session/pool.go` — `Limits` struct + `UpdateLimits(Limits)` + 4 gauge 快照(`snapshotMetricsLocked`)
- `internal/config/watcher.go` — 解锁 `pool.max_memory_per_user` / `pool.max_per_workspace` 热重载
- `internal/config/config.go` — `pool.max_*` 负数校验
- `cmd/hotplex/gateway_run.go` — 热重载回调传完整 Limits
- 对应 `_test.go`(5 个 pool 测试 + config 负数校验 + watcher 白名单)

## Test plan
- [ ] 设计文档 review(brainstorm 各节已逐项过审)
- [ ] 实现后补:`make check` 含 `-race` 通过
- [ ] 实现后补:热重载 e2e(改配置 → 不重启生效)
- [ ] 实现后补:4 gauge `/metrics` 可见